### PR TITLE
Document fzf implementation commonalities and differences

### DIFF
--- a/README.org
+++ b/README.org
@@ -318,6 +318,7 @@ $ brew install llvm
 ** Architecture
 
 See [[file:architecture.org][architecture.org]] for the current implementation.
+See [[file:comparison.org][comparison.org]] for a pinned comparison with fzf and the Telescope port.
 It documents the public API, session lifecycle, request ownership, caches, worker scheduling, and failure model.
 
 See [[file:multi-round-session-plan.org][multi-round-session-plan.org]] for the historical design record and verification results.

--- a/comparison.org
+++ b/comparison.org
@@ -1,0 +1,788 @@
+#+TITLE: fzf Implementation Comparison
+#+STARTUP: overview
+#+OPTIONS: toc:3
+
+* Purpose
+
+This document compares current fzf, the Telescope port, and the Emacs port.
+It records source facts and executed behavior at fixed revisions.
+
+The comparison covers product scope, matching, text handling, incremental work,
+interfaces, memory, concurrency, platforms, tests, and performance evidence.
+
+This document does not rank performance.
+No common end-to-end performance test exists for the three products.
+
+* Terms
+
+| Term | Meaning |
+|------+---------|
+| current fzf | The pinned =junegunn/fzf= snapshot. |
+| Telescope port | The pinned =telescope-fzf-native.nvim= snapshot. |
+| Emacs port | This =fzf-native= repository at the pinned snapshot. |
+| host | The application that owns a native matching component. |
+| candidate | One input string that a matcher tests. |
+| membership | The candidates that match a query. |
+| score | The integer that one matcher assigns to one match. |
+| position | One matched code point or byte offset. |
+| result | Membership, score, positions, and rank where available. |
+| code point | One Unicode scalar value used by a matcher. |
+| grapheme cluster | One displayed character that can contain multiple code points. |
+| slab | Reusable scratch buffers for one matcher worker. |
+| snapshot | Published session metadata with an optional completed candidate list. |
+| refinement | A scan that uses earlier membership to reduce candidate work. |
+| ABI | The compiled interface between a host and a native component. |
+| API | Functions or commands that one component offers to another component. |
+| FFI | The LuaJIT interface that calls C functions. |
+| POSIX | The Unix interface used here on macOS, Linux, and FreeBSD. |
+| FIFO | First-in, first-out work order. |
+| SGR sequence | An ANSI escape sequence that sets text style. |
+| ASan | The AddressSanitizer memory-error detector. |
+| UBSan | The UndefinedBehaviorSanitizer error detector. |
+| TSan | The ThreadSanitizer data-race detector. |
+
+* Audit snapshot
+
+| Product | Revision | Commit time | Observed version |
+|---------+----------+-------------+------------------|
+| [[https://github.com/junegunn/fzf/tree/1372d04f79bde0daa3bab4b96a068baafa808e67][current fzf]] | =1372d04f79bde0daa3bab4b96a068baafa808e67= | 2026-09-06 11:27 +0900 | =v0.74.3-9-g1372d04f= |
+| [[https://github.com/nvim-telescope/telescope-fzf-native.nvim/tree/b25b749b9db64d375d782094e2b9dce53ad53a40][Telescope port]] | =b25b749b9db64d375d782094e2b9dce53ad53a40= | 2026-05-06 16:30 +0200 | =b25b749= |
+| [[https://github.com/dangduc/fzf-native/tree/ae3e3e1e8d737949455210f9304dc726ba0e51a1][Emacs port]] | =ae3e3e1e8d737949455210f9304dc726ba0e51a1= | 2026-09-04 22:49 -0400 | package 2.8 |
+
+The audit ran on Darwin 25.5.0 with arm64 hardware.
+It used Apple Clang 21.0.0, Go 1.27.1, Neovim 0.12.5, and Emacs 30.2.
+
+All conclusions apply to these revisions.
+Later revisions can change any result.
+
+* Main conclusions
+
+- All three products retain the same fzf scoring lineage.
+- All three products support 17 of the 18 tested query forms.
+- Current fzf is a complete terminal application.
+- The Telescope port is a scalar native scorer for Telescope.
+- The Emacs port provides batch scoring and persistent producer sessions.
+- The two C cores still agree on every tested ASCII primitive result.
+- The Emacs port adds Unicode and malformed-byte behavior that the Telescope port lacks.
+- Current fzf uses newer scoring rules, normalization, query syntax, and rank rules.
+- Compatible membership does not imply compatible scores, positions, rank, interface, or lifecycle.
+- None of the three products treats query text as a regular expression.
+
+* Source lineage
+
+The Telescope port first added =src/fzf.c= in April 2021.
+The nearest earlier fzf release was 0.27.0.
+
+The history does not record one exact source commit from current fzf.
+Therefore, the 0.27 reference identifies an era, not an exact import point.
+
+The Emacs port first added =fzf.c= in June 2022.
+Its initial =fzf.c= and =fzf.h= blobs exactly match one Telescope revision.
+
+| Evidence | Value |
+|----------+-------|
+| Telescope first C commit | [[https://github.com/nvim-telescope/telescope-fzf-native.nvim/commit/d5a9c45721ba8cbf4c9b1821e105b552bbac8722][=d5a9c457=]], 2021-04-09 |
+| Earlier fzf tag | [[https://github.com/junegunn/fzf/releases/tag/0.27.0][=0.27.0=]], 2021-04-06 |
+| Emacs first C commit | [[https://github.com/dangduc/fzf-native/commit/10cd7f8aeaa54c8870bf836afbeae6991ea4d48d][=10cd7f8a=]], 2022-06-03 |
+| Matching Telescope commit | [[https://github.com/nvim-telescope/telescope-fzf-native.nvim/commit/8ec164b541327202e5e74f99bcc5fe5845720e18][=8ec164b5=]], 2022-02-19 |
+| Matching =fzf.c= blob | =6973b24e03b2dc998eca40e1c8a11b76b9e789fc= |
+| Matching =fzf.h= blob | =7bc16473c7be5f97d0ae62b6e079986f860af1f8= |
+
+The current C files no longer match.
+A direct diff reports 1,740 additions and 213 deletions in the Emacs file.
+
+This count measures text changes only.
+It does not measure correctness, features, or maintenance cost.
+
+* Product boundary
+
+| Property | current fzf | Telescope port | Emacs port |
+|----------+-------------+----------------+------------|
+| Primary form | Go executable | C shared library and Lua adapter | C dynamic module and Emacs Lisp loader |
+| Primary host | Terminal and shell | Neovim with Telescope | Emacs |
+| User interface | Complete terminal interface | Telescope owns the interface | A higher-level Emacs package owns the interface |
+| Native candidate store | Chunk list | None | Batch arrays or a session arena |
+| Native query lifecycle | Persistent during one fzf run | Scalar calls through one sorter | Scalar, batch, or persistent session calls |
+| Native producer | Standard input, command, channel, or walker | None | One shell command per session |
+| Native result form | Terminal list and selected output | Reciprocal score and byte positions | Emacs strings, highlights, or snapshots |
+
+Current fzf owns the complete find-select cycle.
+The two ports expose matching work to another application.
+
+The Telescope port does not embed current fzf.
+It uses a C translation of an older matcher design.
+
+The Emacs port does not run the fzf executable.
+Its matcher descends from the Telescope C translation.
+
+* Matcher common ground
+
+** Algorithms
+
+All three cores contain these algorithms:
+
+- fuzzy V1
+- fuzzy V2
+- exact substring
+- prefix
+- suffix
+- equal
+
+Current fzf selects V2 by default and accepts =--algo=v1=.
+Both C matcher cores contain V1 and V2 primitives.
+The Telescope library exports both primitives through its C ABI.
+The Emacs dynamic module does not export either primitive directly.
+
+Both C query parsers select V2 for fuzzy terms.
+Their host adapters do not expose an algorithm selection setting.
+
+All three cores use the same base values:
+
+| Value | Number |
+|-------+--------|
+| character match | 16 |
+| new gap | -3 |
+| extended gap | -1 |
+| general boundary bonus | 8 |
+| camel-case bonus | 7 |
+| consecutive bonus | 4 |
+| first-character multiplier | 2 |
+
+These shared values do not make the final scores equal.
+Current fzf applies more boundary classes and configurable schemes.
+
+** Query language
+
+| Query form | current fzf | Telescope port | Emacs port |
+|------------+-------------+----------------+------------|
+| =word= | fuzzy term | fuzzy term | fuzzy term |
+| ='word= | exact term | exact term | exact term |
+| ='word'= | exact term at word boundaries | final quote stays in the term | final quote stays in the term |
+| =^word= | prefix term | prefix term | prefix term |
+| =word$= | suffix term | suffix term | suffix term |
+| =^word$= | equal term | equal term | equal term |
+| =!word= | inverse exact term | inverse exact term | inverse exact term |
+| =word other= | two AND terms | two AND terms | two AND terms |
+| =word | other= | OR alternatives | OR alternatives | OR alternatives |
+| =two\ words= | one term with a space | one term with a space | one term with a space |
+| global exact mode | =--exact= | =fuzzy=false= | =fzf-native-fuzzy=nil= |
+| smart, ignore, respect case | yes | yes | yes |
+| regular-expression query | no | no | no |
+
+Current fzf added the ='word'= boundary form after the C ports diverged.
+The current fzf parser maps this form to =ExactMatchBoundary=.
+
+The C parsers do not define that term type.
+They retain the final quote as candidate data.
+
+A query such as =f.o= is not a regular expression.
+All three probes matched the literal candidate =f.o= and rejected =foo=.
+
+Current fzf separately accepts regular expressions for field delimiters.
+That option does not change query matching.
+
+Source references:
+
+- [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/README.md#L397-L429][current fzf search syntax]]
+- [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/pattern.go#L167-L254][current fzf term parser]]
+- [[https://github.com/nvim-telescope/telescope-fzf-native.nvim/blob/b25b749b9db64d375d782094e2b9dce53ad53a40/src/fzf.c#L993-L1090][Telescope C term parser]]
+- [[https://github.com/dangduc/fzf-native/blob/ae3e3e1e8d737949455210f9304dc726ba0e51a1/fzf.c#L2473-L2604][Emacs C term parser]]
+
+* Score, positions, and rank
+
+Current fzf gives whitespace and delimiter boundaries separate default bonuses.
+The default values are 10 for whitespace, 9 for delimiters, and 8 for other boundaries.
+
+Both C ports use one boundary value of 8.
+This difference changes scores and can change the selected V2 positions.
+
+| V2 query | Candidate | current fzf | Telescope port | Emacs port |
+|----------+-----------+-------------+----------------+------------|
+| =fzf= | =src/fzf= | score 84, positions 4,5,6 | score 80, positions 4,5,6 | score 80, positions 4,5,6 |
+| =/a= | =a//a= | score 59, positions 2,3 | score 56, positions 1,3 | score 56, positions 1,3 |
+
+Current fzf supports =default=, =path=, and =history= scoring schemes.
+It also supports configurable length, chunk, pathname, begin, end, and input-order tie rules.
+
+The default fzf rank compares score and trimmed length.
+The path scheme also compares pathname position.
+
+The Telescope adapter returns =1 / score= for a match.
+Telescope then owns collection ordering and tie behavior.
+
+The Emacs port ranks a session result by higher score, then earlier producer index.
+Its synchronous batch path also keeps stable equal-score order in normal operation.
+An emergency synchronous =qsort= fallback can change equal-score order after an allocation failure.
+
+Do not compare score numbers across current fzf and either C port.
+Do not assume that equal membership produces equal rank.
+
+Source references:
+
+- [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/algo/algo.go#L113-L193][current fzf score values and schemes]]
+- [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/options.go#L1336-L1404][current fzf rank settings]]
+- [[https://github.com/nvim-telescope/telescope-fzf-native.nvim/blob/b25b749b9db64d375d782094e2b9dce53ad53a40/lua/telescope/_extensions/fzf.lua#L78-L92][Telescope score adapter]]
+- [[https://github.com/dangduc/fzf-native/blob/ae3e3e1e8d737949455210f9304dc726ba0e51a1/architecture.org#L187-L201][Emacs rank contract]]
+
+* Text model
+
+| Property | current fzf | Telescope port | Emacs port |
+|----------+-------------+----------------+------------|
+| Valid UTF-8 unit | Go code point | byte | Unicode code point |
+| Case conversion | Go Unicode tables | C =tolower= on each byte | vendored utf8proc 2.10.0 |
+| Case conversion size | one code point to one code point | one byte to one byte | one code point to one code point |
+| Latin accent normalization | on by default | unavailable | unavailable through the public parser |
+| Disable accent normalization | =--literal= | already disabled | already disabled |
+| Distinct malformed bytes | collapse to replacement code points | remain distinct | remain distinct |
+| Valid UTF-8 positions | code-point offsets | byte offsets | code-point offsets |
+| Malformed-byte positions | replacement-code-point offsets | byte offsets | byte offsets in Emacs unibyte strings |
+| Whitespace classes | Go Unicode tables | C byte classes | utf8proc Unicode categories |
+| Grapheme clusters | separate code points | separate bytes | separate code points |
+
+Current fzf uses Latin-letter normalization, not full Unicode normalization.
+The default can make =cafe= match =café=.
+
+The Telescope Lua adapter always passes =normalize=false=.
+Its README also lists Unicode case matching as incomplete.
+
+The Emacs public parser also disables accent normalization.
+Its Unicode path still supports Unicode case matching and Unicode whitespace.
+
+Both current fzf and the Emacs port use simple one-code-point lowercase maps.
+Neither product applies multi-code-point full case folding.
+
+No matcher treats a grapheme cluster as one matching unit.
+For =é=, a query that contains only the combining mark matches that separate component.
+
+** Malformed UTF-8
+
+Current fzf decodes each invalid byte as the Unicode replacement code point.
+Different invalid bytes can therefore become equal during matching.
+
+The Telescope port compares those bytes directly.
+The Emacs port assigns a distinct internal value to each invalid byte.
+
+The Emacs module returns malformed candidates as Emacs unibyte strings.
+This policy preserves Unix path bytes during matching and return.
+
+| Query bytes | Candidate bytes | current fzf | Telescope port | Emacs port |
+|-------------+-----------------+-------------+----------------+------------|
+| =ff= | =ff= | match | match | match |
+| =ff= | =fe= | match | no match | no match |
+| =c3= | =ff= | match | no match | no match |
+| =ff= | =ef bf bd= | match | no match | no match |
+| =ff 61= | =fe 61= | match | no match | no match |
+
+Source references:
+
+- [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/util/chars.go#L110-L158][current fzf byte decoding]]
+- [[https://github.com/nvim-telescope/telescope-fzf-native.nvim/blob/b25b749b9db64d375d782094e2b9dce53ad53a40/README.md#L174-L180][Telescope normalization limitations]]
+- [[https://github.com/dangduc/fzf-native/blob/ae3e3e1e8d737949455210f9304dc726ba0e51a1/architecture.org#L162-L175][Emacs Unicode and raw-byte contract]]
+
+* Incremental operation
+
+** Current fzf
+
+Current fzf keeps one matcher during one interactive run.
+Reader and query events reset that matcher against a candidate snapshot.
+
+The reader accepts standard input, a command, an internal channel, or the built-in file walker.
+The matcher divides 1,024-candidate chunks among Go workers.
+
+Each worker owns reusable scratch memory.
+The default worker limit follows the processor count.
+
+The matcher checks cancellation between chunks.
+It publishes search progress after a 200 millisecond threshold.
+
+Current fzf uses three main cache layers:
+
+1. A parsed-pattern map reuses an exact query string.
+2. A full-result map reuses an exact query while the candidate count stays unchanged.
+3. A per-chunk bitmap reuses exact, prefix, or suffix query evidence.
+
+The bitmap layer stores only full chunks with at most 512 matches.
+It finds the longest cached prefix or suffix for an eligible query.
+
+Reader growth causes another search against a new snapshot.
+A reload action can replace the candidate source.
+
+The matcher publishes a completed merger, not each worker match.
+Reader events can still produce successive completed lists while input grows.
+
+** Telescope port
+
+The Telescope port has no native candidate pool, worker, reader, or producer.
+Telescope calls the native score function once for each prompt and candidate pair.
+
+One sorter owns one reusable slab.
+It also owns a map from prompt text to parsed C patterns.
+
+The prompt map has no explicit entry or byte limit.
+The sorter frees every entry during destruction.
+
+The adapter sets Telescope's =discard=true= hint.
+Its current start hook clears Telescope's filtered state on every probed prompt.
+
+The probe covered an ordinary prompt and prompts that ended with =|=, =\=, or =!=.
+Each start-hook call reduced the retained filtered count from one to zero.
+
+This behavior belongs to the Telescope host layer.
+The native C library has no incremental membership or result cache.
+
+** Emacs port
+
+The synchronous batch path creates bounded workers for one Emacs call.
+Those workers end before the call returns.
+
+The session path keeps one producer, reader, coordinator, candidate pool, and cache set.
+All live sessions share one process-wide worker pool.
+
+The shared pool uses at most 64 workers.
+Each worker keeps a private matcher slab across requests and sessions.
+
+The candidate pool is append-only during one session.
+The reader stores strings in 4 MiB arena chunks and pointers in fixed blocks.
+
+Each pointer block holds 262,144 candidates.
+The fixed top table permits at most 1,073,741,824 candidates.
+
+Each submitted query receives a monotonic request identifier.
+A later query can replace queued or running work.
+
+Candidate growth does not change that logical request identifier.
+The coordinator retries the latest request against the new pool boundary.
+
+The whole-result cache defaults to 40 entries and 64 MiB.
+The stable-batch cache defaults to 64 MiB and 4,096 query records.
+
+Safe refinement can reuse complete membership from an earlier broader query.
+It supports simple prefix growth, added AND terms, reordered AND terms, and safe inverse terms.
+
+The coordinator rescans cached members and appended candidates when the proof is valid.
+It recomputes every retained score and final rank.
+
+The public snapshot contains only completed candidates.
+It retains the earlier completed result and marks that result stale during newer work.
+
+The session does not publish each candidate immediately after one worker finds it.
+It publishes one authoritative result after a scoring attempt completes.
+
+** Incremental comparison
+
+| Property | current fzf | Telescope port | Emacs port session |
+|----------+-------------+----------------+--------------------|
+| Persistent native candidate pool | yes | no | yes |
+| Persistent parsed-query cache | yes | yes | yes, inside result evidence |
+| Membership cache | per 1,024-candidate chunk | none natively, and the start hook clears the host subset | full result and stable batch |
+| Exact full-result cache | yes | no | yes |
+| Candidate-growth refresh | automatic | host controlled | automatic for the latest request |
+| Query supersession | matcher reset | host prompt change | request replacement and abort flag |
+| Native progress | percentage event | none | resolved and total counts |
+| Publish worker matches directly | no | not applicable | no |
+| Retain prior result during new work | terminal owns the shown result | host controlled | yes, marked stale |
+| Replace producer in place | reload actions | host controlled | no, start another session |
+
+Source references:
+
+- [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/matcher.go#L37-L273][current fzf matcher lifecycle]]
+- [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/cache.go#L7-L93][current fzf chunk cache]]
+- [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/chunklist.go#L9-L150][current fzf candidate snapshots]]
+- [[https://github.com/nvim-telescope/telescope-fzf-native.nvim/blob/b25b749b9db64d375d782094e2b9dce53ad53a40/lua/telescope/_extensions/fzf.lua#L18-L99][Telescope sorter state]]
+- [[https://github.com/dangduc/fzf-native/blob/ae3e3e1e8d737949455210f9304dc726ba0e51a1/architecture.org#L245-L545][Emacs session and cache design]]
+
+* Candidate input and user features
+
+| Feature | current fzf | Telescope port | Emacs port |
+|---------+-------------+----------------+------------|
+| Newline input | yes | host supplies strings | session reader uses newlines |
+| NUL-delimited input | =--read0= | no native reader | no |
+| Final unterminated record | yes | not applicable | yes |
+| Built-in file walker | yes | no | no |
+| Shell command producer | yes | no | one per session |
+| Candidate tail limit | =--tail= | host controlled | none, with a separate per-line character cap |
+| ANSI input | parses styling with =--ansi= | no native parser | session reader removes SGR sequences |
+| Field selection | delimiter and =--nth= family | host controlled | no |
+| Regular-expression delimiter | yes | host controlled | no |
+| Preview process | yes | Telescope owns it | no |
+| Key and event actions | yes | Telescope owns them | no |
+| Multiple selection | yes | Telescope owns it | no |
+| Listen server | TCP or Unix socket | no | no |
+| Shell integrations | Bash, Zsh, Fish, and Nushell | no | no |
+
+Current fzf can use NUL as the record delimiter.
+The probe returned =alpha\0beta\0= after =--read0 --print0 --filter a=.
+
+The common parsed-pattern APIs use C strings in both C ports.
+Those APIs cannot represent an embedded NUL.
+
+The Telescope raw algorithm functions also accept explicit buffer sizes.
+The Lua adapter does not expose those raw calls.
+
+The Emacs module rejects embedded NUL in queries and candidates.
+It also rejects NUL in session output, including discarded line data.
+
+Source references:
+
+- [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/reader.go#L23-L244][current fzf reader]]
+- [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/options.go#L36-L227][current fzf feature options]]
+- [[https://github.com/dangduc/fzf-native/blob/ae3e3e1e8d737949455210f9304dc726ba0e51a1/architecture.org#L327-L355][Emacs session reader]]
+
+* Concurrency and cancellation
+
+| Property | current fzf | Telescope port | Emacs port |
+|----------+-------------+----------------+------------|
+| Matching workers | up to processor count by default | none in the C library | up to 64 |
+| Work unit | 1,024-candidate chunk | one scalar host call | 2,048-candidate batch |
+| Scratch reuse | one slab per worker | one slab per sorter | one slab per worker |
+| Session control thread | matcher loop | none | one coordinator per session |
+| Reader task | one Go reader | none | one POSIX reader thread per session |
+| Query cancellation | reset event and atomic flag | no native cancellation | every 256 candidates and during long loops |
+| Producer stop | closes and kills the command | not applicable | kills the producer process group |
+| Multi-session fairness | one fzf process owns one matcher | host controlled | shared FIFO worker epochs |
+
+The Emacs Windows build runs batch work on the calling thread.
+Its persistent session API is unavailable on Windows.
+
+* Cache bounds and memory ownership
+
+| Property | current fzf | Telescope port | Emacs port |
+|----------+-------------+----------------+------------|
+| Candidate ownership | process chunk list | Telescope | batch call or session arena |
+| Parsed-pattern ownership | process map | sorter map | call or cache entry |
+| Explicit parsed-pattern bound | no | no | result-cache bounds apply |
+| Membership representation | 1,024-bit chunk bitmap | none | indexes, sparse arrays, or bitmaps |
+| Aggregate membership byte bound | no explicit cache byte limit | not applicable | 64 MiB per cache class by default |
+| Full-result entry test | fewer than 100,000 results | none | result capacity and byte checks |
+| Public handle cleanup | process exit | explicit free during sorter destroy | Emacs finalizer or explicit stop |
+
+Current fzf retires chunk cache entries when =--tail= removes chunks.
+Its maps have no explicit aggregate byte limit.
+
+The Telescope adapter frees patterns and the slab during sorter destruction.
+
+The Emacs module tags slabs and sessions with distinct finalizers.
+It rejects a handle of the wrong kind.
+
+* Public interfaces and ABI
+
+** Current fzf
+
+The supported public surface is the executable interface.
+It includes command options, environment variables, shell integrations, and the listen server.
+
+The internal Go packages do not provide a versioned shared-library ABI.
+
+** Telescope port
+
+The built library exports 15 C functions.
+They cover six matchers, pattern parsing, scoring, positions, and slab allocation.
+
+The LuaJIT FFI adapter exposes parsed patterns, scores, positions, and slabs.
+The Telescope extension converts these values into one Telescope sorter.
+
+#+begin_src text
+fzf_equal_match           fzf_exact_match_naive
+fzf_free_pattern          fzf_free_positions
+fzf_free_slab             fzf_fuzzy_match_v1
+fzf_fuzzy_match_v2        fzf_get_positions
+fzf_get_score             fzf_make_default_slab
+fzf_make_slab             fzf_parse_pattern
+fzf_pos_array             fzf_prefix_match
+fzf_suffix_match
+#+end_src
+
+** Emacs port
+
+The release module exports =emacs_module_init= and =plugin_is_GPL_compatible= only.
+Module initialization registers 17 Emacs Lisp functions.
+
+| Group | Functions |
+|-------+-----------|
+| scalar and batch | =fzf-native-score=, =fzf-native-score-all= |
+| highlight | =fzf-native-highlight-one=, =fzf-native-highlight-all= |
+| slab | =fzf-native-make-slab=, =fzf-native-make-default-slab= |
+| session lifecycle | =fzf-native-async-start=, =fzf-native-async-stop= |
+| request API | =fzf-native-async-submit=, =fzf-native-async-status=, =fzf-native-async-snapshot= |
+| compatibility API | =fzf-native-async-candidates=, =fzf-native-async-stats=, =fzf-native-async-generation=, =fzf-native-async-result-fresh-p= |
+| configuration helper | =fzf-native-filter-only-p= |
+| ABI check | =fzf-native-session-abi-version= |
+
+POSIX modules report session ABI version 1.
+The Emacs Lisp loader rejects a missing or different session ABI.
+
+This handshake protects the persistent session interface.
+It does not make the module ABI compatible with the Telescope C library.
+
+* Build, platform, and license
+
+| Property | current fzf | Telescope port | Emacs port |
+|----------+-------------+----------------+------------|
+| Main languages | Go | C and Lua | C and Emacs Lisp |
+| Build tool | Go and Make | CMake or Make | CMake and Make |
+| Host requirement | none | Neovim, Telescope, and LuaJIT FFI | Emacs 29.1 or later |
+| Runtime native dependency | self-contained executable | built shared C library | vendored utf8proc linked statically |
+| Published native artifacts | release executables | none in the repository | committed Emacs modules |
+| CI or release systems | Darwin, Linux, Windows, FreeBSD, OpenBSD, Android | Linux and macOS tests, plus a Windows build | macOS, Linux, FreeBSD, and Windows |
+| Architecture coverage | release matrix has six systems and seven architecture names, with exclusions | current compiler target | listed bundled architectures only |
+| Repository license | MIT | MIT | GPL-3.0-or-later |
+
+The Emacs matcher files retain MIT license markers and copied fzf attribution.
+The module, Emacs Lisp, and repository license use GPL-3.0-or-later.
+
+This table reports repository markings only.
+It does not provide legal advice.
+
+The Emacs bundled targets are macOS arm64 and x86-64, Linux x86-64, FreeBSD x86-64, and Windows x86-64.
+Windows supports the synchronous API only.
+
+Source references:
+
+- [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/.goreleaser.yml#L5-L49][current fzf release targets]]
+- [[https://github.com/nvim-telescope/telescope-fzf-native.nvim/blob/b25b749b9db64d375d782094e2b9dce53ad53a40/.github/workflows/ci.yml][Telescope build matrix]]
+- [[https://github.com/dangduc/fzf-native/blob/ae3e3e1e8d737949455210f9304dc726ba0e51a1/architecture.org#L56-L75][Emacs platform contract]]
+
+* Executed evidence
+
+** Repository tests
+
+| Product | Command | Result |
+|---------+---------+--------|
+| current fzf | =FZF_VERSION=0.74.3 GO=/opt/homebrew/bin/go make test= | four Go packages passed |
+| Telescope C | =DYLD_LIBRARY_PATH=$PWD/build ./build/test= | 63 passed |
+| Telescope Lua | =make ntest= | 10 passed, 0 failed, 0 errors |
+| Emacs native C | =make BUILD_DIR=build-comparison-ctest ctest= | 115 module tests and 34 matcher tests passed |
+| Emacs parser failures | same =ctest= command | 25 allocation sites passed |
+| Emacs scorer failures | same =ctest= command | 36 allocation failures passed |
+| Emacs public API | =FZF_NATIVE_TEST_MODULE=MODULE EMACS=EMACS make test= | 168 passed, 0 unexpected |
+
+The current fzf suite includes exhaustive one-character and two-character V2 equivalence tests.
+It also contains five Go fuzz entry points.
+
+The Telescope repository contains no sanitizer or coverage-guided fuzz target.
+Its own test commands still passed at the pinned revision.
+
+The Emacs repository contains matcher and session libFuzzer targets.
+It also contains sanitizer replay, TSan replay, real-Emacs random, and upstream membership targets.
+
+The Emacs C test build completed with compiler warnings.
+Apple Clang reported unused values and signed integer comparisons in =fzf.c=.
+
+** ASCII primitive matrix
+
+A temporary Go driver called the current fzf algorithm functions directly.
+A temporary C driver called the exported C algorithm functions directly.
+
+The matrix used this finite set of combinations:
+
+| Dimension | Values |
+|-----------+--------|
+| algorithms | V1, V2, exact, prefix, suffix, equal |
+| case setting | ignore and respect |
+| normalization | disabled |
+| direction | forward |
+| pattern alphabet | =aA/= |
+| pattern length | one through two bytes |
+| candidate alphabet | =aA/= |
+| candidate length | zero through four bytes |
+| total calls per implementation | 17,424 |
+
+The drivers pre-lowered ignored-case C patterns.
+This step matches the preparation done by both C parsers.
+
+| Comparison | Membership equal | Raw result tuple equal | Score equal among 6,324 matches | Positions equal among matches |
+|------------+------------------+-----------------------+----------------------------------+-------------------------------|
+| Telescope port versus Emacs port | 17,424 | 17,424 | 6,324 | 6,324 |
+| current fzf versus Telescope port | 17,424 | 11,677 | 1,266 | 3,252 |
+| current fzf versus Emacs port | 17,424 | 11,677 | 1,266 | 3,252 |
+
+Current fzf exact, prefix, suffix, and equal primitives return no position slice.
+The C primitives return explicit positions for these matches.
+
+For V2, 32 matching cases selected a different range and position set.
+Boundary scoring explains the shown =/a= example.
+
+This finite matrix proves only the tested domain.
+It does not prove general equivalence.
+
+** Public query matrix
+
+The query probe used 20 distinct candidates and 18 query forms.
+It compared membership through =fzf --filter= and each C parsed-pattern API.
+
+The query set covered fuzzy, exact, boundary, prefix, suffix, equal, inverse, AND, OR, spaces, smart case, and global exact mode.
+
+The two C ports agreed on all 18 rows.
+Current fzf agreed on 17 rows.
+
+The only difference was the newer ='foo'= exact-boundary form.
+Current fzf matched =foo=, =bar foo baz=, =foo-bar=, and =FOO=.
+
+Both C ports matched no candidate in that test row.
+Their parsed term included the final quote.
+
+** Unicode matrix
+
+The Unicode probe used parsed public patterns for both C ports.
+It used ignore-case mode in all 13 rows.
+Twelve rows disabled normalization in every core.
+One row enabled current fzf normalization to test that product-specific feature.
+
+| Query and candidate | current fzf | Telescope port | Emacs port |
+|---------------------+-------------+----------------+------------|
+| =café= and =CAFÉ= | match | no match | match |
+| =σ= and =Σ= | match | no match | match |
+| =k= and =K= | match | no match | match |
+| =ⱥ= and =Ⱥ= | match | no match | match |
+| =ß= and =ẞ= | match | no match | match |
+| =中文= and =测试中文= | match at 2,3 | match at bytes 6-11 | match at 2,3 |
+| =😀= and =a😀b= | match at 1 | match at bytes 1-4 | match at 1 |
+| combining mark and =é= | match at 1 | match at bytes 1-2 | match at 1 |
+| normalized =cafe= and =café= | match | no match | no match |
+
+The complete Unicode probe contained 13 cases.
+Current fzf and the Emacs port agreed on membership in 12 cases.
+
+The accent-normalization case caused their only difference.
+Current fzf and the Telescope port agreed on membership in six cases.
+
+** Malformed-byte matrix
+
+The malformed-byte probe passed raw byte arguments on POSIX.
+It used respect-case mode to avoid case conversion.
+
+All six same-byte and different-byte cases produced stable results.
+The current fzf command interface and direct Go core driver agreed in all six cases.
+The table in [[*Malformed UTF-8][Malformed UTF-8]] shows the distinguishing cases.
+
+** Persistent Emacs session probe
+
+One Emacs process loaded the fresh module, started one producer, and submitted two queries through one handle.
+
+#+begin_src text
+abi=1 first-id=1 first=("alpha" "alphabet" "beta" "gamma")
+second-id=2 second=("alpha" "alphabet") total=4
+#+end_src
+
+The second query reused the same producer and four-candidate pool.
+The narrower query received a new request identifier.
+
+** Native symbol probe
+
+=nm -gU= found 15 text exports in the Telescope shared library.
+The symbol list appears in [[*Telescope port][Telescope port]].
+
+The same command found one text export in the Emacs module.
+=nm= also found the required GPL compatibility data symbol.
+
+Both Darwin libraries linked only to =/usr/lib/libSystem.B.dylib=.
+The Emacs module contains utf8proc through static linkage.
+
+** Telescope adapter probe
+
+A LuaJIT probe supplied two mock modules for =telescope= and =telescope.sorters=.
+It loaded the real FFI adapter and the real Telescope extension.
+
+#+begin_src text
+prompt  retained filtered count after start
+abc     0
+abc|    0
+abc\    0
+abc!    0
+#+end_src
+
+The current start hook clears the filtered subset for ordinary and operator prompts.
+The native prompt-pattern cache still persists until sorter destruction.
+
+The exported sorter uses defaults only when callers omit the options table.
+An empty options table raises =nil is not a valid case mode=.
+
+The ten Lua tests load =fzf_lib= only.
+They do not load =telescope._extensions.fzf= or test these sorter behaviors.
+
+* Test and benchmark coverage
+
+| Area | current fzf | Telescope port | Emacs port |
+|------+-------------+----------------+------------|
+| Core unit tests | four Go package suites | 63 C tests | 149 direct C tests plus failure sweeps |
+| Application or binding tests | terminal and reader packages | 10 FFI tests, no sorter test found | 168 Emacs tests |
+| Finite domains | exhaustive V2 fast paths | none found | differential matrices and fuzz corpora |
+| Coverage-guided fuzzing | five Go targets | none found | matcher and session libFuzzer targets |
+| Concurrency sanitizer | no repository target found | none found | session TSan replay target |
+| Memory sanitizers | Go runtime checks | none found | ASan and UBSan targets |
+| Upstream comparison | not applicable | none found | current fzf membership target |
+
+Each repository measures a different performance boundary.
+Current fzf has Go microbenchmarks for cache, ANSI, and low-level search helpers.
+
+The Telescope README shows an older comparison against Telescope sorters.
+The repository does not contain the benchmark driver or raw result data.
+
+The Emacs repository has relative ERT guards and a session cache history test.
+It also records external completion benchmark work in the session design history.
+
+These tests do not support a fastest-product claim.
+A fair test needs equivalent data, queries, warm state, result limits, host work, and output work.
+
+* Compatibility rules
+
+Use these rules when one integration claims fzf compatibility:
+
+1. Name the exact fzf revision or query subset.
+2. Compare membership separately from score, positions, and rank.
+3. State whether Latin accent normalization is active.
+4. State the case table and malformed-byte policy.
+5. State whether positions count bytes or code points.
+6. Treat ='word'= as unsupported in both C ports.
+7. Treat regular-expression query syntax as unsupported everywhere.
+8. Treat host lifecycle and native lifecycle as separate contracts.
+9. Do not use one implementation's score as another implementation's threshold.
+10. Run an end-to-end host test before a compatibility release.
+
+The ASCII and query probes show membership agreement across their tested subsets.
+For score-sensitive rank, Unicode text, or interactive state, use product-specific tests.
+
+* Audit limitations
+
+- The behavior matrices are finite.
+- The audit did not exercise every current fzf option or terminal action.
+- The audit did not compare rendered terminal, Telescope, and Emacs interfaces.
+- The audit did not run a common end-to-end performance test.
+- Host applications can add filtering, ordering, display, and cancellation behavior.
+- Repository tests describe implemented checks, not complete correctness proofs.
+- License statements report file and repository markings only.
+
+* Update procedure
+
+1. Pin all three revisions before the audit.
+2. Record tool versions and the test system.
+3. Run each repository's own test commands.
+4. Rebuild both C libraries from their pinned sources.
+5. Run the ASCII, query, Unicode, and malformed-byte probes.
+6. Inspect new query terms, score values, rank rules, and text tables.
+7. Inspect reader, cache, worker, and public interface changes.
+8. Update every revision link and observed result.
+9. Run =org-lint= and the documentation language check.
+10. Avoid performance conclusions without one common host-aware test.
+
+* Source map
+
+| Product | Area | Pinned source |
+|---------+------+---------------|
+| current fzf | algorithms | [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/algo/algo.go][=src/algo/algo.go=]] |
+| current fzf | query parser | [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/pattern.go][=src/pattern.go=]] |
+| current fzf | matcher | [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/matcher.go][=src/matcher.go=]] |
+| current fzf | candidate store | [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/chunklist.go][=src/chunklist.go=]] |
+| current fzf | cache | [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/cache.go][=src/cache.go=]] |
+| current fzf | reader | [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/reader.go][=src/reader.go=]] |
+| current fzf | terminal | [[https://github.com/junegunn/fzf/blob/1372d04f79bde0daa3bab4b96a068baafa808e67/src/terminal.go][=src/terminal.go=]] |
+| Telescope port | matcher and parser | [[https://github.com/nvim-telescope/telescope-fzf-native.nvim/blob/b25b749b9db64d375d782094e2b9dce53ad53a40/src/fzf.c][=src/fzf.c=]] |
+| Telescope port | C interface | [[https://github.com/nvim-telescope/telescope-fzf-native.nvim/blob/b25b749b9db64d375d782094e2b9dce53ad53a40/src/fzf.h][=src/fzf.h=]] |
+| Telescope port | FFI adapter | [[https://github.com/nvim-telescope/telescope-fzf-native.nvim/blob/b25b749b9db64d375d782094e2b9dce53ad53a40/lua/fzf_lib.lua][=lua/fzf_lib.lua=]] |
+| Telescope port | Telescope sorter | [[https://github.com/nvim-telescope/telescope-fzf-native.nvim/blob/b25b749b9db64d375d782094e2b9dce53ad53a40/lua/telescope/_extensions/fzf.lua][=lua/telescope/_extensions/fzf.lua=]] |
+| Emacs port | matcher and parser | [[https://github.com/dangduc/fzf-native/blob/ae3e3e1e8d737949455210f9304dc726ba0e51a1/fzf.c][=fzf.c=]] |
+| Emacs port | batch and session module | [[https://github.com/dangduc/fzf-native/blob/ae3e3e1e8d737949455210f9304dc726ba0e51a1/fzf-native-module.c][=fzf-native-module.c=]] |
+| Emacs port | Lisp loader | [[https://github.com/dangduc/fzf-native/blob/ae3e3e1e8d737949455210f9304dc726ba0e51a1/fzf-native.el][=fzf-native.el=]] |
+| Emacs port | architecture | [[https://github.com/dangduc/fzf-native/blob/ae3e3e1e8d737949455210f9304dc726ba0e51a1/architecture.org][=architecture.org=]] |
+| Emacs port | matcher fuzz target | [[https://github.com/dangduc/fzf-native/blob/ae3e3e1e8d737949455210f9304dc726ba0e51a1/fuzz/fzf-native-fuzz.c][=fuzz/fzf-native-fuzz.c=]] |
+| Emacs port | session fuzz target | [[https://github.com/dangduc/fzf-native/blob/ae3e3e1e8d737949455210f9304dc726ba0e51a1/fuzz/fzf-native-session-fuzz.c][=fuzz/fzf-native-session-fuzz.c=]] |


### PR DESCRIPTION
## Summary

- compare current junegunn/fzf, telescope-fzf-native.nvim, and fzf-native at pinned revisions
- document matcher lineage, query syntax, scoring, Unicode, malformed bytes, incremental state, caches, concurrency, ABI, platforms, and test coverage
- link the comparison from README.org

## Executed evidence

- current fzf: four Go package suites passed
- Telescope: 63 C tests and 10 Neovim FFI tests passed
- fzf-native: 149 direct C tests, allocation-failure sweeps, and 168 Emacs tests passed
- cross-core probes covered 17,424 ASCII calls per implementation, 18 public query forms, 13 Unicode cases, and six malformed-byte cases
- persistent Emacs session, native symbols, NUL records, and Telescope sorter state received focused probes
- Org lint, Org HTML export, and the Simplified English check passed

The document avoids cross-product performance rankings because no common host-aware benchmark exists.