### PR TITLE
Add fzf-native-score-all

### DIFF
--- a/fzf-native-module.c
+++ b/fzf-native-module.c
@@ -24,7 +24,9 @@
 EXPORT
 int plugin_is_GPL_compatible;
 
-emacs_value Qnil, Qlistofzero, Qcons, Flist;
+emacs_value Qnil, Qlistofzero, Qcons, Flist, Qt;
+emacs_value Fhashtablep, Fmessage, Fvectorp, Fconsp, Ffunctionp, Fsymbolp, Fsymbolname, Flength, Fnth, Fprinc;
+
 
 /** An Emacs string made accessible by copying. */
 struct EmacsStr {
@@ -253,9 +255,20 @@ int emacs_module_init(struct emacs_runtime *rt) {
                (emacs_value[]) { env->intern(env, "fzf-native-make-slab") });
 
   // Get a few common lisp functions.
+  Qt = env->make_global_ref(env, env->intern(env, "t"));
   Qnil = env->make_global_ref(env, env->intern(env, "nil"));
   Qcons = env->make_global_ref(env, env->intern(env, "cons"));
   Flist = env->make_global_ref(env, env->intern(env, "list"));
+  Fhashtablep = env->make_global_ref(env, env->intern(env, "hash-table-p"));
+  Fmessage = env->make_global_ref(env, env->intern(env, "message"));
+  Fvectorp = env->make_global_ref(env, env->intern(env, "vectorp"));
+  Fconsp = env->make_global_ref(env, env->intern(env, "consp"));
+  Ffunctionp = env->make_global_ref(env, env->intern(env, "functionp"));
+  Fsymbolp = env->make_global_ref(env, env->intern(env, "symbolp"));
+  Fsymbolname = env->make_global_ref(env, env->intern(env, "symbol-name"));
+  Flength = env->make_global_ref(env, env->intern(env, "length"));
+  Fnth = env->make_global_ref(env, env->intern(env, "nth"));
+  Fprinc = env->make_global_ref(env, env->intern(env, "princ"));
 
   Qlistofzero = env->make_global_ref(
       env, env->funcall(env, Qcons, 2,

--- a/fzf-native-module.c
+++ b/fzf-native-module.c
@@ -16,9 +16,9 @@
 
 /** MSVC does not recognize __attribute__((unused)), so define it away. */
 #ifdef _MSC_VER
-    #define UNUSED(x) x
+#define UNUSED(x) x
 #else
-    #define UNUSED(x) __attribute__((unused)) x
+#define UNUSED(x) __attribute__((unused)) x
 #endif
 
 EXPORT

--- a/fzf-native-module.c
+++ b/fzf-native-module.c
@@ -100,6 +100,7 @@ static struct EmacsStr *copy_emacs_string(emacs_env *env, struct Bump **bump, em
   return result;
 }
 
+// fzf-native-score STR QUERY &optional SLAB
 emacs_value fzf_native_score(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void UNUSED(*data_ptr)) {
   // Short-circuit if QUERY is empty.
   ptrdiff_t query_len;

--- a/fzf-native.el
+++ b/fzf-native.el
@@ -20,6 +20,7 @@
   :group 'minibuffer
   :link '(url-link :tag "GitHub" "https://github.com/dangduc/fzf-native"))
 
+(declare-function fzf-native-score-all "fzf-native-module")
 (declare-function fzf-native-score "fzf-native-module")
 (declare-function fzf-native-make-default-slab "fzf-native-module")
 (declare-function fzf-native-make-slab "fzf-native-module")

--- a/fzf.c
+++ b/fzf.c
@@ -663,27 +663,29 @@ fzf_result_t fzf_fuzzy_match_v2(bool case_sensitive, bool normalize,
   str_slice_t p_sub =
       slice_str_right(slice_str(pattern->data, 1, M).data, f_sub.size);
   for (size_t off = 0; off < f_sub.size; off++) {
-    size_t f = (size_t)f_sub.data[off];
+    size_t foff = (size_t)f_sub.data[off];
     pchar = p_sub.data[off];
     pidx = off + 1;
     size_t row = pidx * width;
     in_gap = false;
-    t_sub = slice_i32(t.data, f, last_idx + 1);
-    b_sub = slice_i16_right(slice_i16(bo.data, f, bo.size).data, t_sub.size);
+    t_sub = slice_i32(t.data, foff, last_idx + 1);
+    b_sub = slice_i16_right(slice_i16(bo.data, foff, bo.size).data, t_sub.size);
     i16_slice_t c_sub = slice_i16_right(
-        slice_i16(c.data, row + f - f0, c.size).data, t_sub.size);
+        slice_i16(c.data, row + foff - f0, c.size).data, t_sub.size);
     i16_slice_t c_diag = slice_i16_right(
-        slice_i16(c.data, row + f - f0 - 1 - width, c.size).data, t_sub.size);
+        slice_i16(c.data, row + foff - f0 - 1 - width, c.size).data,
+        t_sub.size);
     i16_slice_t h_sub = slice_i16_right(
-        slice_i16(h.data, row + f - f0, h.size).data, t_sub.size);
+        slice_i16(h.data, row + foff - f0, h.size).data, t_sub.size);
     i16_slice_t h_diag = slice_i16_right(
-        slice_i16(h.data, row + f - f0 - 1 - width, h.size).data, t_sub.size);
+        slice_i16(h.data, row + foff - f0 - 1 - width, h.size).data,
+        t_sub.size);
     i16_slice_t h_left = slice_i16_right(
-        slice_i16(h.data, row + f - f0 - 1, h.size).data, t_sub.size);
+        slice_i16(h.data, row + foff - f0 - 1, h.size).data, t_sub.size);
     h_left.data[0] = 0;
     for (size_t j = 0; j < t_sub.size; j++) {
       char ch = (char)t_sub.data[j];
-      size_t col = j + f;
+      size_t col = j + foff;
       int16_t s1 = 0;
       int16_t s2 = 0;
       int16_t consecutive = 0;


### PR DESCRIPTION
Usage:

```
(defun fussy-fzf-score (candidates string &optional cache)
  "Score and propertize CANDIDATES using STRING.

This implementation uses `fzf-native-score-all' to do all its scoring in one go.

Ignore CACHE. This is only added to match `fussy-score'.

Set a text-property \='completion-score on candidates with their score.
`completion--adjust-metadata' later uses this \='completion-score for sorting."
  (let ((result '())
        (scored-candidates (fzf-native-score-all
                            candidates string (fussy--fzf-native-slab))))
    (dolist (candidate scored-candidates)
      (let ((x (car candidate))
            (score (cdr candidate)))
        (when (fussy-valid-score-p score)
          (setf x (copy-sequence x))
          (put-text-property 0 1 'completion-score (car score) x)
          (setf x (funcall fussy-propertize-fn x score))
          (push x result))))
    result))

;; Replace `fussy-score'.
(advice-add 'fussy-score :override 'fussy-fzf-score)

;; Standalone test call.
(fussy-fzf-score '("abc" "cef" "fff") "a")
```