### PR TITLE
Add an upstream differential fuzz regime

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -9,12 +9,16 @@ on:
     - cron: "17 9 * * 1"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 env:
-  FZF_VERSION: 0.74.3
-  FZF_LINUX_AMD64_SHA256: 3501a595e4b5c40a6b047340a0e8f805c46fd4e61ef95ef8a136ba8c61cf6f22
+  FZF_ORACLE_REVISION: 1372d04f79bde0daa3bab4b96a068baafa808e67
+  EMACS_CI_REVISION: 159c450a1f054908e54114899556f82ddcfeaf60
+  GO_VERSION: 1.27.1
+  FUZZ_SECONDS: ${{ github.event_name == 'schedule' && '1800' || '60' }}
+  FUZZ_SESSION_READER_SECONDS: ${{ github.event_name == 'schedule' && '300' || '30' }}
+  FZF_NATIVE_UPSTREAM_CASES: ${{ github.event_name == 'schedule' && '10000' || '1000' }}
 
 jobs:
   fuzz:
@@ -22,21 +26,49 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - name: Install pinned upstream fzf reference
+      - name: Check out the pinned upstream fzf oracle
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: junegunn/fzf
+          ref: ${{ env.FZF_ORACLE_REVISION }}
+          path: build/fzf-oracle-source
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
+      - name: Restore learned fuzz corpora
+        id: fuzz-corpus-cache
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            build/fuzz-corpus
+            build/fuzz-session-corpus
+            build/fuzz-session-reader-corpus
+          key: fzf-native-fuzz-${{ runner.os }}-${{ hashFiles('fzf.c', 'fzf-additions.c', 'fzf-native-module.c', 'fuzz/**/*.c', 'fuzz/corpus/**', 'fuzz/session-corpus/**') }}-${{ github.run_id }}
+          restore-keys: |
+            fzf-native-fuzz-${{ runner.os }}-${{ hashFiles('fzf.c', 'fzf-additions.c', 'fzf-native-module.c', 'fuzz/**/*.c', 'fuzz/corpus/**', 'fuzz/session-corpus/**') }}-
+            fzf-native-fuzz-${{ runner.os }}-
+
+      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+
+      - name: Install the pinned Emacs 30.2 toolchain
         shell: bash
         run: |
-          curl -fsSL -o "$RUNNER_TEMP/fzf.tar.gz" \
-            "https://github.com/junegunn/fzf/releases/download/v${FZF_VERSION}/fzf-${FZF_VERSION}-linux_amd64.tar.gz"
-          echo "${FZF_LINUX_AMD64_SHA256}  $RUNNER_TEMP/fzf.tar.gz" | sha256sum --check
-          mkdir -p "$RUNNER_TEMP/fzf-reference"
-          tar -xzf "$RUNNER_TEMP/fzf.tar.gz" -C "$RUNNER_TEMP/fzf-reference"
-          echo "$RUNNER_TEMP/fzf-reference" >> "$GITHUB_PATH"
+          nix profile install --accept-flake-config \
+            "github:purcell/nix-emacs-ci/${EMACS_CI_REVISION}#emacs-30-2"
+          test "$(emacs --batch --eval '(princ emacs-version)')" = "30.2"
 
-      - uses: jcs090218/setup-emacs@master
-        with:
-          version: 30.1
+      - name: Compare raw matcher results with pinned fzf code
+        env:
+          FZF_SOURCE: ${{ github.workspace }}/build/fzf-oracle-source
+        run: make FUZZ_CC=clang fuzz-oracle-test-san
 
       - name: Replay the permanent ASan/UBSan corpus
         run: make FUZZ_CC=clang fuzz-replay
@@ -45,22 +77,42 @@ jobs:
         run: make FUZZ_CC=clang fuzz-session-tsan
 
       - name: Run a bounded coverage-guided campaign
-        run: make FUZZ_CC=clang FUZZ_SECONDS=60 fuzz
+        run: make FUZZ_CC=clang fuzz
 
-      - name: Exercise the unchanged Emacs module ABI
+      - name: Merge learned corpora by target coverage
+        run: make FUZZ_CC=clang fuzz-merge
+
+      - name: Save learned fuzz corpora
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            build/fuzz-corpus
+            build/fuzz-session-corpus
+            build/fuzz-session-reader-corpus
+          key: ${{ steps.fuzz-corpus-cache.outputs.cache-primary-key }}
+
+      - name: Fuzz the Emacs module ABI and session API
         env:
           FZF_NATIVE_FUZZ_CASES: 2000
+          FZF_NATIVE_FUZZ_ABI_CASES: 2000
+          FZF_NATIVE_FUZZ_SESSION_CASES: ${{ github.event_name == 'schedule' && '1000' || '250' }}
         run: make fuzz-elisp
 
-      - name: Compare ASCII match sets with pinned upstream fzf
+      - name: Compare structured and persistent-session results with pinned fzf
         env:
-          FZF_REFERENCE_VERSION: ${{ env.FZF_VERSION }}
-          FZF_NATIVE_UPSTREAM_CASES: 1000
-        run: make fuzz-upstream
+          FZF_SOURCE: ${{ github.workspace }}/build/fzf-oracle-source
+        run: make fuzz-upstream-pinned
+
+      - name: Compare V2 fallback length boundaries
+        env:
+          FZF_SOURCE: ${{ github.workspace }}/build/fzf-oracle-source
+          FZF_NATIVE_UPSTREAM_PROFILE: long
+          FZF_NATIVE_UPSTREAM_CASES: 3
+        run: make fuzz-upstream-pinned
 
       - name: Upload reproducible crash artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: fzf-native-fuzz-artifacts
           path: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,8 +173,10 @@ if(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
   # -DENABLE_UBSAN=ON -DCMAKE_BUILD_TYPE=Debug ..
   if(ENABLE_UBSAN)
     target_compile_options(fzf-native-module PRIVATE -fsanitize=undefined
+                                                     -fno-sanitize-recover=undefined
                                                      -fno-omit-frame-pointer -g)
     target_compile_options(utf8proc PRIVATE -fsanitize=undefined
+                                            -fno-sanitize-recover=undefined
                                             -fno-omit-frame-pointer -g)
     target_link_options(fzf-native-module PRIVATE -fsanitize=undefined)
     message(STATUS "UndefinedBehaviorSanitizer enabled")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,12 +172,13 @@ if(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
   # misaligned access, out-of-bounds shifts, etc. Enable with: cmake
   # -DENABLE_UBSAN=ON -DCMAKE_BUILD_TYPE=Debug ..
   if(ENABLE_UBSAN)
-    target_compile_options(fzf-native-module PRIVATE -fsanitize=undefined
-                                                     -fno-sanitize-recover=undefined
-                                                     -fno-omit-frame-pointer -g)
-    target_compile_options(utf8proc PRIVATE -fsanitize=undefined
-                                            -fno-sanitize-recover=undefined
-                                            -fno-omit-frame-pointer -g)
+    target_compile_options(
+      fzf-native-module
+      PRIVATE -fsanitize=undefined -fno-sanitize-recover=undefined
+              -fno-omit-frame-pointer -g)
+    target_compile_options(
+      utf8proc PRIVATE -fsanitize=undefined -fno-sanitize-recover=undefined
+                       -fno-omit-frame-pointer -g)
     target_link_options(fzf-native-module PRIVATE -fsanitize=undefined)
     message(STATUS "UndefinedBehaviorSanitizer enabled")
   endif()

--- a/Makefile
+++ b/Makefile
@@ -158,19 +158,19 @@ ctest-scorer-oom:
 ctest-asan: export UBSAN_OPTIONS = halt_on_error=1:print_stacktrace=1
 ctest-asan:
 	mkdir -p $(BUILD_DIR)
-	$(CC) -std=gnu11 -Wall -Wextra -fsanitize=address,undefined -fno-omit-frame-pointer -g \
+	$(CC) -std=gnu11 -Wall -Wextra -fsanitize=address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g \
 		-I. -I$(UTF8PROC_DIR) -pthread \
 		-o $(BUILD_DIR)/fzf-native-ctest-asan fzf-native-ctest.c fzf.c fzf-additions.c $(UTF8PROC_SRC)
 	$(BUILD_DIR)/fzf-native-ctest-asan
-	$(CC) -std=gnu11 -Wall -Wextra -fsanitize=address,undefined -fno-omit-frame-pointer -g \
+	$(CC) -std=gnu11 -Wall -Wextra -fsanitize=address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g \
 		-I. -I$(UTF8PROC_DIR) -pthread \
 		-o $(BUILD_DIR)/fzf-additions-test-asan fzf-additions-test.c fzf.c fzf-additions.c $(UTF8PROC_SRC)
 	$(BUILD_DIR)/fzf-additions-test-asan
-	$(CC) -std=gnu11 -Wall -Wextra -fsanitize=address,undefined -fno-omit-frame-pointer -g \
+	$(CC) -std=gnu11 -Wall -Wextra -fsanitize=address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g \
 		-I. -I$(UTF8PROC_DIR) \
 		-o $(BUILD_DIR)/fzf-parser-oom-ctest-asan fzf-parser-oom-ctest.c fzf-additions.c $(UTF8PROC_SRC)
 	$(BUILD_DIR)/fzf-parser-oom-ctest-asan
-	$(CC) -std=gnu11 -Wall -Wextra -fsanitize=address,undefined -fno-omit-frame-pointer -g \
+	$(CC) -std=gnu11 -Wall -Wextra -fsanitize=address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g \
 		-I. -I$(UTF8PROC_DIR) \
 		-o $(BUILD_DIR)/fzf-scorer-oom-ctest-asan fzf-scorer-oom-ctest.c $(UTF8PROC_SRC)
 	$(BUILD_DIR)/fzf-scorer-oom-ctest-asan

--- a/fuzz/README.org
+++ b/fuzz/README.org
@@ -5,6 +5,8 @@
 These tests move fzf-native toward parity with junegunn/fzf.
 They use generated inputs, internal properties, and a pinned fzf oracle.
 
+Read [[file:upstream-parity-handoff.org][the PR 48 hand-off]] for the dated maintainer-transfer state.
+
 The tests keep crashes, hangs, data races, and unknown output as unconditional failures.
 They also fail on unclassified differences from the oracle.
 

--- a/fuzz/README.org
+++ b/fuzz/README.org
@@ -1,0 +1,216 @@
+#+title: Fuzz and differential test guide
+
+* Purpose
+
+These tests move fzf-native toward parity with junegunn/fzf.
+They use generated inputs, internal properties, and a pinned fzf oracle.
+
+The tests keep crashes, hangs, data races, and unknown output as unconditional failures.
+They also fail on unclassified differences from the oracle.
+
+* Test design
+
+The raw lane compares independently implemented Go and C matchers.
+The parsed lane compares both public parsers through a pinned fzf executable.
+Sanitizer and metamorphic checks can expose crashes or weak differential assumptions.
+
+Each generator records its seed and serial number.
+The generators vary input dimensions independently and check their cross-product.
+Permanent regression seeds preserve each confirmed failure.
+
+Do not treat one difference as proof that fzf-native is wrong.
+First verify the oracle revision, input contract, and documented difference policy.
+Then minimize the case and add a permanent regression test.
+
+* Oracle pin
+
+The oracle uses fzf commit =1372d04f79bde0daa3bab4b96a068baafa808e67=.
+The raw oracle requires Go =1.27.1=.
+
+Use the same fzf commit and Go version for one campaign.
+Record both versions with every saved failure.
+
+Update the pin in one reviewable change.
+Run all differential profiles before you accept a new pin.
+Do not change an exception to make a new pin pass.
+
+* Test lanes
+
+** Raw algorithm lane
+
+This lane compares one native algorithm result with the corresponding Go result.
+It compares membership, range, score, and positions.
+Both peers stay active across many framed requests.
+
+Run the sanitizer checks:
+
+#+begin_src sh
+make FUZZ_CC=clang FZF_SOURCE=/path/to/pinned/fzf fuzz-oracle-test-san
+#+end_src
+
+The default run compares 20,000 generated membership cases.
+Set =FZF_RAW_MATRIX_SEED=, =FZF_RAW_MATRIX_START=, and =FZF_RAW_MATRIX_CASES= for replay.
+Set =FZF_RAW_MATRIX_FULL_RESULTS=1= to expose score, range, and position debt.
+The full-result audit currently fails on known parity debt.
+
+The protocol and current parity cases are in [[file:oracle/README.org][oracle/README.org]].
+
+** Parsed query lane
+
+This lane generates a query tree and a candidate collection.
+It renders the same query for the native module and the fzf executable.
+It compares stable candidate identities instead of candidate text.
+
+Run the common profile:
+
+#+begin_src sh
+make FZF_SOURCE=/path/to/pinned/fzf \
+  FZF_NATIVE_UPSTREAM_CASES=1000 fuzz-upstream-pinned
+#+end_src
+
+Replay one range with a fixed seed:
+
+#+begin_src sh
+make FZF_SOURCE=/path/to/pinned/fzf \
+  FZF_NATIVE_FUZZ_SEED=12648430 \
+  FZF_NATIVE_UPSTREAM_START=400 \
+  FZF_NATIVE_UPSTREAM_CASES=20 fuzz-upstream-pinned
+#+end_src
+
+Set =FZF_NATIVE_UPSTREAM_PROFILE=long= to test lengths 999, 1000, and 1001.
+Set =FZF_NATIVE_UPSTREAM_PROFILE=parity= to expose known parity debt.
+The parity profile fails until the related behavior has parity.
+
+** Native matcher lane
+
+This lane uses libFuzzer with AddressSanitizer and UndefinedBehaviorSanitizer.
+It checks result invariants and metamorphic relations inside the C matcher.
+
+The checks cover query transformations, Unicode, slab fallback, and candidate extension.
+They also compare V1 and V2 membership where both algorithms apply.
+
+Run and replay this lane:
+
+#+begin_src sh
+make FUZZ_SECONDS=60 fuzz-matcher
+make fuzz-matcher-replay
+#+end_src
+
+** Interactive session lane
+
+This lane drives the real persistent session core with generated operation traces.
+The state target covers worker, cache, request, cancellation, and teardown behavior.
+The reader target covers blocking producer input and child-process ownership.
+
+Run the session targets:
+
+#+begin_src sh
+make FUZZ_SESSION_SECONDS=60 FUZZ_SESSION_READER_SECONDS=30 fuzz-session
+make fuzz-session-replay
+make fuzz-session-tsan
+#+end_src
+
+The end-to-end session check loads the native module in Emacs.
+It compares completed session rounds with fresh fzf results.
+It keeps one native handle for broad, narrow, repeated, and Unicode queries.
+
+Run it with a source-pinned fzf executable:
+
+#+begin_src sh
+make FZF_SOURCE=/path/to/pinned/fzf fuzz-upstream-session-pinned
+#+end_src
+
+** Emacs ABI lane
+
+This lane loads the built native module in Emacs 30.2.
+It generates values at the Lisp and native-module boundary.
+It checks scalar, batch, highlight, type, and session behavior.
+
+Run this lane:
+
+#+begin_src sh
+make FZF_NATIVE_FUZZ_CASES=2000 \
+  FZF_NATIVE_FUZZ_ABI_CASES=2000 \
+  FZF_NATIVE_FUZZ_SESSION_CASES=250 fuzz-elisp
+#+end_src
+
+* Generator dimensions
+
+The parsed generator selects these dimensions independently when possible:
+
+- query tree: empty, one term, AND, OR, inverse, or mixed
+- term kind: fuzzy, exact, prefix, suffix, or equal
+- case mode: smart, ignore, or respect
+- text: ASCII, Unicode, case-fold pair, or malformed bytes
+- layout: front, middle, tail, ambiguous, near miss, or distractor
+- multiplicity: distinct candidates and duplicate occurrences
+- length: 1, 2, 7, 31, 32, 63, 64, 999, 1000, or 1001
+
+Every generated occurrence has a unique numeric identity.
+Every ordinary case also has one candidate that must match upstream fzf.
+
+* Difference policy
+
+An accepted difference needs a narrow executable predicate.
+The entry must include an owner, an upstream revision, and a removal condition.
+
+The only accepted difference is malformed UTF-8 decoder behavior.
+Go and utf8proc replace malformed byte sequences differently.
+The exception applies only to membership and position differences for malformed input.
+
+Scoring, ranking, normalization, backward search, and boundary syntax are parity debt.
+The exception file names these differences, but it does not make them pass.
+Crashes, hangs, races, unknown candidates, and valid UTF-8 differences always fail.
+
+Review [[file:differential/fzf-native-differential-exceptions.el][the exception policy]] when a result differs.
+Reduce the input before you change this policy.
+
+* Corpus management
+
+Permanent seeds live in =fuzz/corpus= and =fuzz/session-corpus=.
+Learned inputs live below the selected build directory.
+
+Merge learned inputs after a clean run:
+
+#+begin_src sh
+make fuzz-merge
+#+end_src
+
+The merge keeps inputs that add coverage for each target.
+Add a readable permanent seed for every confirmed defect.
+Also add a focused regression test for that defect.
+
+* Failure record
+
+Keep this data for each failure:
+
+- fzf-native commit
+- pinned fzf commit and Go version
+- target name and sanitizer
+- generator seed, start value, and serial number
+- exact query, options, candidate bytes, and operation trace
+- native result, oracle result, and accepted-difference classification
+- minimized artifact path and replay command
+
+First replay the exact input without a time limit.
+Then reduce it while you preserve the same failure.
+Treat an isolated RSS-limit artifact as test infrastructure until replay confirms target growth.
+
+* CI cadence
+
+Pull requests run short sanitizer, replay, ABI, and differential gates.
+The weekly job runs longer libFuzzer epochs and more differential cases.
+CI merges and caches each learned corpus after a clean run.
+
+Run the complete local replay set before you submit a matcher change:
+
+#+begin_src sh
+make fuzz-replay
+make fuzz-session-tsan
+make FZF_SOURCE=/path/to/pinned/fzf fuzz-oracle-test-san
+make FZF_SOURCE=/path/to/pinned/fzf fuzz-upstream-pinned
+make FZF_SOURCE=/path/to/pinned/fzf \
+  FZF_NATIVE_UPSTREAM_PROFILE=long \
+  FZF_NATIVE_UPSTREAM_CASES=3 fuzz-upstream-pinned
+make fuzz-elisp
+#+end_src

--- a/fuzz/differential/build-pinned-fzf.sh
+++ b/fuzz/differential/build-pinned-fzf.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+pin=1372d04f79bde0daa3bab4b96a068baafa808e67
+go_pin=go1.27.1
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 FZF_SOURCE OUTPUT" >&2
+  exit 2
+fi
+
+source_dir=$1
+output=$2
+source_commit=$(git -C "$source_dir" rev-parse HEAD)
+
+if [ "$source_commit" != "$pin" ]; then
+  echo "fzf source is at $source_commit; expected $pin" >&2
+  exit 2
+fi
+
+go_version=$(go env GOVERSION)
+if [ "$go_version" != "$go_pin" ]; then
+  echo "Go version is $go_version; expected $go_pin" >&2
+  exit 2
+fi
+
+case "$output" in
+  /*) ;;
+  *) output="$PWD/$output" ;;
+esac
+
+temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/fzf-pinned-cli.XXXXXX")
+trap 'rm -rf "$temp_dir"' EXIT HUP INT TERM
+
+git -C "$source_dir" archive "$pin" | tar -x -C "$temp_dir"
+cd "$temp_dir"
+GOWORK=off go build -mod=readonly -trimpath \
+  -ldflags "-X main.revision=$pin" -o "$output" .

--- a/fuzz/differential/fzf-native-differential-exceptions.el
+++ b/fuzz/differential/fzf-native-differential-exceptions.el
@@ -130,16 +130,41 @@ CONTEXT is not applicable to this classifier."
        (fzf-native-differential-candidate-text candidate)))
     (fzf-native-differential-case-candidates case))))
 
-(defun fzf-native-differential--exception-malformed-utf8-p
-    (case facet _context)
-  "Recognize CASE decoder differences for FACET only with malformed input.
+(defun fzf-native-differential--malformed-difference-p (case context)
+  "Return non-nil if CONTEXT identifies malformed differences in CASE.
 
-CONTEXT is not applicable to this classifier."
+CONTEXT must contain a nonempty `:differing-identities' list.  Every identity
+must name a candidate in CASE.  A malformed query can affect every candidate;
+otherwise, every differing candidate must itself contain malformed UTF-8."
+  (let ((identities (and (listp context)
+                         (plist-get context :differing-identities)))
+        (query-malformed
+         (fzf-native-differential--malformed-utf8-string-p
+          (fzf-native-differential-case-rendered-query case)))
+        (candidates (fzf-native-differential-case-candidates case)))
+    (and (consp identities)
+         (cl-every
+          (lambda (identity)
+            (let ((candidate
+                   (cl-find identity candidates
+                            :key #'fzf-native-differential-candidate-id
+                            :test #'equal)))
+              (and candidate
+                   (or query-malformed
+                       (fzf-native-differential--malformed-utf8-string-p
+                        (fzf-native-differential-candidate-text
+                         candidate))))))
+          identities))))
+
+(defun fzf-native-differential--exception-malformed-utf8-p
+    (case facet context)
+  "Recognize malformed decoder differences for CASE, FACET, and CONTEXT."
   (and (memq facet '(membership positions))
        (not (plist-get
              (fzf-native-differential-case-dimensions case)
              :valid-utf8))
-       (fzf-native-differential--case-has-malformed-utf8-p case)))
+       (fzf-native-differential--case-has-malformed-utf8-p case)
+       (fzf-native-differential--malformed-difference-p case context)))
 
 (defconst fzf-native-differential-exceptions
   `((:name exact-boundary-syntax
@@ -175,7 +200,7 @@ CONTEXT is not applicable to this classifier."
      :disposition accepted
      :upstream-revision ,fzf-native-differential-upstream-revision
      :owner "fzf-native UTF-8 compatibility policy"
-     :scope "Only malformed-byte membership or positions with :valid-utf8 nil."
+     :scope "Only differing malformed inputs for membership or positions."
      :remove-when "Both oracles apply one documented malformed-byte policy."
      :predicate ,#'fzf-native-differential--exception-malformed-utf8-p))
   "Ordered, narrow predicates for known differential behavior.")

--- a/fuzz/differential/fzf-native-differential-exceptions.el
+++ b/fuzz/differential/fzf-native-differential-exceptions.el
@@ -134,13 +134,11 @@ CONTEXT is not applicable to this classifier."
   "Return non-nil if CONTEXT identifies malformed differences in CASE.
 
 CONTEXT must contain a nonempty `:differing-identities' list.  Every identity
-must name a candidate in CASE.  A malformed query can affect every candidate;
-otherwise, every differing candidate must itself contain malformed UTF-8."
+must name a candidate in CASE, and every differing candidate must itself
+contain malformed UTF-8.  A malformed query alone does not attribute an
+arbitrary valid-candidate difference to the decoder policy."
   (let ((identities (and (listp context)
                          (plist-get context :differing-identities)))
-        (query-malformed
-         (fzf-native-differential--malformed-utf8-string-p
-          (fzf-native-differential-case-rendered-query case)))
         (candidates (fzf-native-differential-case-candidates case)))
     (and (consp identities)
          (cl-every
@@ -150,10 +148,8 @@ otherwise, every differing candidate must itself contain malformed UTF-8."
                             :key #'fzf-native-differential-candidate-id
                             :test #'equal)))
               (and candidate
-                   (or query-malformed
-                       (fzf-native-differential--malformed-utf8-string-p
-                        (fzf-native-differential-candidate-text
-                         candidate))))))
+                   (fzf-native-differential--malformed-utf8-string-p
+                    (fzf-native-differential-candidate-text candidate)))))
           identities))))
 
 (defun fzf-native-differential--exception-malformed-utf8-p

--- a/fuzz/differential/fzf-native-differential-exceptions.el
+++ b/fuzz/differential/fzf-native-differential-exceptions.el
@@ -1,0 +1,193 @@
+;;; fzf-native-differential-exceptions.el --- Differential exception policy -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Duc Dang
+;; Author: Duc Dang <me@dangduc.com>
+;; Assisted-by: Codex:gpt-5
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is part of fzf-native.
+
+;;; Commentary:
+
+;; Classify only explicit compatibility differences.  A classifier receives
+;; the compared result facet and a structured case.  No rule permits a crash,
+;; hang, unknown candidate, or ordinary common-profile membership difference.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'fzf-native-differential-generator)
+
+(defconst fzf-native-differential-upstream-revision
+  "1372d04f79bde0daa3bab4b96a068baafa808e67"
+  "Pinned junegunn/fzf revision for differential exception metadata.")
+
+(defun fzf-native-differential--case-has-kind-p (case kind)
+  "Return non-nil if CASE has a term of KIND."
+  (cl-some
+   (lambda (set)
+     (cl-some
+      (lambda (term)
+        (eq (fzf-native-differential-term-kind term) kind))
+      set))
+   (fzf-native-differential-query-sets
+    (fzf-native-differential-case-query case))))
+
+(defun fzf-native-differential--exception-exact-boundary-p
+    (case facet _context)
+  "Return non-nil for current fzf boundary syntax in CASE and FACET.
+
+CONTEXT is not applicable to this classifier."
+  (and (eq facet 'membership)
+       (fzf-native-differential--case-has-kind-p case 'boundary-exact)))
+
+(defun fzf-native-differential--exception-ranking-p
+    (case facet context)
+  "Return non-nil for CASE and FACET after CONTEXT confirms membership."
+  (and (eq facet 'ranking)
+       (eq (fzf-native-differential-case-comparison case) 'ranking)
+       (plist-get context :membership-equal)))
+
+(defun fzf-native-differential--exception-normalization-p
+    (case facet _context)
+  "Recognize CASE normalization for FACET only when the query enables it.
+
+CONTEXT is not applicable to this classifier."
+  (and (eq facet 'membership)
+       (fzf-native-differential-query-normalize
+        (fzf-native-differential-case-query case))))
+
+(defun fzf-native-differential--exception-backward-p
+    (case facet _context)
+  "Recognize CASE backward search for FACET only when the query requests it.
+
+CONTEXT is not applicable to this classifier."
+  (and (memq facet '(membership positions ranking))
+       (not (fzf-native-differential-query-forward
+             (fzf-native-differential-case-query case)))))
+
+(defun fzf-native-differential--utf8-continuation-p (byte)
+  "Return non-nil when BYTE is a UTF-8 continuation byte."
+  (and (<= #x80 byte) (<= byte #xbf)))
+
+(defun fzf-native-differential--valid-utf8-bytes-p (string)
+  "Return non-nil when unibyte STRING is structurally valid UTF-8."
+  (let ((index 0)
+        (length (length string))
+        valid)
+    (setq valid t)
+    (while (and valid (< index length))
+      (let ((first (aref string index)))
+        (cond
+         ((<= first #x7f)
+          (setq index (1+ index)))
+         ((and (<= #xc2 first) (<= first #xdf)
+               (< (1+ index) length)
+               (fzf-native-differential--utf8-continuation-p
+                (aref string (1+ index))))
+          (setq index (+ index 2)))
+         ((and (<= #xe0 first) (<= first #xef)
+               (< (+ index 2) length)
+               (let ((second (aref string (1+ index))))
+                 (and
+                  (cond
+                   ((= first #xe0) (and (<= #xa0 second) (<= second #xbf)))
+                   ((= first #xed) (and (<= #x80 second) (<= second #x9f)))
+                   (t (fzf-native-differential--utf8-continuation-p second)))
+                  (fzf-native-differential--utf8-continuation-p
+                   (aref string (+ index 2))))))
+          (setq index (+ index 3)))
+         ((and (<= #xf0 first) (<= first #xf4)
+               (< (+ index 3) length)
+               (let ((second (aref string (1+ index))))
+                 (and
+                  (cond
+                   ((= first #xf0) (and (<= #x90 second) (<= second #xbf)))
+                   ((= first #xf4) (and (<= #x80 second) (<= second #x8f)))
+                   (t (fzf-native-differential--utf8-continuation-p second)))
+                  (fzf-native-differential--utf8-continuation-p
+                   (aref string (+ index 2)))
+                  (fzf-native-differential--utf8-continuation-p
+                   (aref string (+ index 3))))))
+          (setq index (+ index 4)))
+         (t (setq valid nil)))))
+    valid))
+
+(defun fzf-native-differential--malformed-utf8-string-p (string)
+  "Return non-nil if STRING has bytes that are not valid UTF-8."
+  (and (stringp string)
+       (not (multibyte-string-p string))
+       (not (fzf-native-differential--valid-utf8-bytes-p string))))
+
+(defun fzf-native-differential--case-has-malformed-utf8-p (case)
+  "Return non-nil if CASE has an actually malformed byte string."
+  (or
+   (fzf-native-differential--malformed-utf8-string-p
+    (fzf-native-differential-case-rendered-query case))
+   (cl-some
+    (lambda (candidate)
+      (fzf-native-differential--malformed-utf8-string-p
+       (fzf-native-differential-candidate-text candidate)))
+    (fzf-native-differential-case-candidates case))))
+
+(defun fzf-native-differential--exception-malformed-utf8-p
+    (case facet _context)
+  "Recognize CASE decoder differences for FACET only with malformed input.
+
+CONTEXT is not applicable to this classifier."
+  (and (memq facet '(membership positions))
+       (not (plist-get
+             (fzf-native-differential-case-dimensions case)
+             :valid-utf8))
+       (fzf-native-differential--case-has-malformed-utf8-p case)))
+
+(defconst fzf-native-differential-exceptions
+  `((:name exact-boundary-syntax
+     :reason "Current fzf implements the trailing-quote boundary term."
+     :disposition parity-debt
+     :upstream-revision ,fzf-native-differential-upstream-revision
+     :owner "fzf-native query parser"
+     :remove-when "Boundary-term membership matches the pinned fzf revision."
+     :predicate ,#'fzf-native-differential--exception-exact-boundary-p)
+    (:name score-ranking-revision
+     :reason "Current fzf and fzf-native use different score and rank rules."
+     :disposition parity-debt
+     :upstream-revision ,fzf-native-differential-upstream-revision
+     :owner "fzf-native scoring implementation"
+     :remove-when "Ordered identities match pinned fzf when membership agrees."
+     :predicate ,#'fzf-native-differential--exception-ranking-p)
+    (:name normalization-policy
+     :reason "The public fzf-native parser does not enable fzf normalization."
+     :disposition parity-debt
+     :upstream-revision ,fzf-native-differential-upstream-revision
+     :owner "fzf-native public query API"
+     :remove-when "Normalized-query membership matches the pinned fzf revision."
+     :predicate ,#'fzf-native-differential--exception-normalization-p)
+    (:name backward-search-capability
+     :reason "fzf-native does not expose fzf's backward matcher direction."
+     :disposition parity-debt
+     :upstream-revision ,fzf-native-differential-upstream-revision
+     :owner "fzf-native matcher API"
+     :remove-when "Backward membership, positions, and ranking match pinned fzf."
+     :predicate ,#'fzf-native-differential--exception-backward-p)
+    (:name malformed-utf8-decoder
+     :reason "Go and utf8proc preserve malformed input differently."
+     :disposition accepted
+     :upstream-revision ,fzf-native-differential-upstream-revision
+     :owner "fzf-native UTF-8 compatibility policy"
+     :scope "Only malformed-byte membership or positions with :valid-utf8 nil."
+     :remove-when "Both oracles apply one documented malformed-byte policy."
+     :predicate ,#'fzf-native-differential--exception-malformed-utf8-p))
+  "Ordered, narrow predicates for known differential behavior.")
+
+(defun fzf-native-differential-classify (case facet &optional context)
+  "Return the first exception entry for CASE, FACET, and CONTEXT.
+
+Return nil for an unclassified difference."
+  (cl-find-if
+   (lambda (entry)
+     (funcall (plist-get entry :predicate) case facet context))
+   fzf-native-differential-exceptions))
+
+(provide 'fzf-native-differential-exceptions)
+;;; fzf-native-differential-exceptions.el ends here

--- a/fuzz/differential/fzf-native-differential-generator.el
+++ b/fuzz/differential/fzf-native-differential-generator.el
@@ -1,0 +1,520 @@
+;;; fzf-native-differential-generator.el --- Structured differential cases -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Duc Dang
+;; Author: Duc Dang <me@dangduc.com>
+;; Assisted-by: Codex:gpt-5
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is part of fzf-native.
+
+;;; Commentary:
+
+;; Generate deterministic, parsed-query cases for comparison with upstream fzf.
+;; The generator constructs at least one matching candidate before it adds near
+;; misses, ranking variants, and duplicate occurrences.  Stable numeric
+;; identities let the comparison preserve multiplicity.
+
+;;; Code:
+
+(require 'cl-lib)
+
+(cl-defstruct fzf-native-differential-rng state)
+
+(cl-defstruct fzf-native-differential-term
+  kind inverse literal)
+
+(cl-defstruct fzf-native-differential-query
+  sets case-mode fuzzy normalize forward)
+
+(cl-defstruct fzf-native-differential-candidate
+  id text role)
+
+(cl-defstruct fzf-native-differential-case
+  seed serial profile query rendered-query candidates dimensions comparison)
+
+(defconst fzf-native-differential--ascii-atoms
+  ["a" "ab" "alpha" "Beta" "fzf" "main" "src" "test42" "xYz"])
+
+(defconst fzf-native-differential--unicode-atoms
+  ["café" "σ" "中文" "😀" "é" "Ωmega" "𐐷"])
+
+(defconst fzf-native-differential--malformed-atoms
+  (vector (unibyte-string #xff)
+          (unibyte-string #xc3)
+          (unibyte-string #xe2 #x82)
+          (unibyte-string #xed #xa0 #x80)
+          (unibyte-string #xf5 #x80 #x80 #x80))
+  "Byte strings that are not valid UTF-8.")
+
+(defconst fzf-native-differential--case-pairs
+  [["café" "CAFÉ"]
+   ["σ" "Σ"]
+   ["k" "K"]
+   ["ⱥ" "Ⱥ"]
+   ["i" "İ"]
+   ["ß" "ẞ"]])
+
+(defconst fzf-native-differential--separators
+  ["/" "-" "_" "." ":" " "])
+
+(defconst fzf-native-differential--absent-atoms
+  ["@" "#" "%" "&" ";" "?" "+" "=" "🛸"])
+
+(defconst fzf-native-differential--common-kinds
+  [fuzzy exact prefix suffix equal])
+
+(defun fzf-native-differential-rng-create (seed)
+  "Return a deterministic generator initialized with SEED."
+  (make-fzf-native-differential-rng
+   :state (logand (max 1 seed) #xffffffff)))
+
+(defun fzf-native-differential-random (rng limit)
+  "Use RNG to return an integer in [0, LIMIT)."
+  (let ((x (fzf-native-differential-rng-state rng)))
+    (setq x (logxor x (ash x 13)))
+    (setq x (logxor x (ash x -17)))
+    (setq x (logxor x (ash x 5)))
+    (setq x (logand x #xffffffff))
+    (setf (fzf-native-differential-rng-state rng) x)
+    (if (<= limit 0) 0 (% x limit))))
+
+(defun fzf-native-differential--pick (rng vector)
+  "Return one member of VECTOR using RNG."
+  (aref vector (fzf-native-differential-random rng (length vector))))
+
+(defun fzf-native-differential--identity (id)
+  "Return the stable textual identity for ID."
+  (format "~%04x~" id))
+
+(defun fzf-native-differential--escape-literal (literal)
+  "Escape spaces in LITERAL for the extended-search parser."
+  (replace-regexp-in-string " " "\\ " literal t t))
+
+(defun fzf-native-differential-render-term (term fuzzy)
+  "Render TERM for an extended query with global FUZZY mode."
+  (let* ((literal
+          (fzf-native-differential--escape-literal
+           (fzf-native-differential-term-literal term)))
+         (kind (fzf-native-differential-term-kind term))
+         (inverse (fzf-native-differential-term-inverse term)))
+    (if inverse
+        (pcase kind
+          ('fuzzy (concat "!'" literal))
+          ('exact (concat "!" literal))
+          ('prefix (concat "!^" literal))
+          ('suffix (concat "!" literal "$"))
+          ('equal (concat "!^" literal "$"))
+          (_ (error "Unsupported inverse term kind: %S" kind)))
+      (pcase kind
+        ('fuzzy (if fuzzy literal (concat "'" literal)))
+        ('exact (if fuzzy (concat "'" literal) literal))
+        ('prefix (concat "^" literal))
+        ('suffix (concat literal "$"))
+        ('equal (concat "^" literal "$"))
+        ('boundary-exact (concat "'" literal "'"))
+        (_ (error "Unsupported term kind: %S" kind))))))
+
+(defun fzf-native-differential-render-query (query)
+  "Render structured QUERY for fzf and fzf-native."
+  (mapconcat
+   (lambda (set)
+     (mapconcat
+      (lambda (term)
+        (fzf-native-differential-render-term
+         term (fzf-native-differential-query-fuzzy query)))
+      set " | "))
+   (fzf-native-differential-query-sets query) " "))
+
+(defun fzf-native-differential--subsequence (string)
+  "Return a nonempty, ordered subsequence of STRING."
+  (let ((characters (string-to-list string)) result)
+    (cl-loop for character in characters
+             for index from 0
+             when (zerop (% index 2))
+             do (push character result))
+    (if result
+        (apply (if (multibyte-string-p string)
+                   #'string
+                 #'unibyte-string)
+               (nreverse result))
+      "a")))
+
+(defun fzf-native-differential--prefix (string)
+  "Return a nonempty prefix of STRING."
+  (substring string 0 (max 1 (min (length string) 5))))
+
+(defun fzf-native-differential--suffix (string)
+  "Return a nonempty suffix of STRING."
+  (substring string (max 0 (- (length string) 6))))
+
+(defun fzf-native-differential--absent (rng candidate)
+  "Return a one-character atom that is absent from CANDIDATE.
+
+Use RNG only for the defensive fallback.  A missing single character cannot
+match CANDIDATE under fuzzy, exact, prefix, suffix, or equal matching."
+  (or (cl-find-if
+       (lambda (atom) (not (string-search atom candidate)))
+       (append fzf-native-differential--absent-atoms nil))
+      (concat "qzx" (number-to-string
+                     (fzf-native-differential-random rng 100000)))))
+
+(defun fzf-native-differential--term-for-candidate
+    (kind candidate needle &optional query-needle)
+  "Return a KIND term that matches CANDIDATE.
+
+For fuzzy and exact terms, derive text from QUERY-NEEDLE or NEEDLE."
+  (let ((source (or query-needle needle)))
+    (make-fzf-native-differential-term
+     :kind kind
+     :inverse nil
+     :literal
+     (pcase kind
+       ('fuzzy (fzf-native-differential--subsequence source))
+       ('exact source)
+       ('prefix (fzf-native-differential--prefix candidate))
+       ('suffix (fzf-native-differential--suffix candidate))
+       ('equal candidate)
+       ('boundary-exact source)
+       (_ (error "Unsupported generated term kind: %S" kind))))))
+
+(defun fzf-native-differential--inverse-for-candidate (rng candidate)
+  "Use RNG to return an inverse shared-syntax term that accepts CANDIDATE."
+  (make-fzf-native-differential-term
+   :kind (fzf-native-differential--pick
+          rng fzf-native-differential--common-kinds)
+   :inverse t
+   :literal (fzf-native-differential--absent rng candidate)))
+
+(defun fzf-native-differential--miss-for-candidate (rng candidate)
+  "Use RNG to return a positive exact term that rejects CANDIDATE."
+  (make-fzf-native-differential-term
+   :kind 'exact :inverse nil
+   :literal (fzf-native-differential--absent rng candidate)))
+
+(defun fzf-native-differential--repeat-unit (unit count)
+  "Return UNIT repeated COUNT times."
+  (apply #'concat (make-list (max 0 count) unit)))
+
+(defun fzf-native-differential--fit-length (unit target)
+  "Repeat and truncate UNIT to exactly TARGET characters."
+  (let* ((unit-length (max 1 (length unit)))
+         (copies (/ (+ target unit-length -1) unit-length)))
+    (substring (fzf-native-differential--repeat-unit unit copies) 0 target)))
+
+(defun fzf-native-differential--length-target (profile serial)
+  "Return the query-length target for PROFILE and SERIAL."
+  (if (eq profile 'long)
+      (aref [999 1000 1001] (% serial 3))
+    (aref [1 2 7 31 32 63 64] (% serial 7))))
+
+(defun fzf-native-differential--text-plan (rng profile serial case-mode)
+  "Return a text-generation plan for RNG, PROFILE, SERIAL, and CASE-MODE."
+  (let* ((variant
+          (fzf-native-differential--pick
+           rng [ascii unicode unicode casefold malformed]))
+         ;; A case-fold pair cannot be the guaranteed matching candidate in
+         ;; respect-case mode.  Keep that draw as ordinary Unicode instead.
+         (casefold (and (eq variant 'casefold)
+                        (not (eq case-mode 'respect))))
+         (text-class
+          (cond (casefold 'unicode)
+                ((eq variant 'casefold) 'unicode)
+                (t variant)))
+         (target (fzf-native-differential--length-target profile serial))
+         (pair (and casefold
+                    (fzf-native-differential--pick
+                     rng fzf-native-differential--case-pairs)))
+         (query-unit
+          (cond
+           (pair (aref pair 0))
+           ((eq text-class 'unicode)
+            (fzf-native-differential--pick
+             rng fzf-native-differential--unicode-atoms))
+           ((eq text-class 'malformed)
+            (fzf-native-differential--pick
+             rng fzf-native-differential--malformed-atoms))
+           (t
+            (fzf-native-differential--pick
+             rng fzf-native-differential--ascii-atoms))))
+         (candidate-unit (if pair (aref pair 1) query-unit))
+         (query-needle
+          (fzf-native-differential--fit-length query-unit target))
+         (candidate-needle
+          (fzf-native-differential--fit-length candidate-unit target)))
+    (list :class text-class
+          :casefold casefold
+          :target target
+          :query-needle query-needle
+          :candidate-needle candidate-needle)))
+
+(defun fzf-native-differential--anchor-text
+    (rng id needle primary-kind rank-shape)
+  "Use RNG to give ID to a NEEDLE candidate.
+
+PRIMARY-KIND and RANK-SHAPE control its layout."
+  (let ((identity (fzf-native-differential--identity id))
+        (separator (fzf-native-differential--pick
+                    rng fzf-native-differential--separators)))
+    (pcase primary-kind
+      ('prefix (concat needle separator "tail" separator identity))
+      ('suffix (concat identity separator "head" separator needle))
+      ('equal (concat needle separator identity))
+      ('boundary-exact (concat identity "/" needle "/tail"))
+      (_
+       (pcase rank-shape
+         ('front (concat needle separator "tail" separator identity))
+         ('middle (concat "head" separator needle separator identity))
+         ('tail (concat identity separator "head" separator needle))
+         ('ambiguous
+          (concat needle separator "head" separator needle separator identity))
+         (_ (concat "head" separator needle separator identity)))))))
+
+(defun fzf-native-differential--query-shape (rng profile)
+  "Use RNG to return the structured-query shape for PROFILE."
+  (if (eq profile 'long)
+      'single
+    (fzf-native-differential--pick
+     rng [empty single and or inverse mixed])))
+
+(defun fzf-native-differential--primary-kind (rng profile)
+  "Use RNG to return the primary term kind for PROFILE."
+  (cond
+   ((eq profile 'long) 'fuzzy)
+   ((and (eq profile 'parity)
+         (zerop (fzf-native-differential-random rng 11)))
+    'boundary-exact)
+   (t (fzf-native-differential--pick
+       rng fzf-native-differential--common-kinds))))
+
+(defun fzf-native-differential--secondary-kind (rng)
+  "Return one shared term kind using RNG."
+  (fzf-native-differential--pick rng fzf-native-differential--common-kinds))
+
+(defun fzf-native-differential--build-sets
+    (rng shape primary anchor needle)
+  "Use RNG to build a term-set list that accepts ANCHOR.
+
+SHAPE selects the grammar.  PRIMARY and NEEDLE supply matching text."
+  (let ((miss (fzf-native-differential--miss-for-candidate rng anchor))
+        (second
+         (fzf-native-differential--term-for-candidate
+          (fzf-native-differential--secondary-kind rng)
+          anchor needle)))
+    (pcase shape
+      ('empty nil)
+      ('single (list (list primary)))
+      ('and (list (list primary) (list second)))
+      ('or (list (list primary miss)))
+      ('inverse
+       (list (list primary)
+             (list (fzf-native-differential--inverse-for-candidate
+                    rng anchor))))
+      ('mixed
+       (list (list primary miss)
+             (list second)
+             (list (fzf-native-differential--inverse-for-candidate
+                    rng anchor))))
+      (_ (error "Unsupported query shape: %S" shape)))))
+
+(defun fzf-native-differential--identified-text (id body)
+  "Add stable identity ID after BODY."
+  (concat body "/" (fzf-native-differential--identity id)))
+
+(defun fzf-native-differential--rank-candidates
+    (primary-kind candidate-needle query-needle)
+  "Return ranking variants for PRIMARY-KIND.
+
+CANDIDATE-NEEDLE and QUERY-NEEDLE supply equivalent match text."
+  (let ((needle candidate-needle)
+        (query query-needle))
+    (pcase primary-kind
+      ((or 'fuzzy 'exact)
+       (list
+        (list 'short (concat needle "/" (fzf-native-differential--identity 1)))
+        (list 'middle (fzf-native-differential--identified-text
+                       2 (concat "head/" needle)))
+        (list 'long (fzf-native-differential--identified-text
+                     3 (concat "long/prefix/" needle "/long/tail")))
+        (list 'ambiguous (fzf-native-differential--identified-text
+                          4 (concat needle "/x/" needle)))))
+      ('prefix
+       (list
+        (list 'short (fzf-native-differential--identified-text 1 query))
+        (list 'long
+              (fzf-native-differential--identified-text
+               2 (concat query "/long/tail")))))
+      ('suffix
+       (list
+        (list 'short
+              (concat (fzf-native-differential--identity 1) "/" query))
+        (list 'long
+              (concat (fzf-native-differential--identity 2)
+                      "/long/prefix/" query))))
+      (_ nil))))
+
+(defun fzf-native-differential--negative-text (id needle)
+  "Return a near miss for NEEDLE with identity ID."
+  (let* ((characters (string-to-list needle))
+         (replacement (if characters
+                          (apply (if (multibyte-string-p needle)
+                                     #'string
+                                   #'unibyte-string)
+                                 (cdr characters))
+                        "qzx")))
+    (fzf-native-differential--identified-text
+     id (concat "miss/" (if (string-empty-p replacement) "qzx" replacement)))))
+
+(defun fzf-native-differential--random-candidate (rng id text-class)
+  "Use RNG to return candidate ID from TEXT-CLASS."
+  (let ((count (1+ (fzf-native-differential-random rng 5))) pieces)
+    (dotimes (_ count)
+      (push
+       (cond
+        ((and (eq text-class 'unicode)
+              (zerop (fzf-native-differential-random rng 3)))
+         (fzf-native-differential--pick
+          rng fzf-native-differential--unicode-atoms))
+        ((and (eq text-class 'malformed)
+              (zerop (fzf-native-differential-random rng 2)))
+         (fzf-native-differential--pick
+          rng fzf-native-differential--malformed-atoms))
+        (t
+         (fzf-native-differential--pick
+          rng fzf-native-differential--ascii-atoms)))
+       pieces)
+      (push (fzf-native-differential--pick
+             rng fzf-native-differential--separators)
+            pieces))
+    (fzf-native-differential--identified-text
+     id (apply #'concat (nreverse pieces)))))
+
+(defun fzf-native-differential--candidates
+    (rng anchor primary-kind candidate-needle query-needle text-class)
+  "Use RNG to return identified candidates around ANCHOR.
+
+PRIMARY-KIND, CANDIDATE-NEEDLE, QUERY-NEEDLE, and TEXT-CLASS select variants."
+  (let ((candidates
+         (list (make-fzf-native-differential-candidate
+                :id 0 :text anchor :role 'anchor)))
+        (next-id 1))
+    (dolist (variant
+             (fzf-native-differential--rank-candidates
+              primary-kind candidate-needle query-needle))
+      (push (make-fzf-native-differential-candidate
+             :id next-id :text (cadr variant) :role (car variant))
+            candidates)
+      (setq next-id (1+ next-id)))
+    ;; Preserve duplicate occurrences as distinct candidates.  The oracle
+    ;; harness assigns output occurrences to these IDs in producer order.
+    (push (make-fzf-native-differential-candidate
+           :id next-id :text (copy-sequence anchor) :role 'duplicate)
+          candidates)
+    (setq next-id (1+ next-id))
+    (push (make-fzf-native-differential-candidate
+           :id next-id
+           :text (fzf-native-differential--negative-text
+                  next-id candidate-needle)
+           :role 'near-miss)
+          candidates)
+    (setq next-id (1+ next-id))
+    (dotimes (_ (+ 3 (fzf-native-differential-random rng 6)))
+      (push (make-fzf-native-differential-candidate
+             :id next-id
+             :text (fzf-native-differential--random-candidate
+                    rng next-id text-class)
+             :role 'random)
+            candidates)
+      (setq next-id (1+ next-id)))
+    (nreverse candidates)))
+
+(defun fzf-native-differential-generate-case (rng seed serial profile)
+  "Generate one deterministic differential case.
+
+RNG supplies choices, SEED and SERIAL identify the replay, and PROFILE is one
+of `common', `parity', or `long'."
+  (unless (memq profile '(common parity long))
+    (error "Unknown differential profile: %S" profile))
+  (let* ((case-mode
+          (if (eq profile 'long)
+              'smart
+            (fzf-native-differential--pick rng [smart ignore respect])))
+         (fuzzy
+          (if (eq profile 'long)
+              t
+            (not (zerop (fzf-native-differential-random rng 2)))))
+         (shape (fzf-native-differential--query-shape rng profile))
+         (primary-kind
+          (fzf-native-differential--primary-kind rng profile))
+         (rank-shape
+          (fzf-native-differential--pick rng [front middle tail ambiguous]))
+         (text-plan
+          (fzf-native-differential--text-plan
+           rng profile serial case-mode))
+         (text-class (plist-get text-plan :class))
+         (casefold (plist-get text-plan :casefold))
+         (query-needle (plist-get text-plan :query-needle))
+         (candidate-needle (plist-get text-plan :candidate-needle))
+         (anchor
+          (fzf-native-differential--anchor-text
+           rng 0 candidate-needle primary-kind rank-shape))
+         (primary
+          (if (eq profile 'long)
+              (make-fzf-native-differential-term
+               :kind 'fuzzy :inverse nil :literal query-needle)
+            (fzf-native-differential--term-for-candidate
+             primary-kind anchor candidate-needle query-needle)))
+         (sets
+          (fzf-native-differential--build-sets
+           rng shape primary anchor candidate-needle))
+         (query
+          (make-fzf-native-differential-query
+           :sets sets :case-mode case-mode :fuzzy fuzzy
+           :normalize nil :forward t))
+         (rendered-query (fzf-native-differential-render-query query))
+         (comparison
+          (if (and (eq profile 'parity)
+                   (not (eq primary-kind 'boundary-exact))
+                   (zerop (% serial 3)))
+              'ranking
+            'membership))
+         (candidates
+          (fzf-native-differential--candidates
+           rng anchor primary-kind candidate-needle query-needle text-class)))
+    (make-fzf-native-differential-case
+     :seed seed
+     :serial serial
+     :profile profile
+     :query query
+     :rendered-query rendered-query
+     :candidates candidates
+     :dimensions
+     (list :text-class text-class
+           :unicode-casefold casefold
+           :needle-length (plist-get text-plan :target)
+           :query-length (length rendered-query)
+           :anchor-length (length anchor)
+           :query-shape shape
+           :primary-kind primary-kind
+           :rank-shape rank-shape
+           :valid-utf8 (not (eq text-class 'malformed)))
+     :comparison comparison)))
+
+(defun fzf-native-differential-case-description (case)
+  "Return a compact replay description for CASE."
+  (format
+   "seed=%d serial=%d profile=%S comparison=%S dimensions=%S query=%S candidates=%S"
+   (fzf-native-differential-case-seed case)
+   (fzf-native-differential-case-serial case)
+   (fzf-native-differential-case-profile case)
+   (fzf-native-differential-case-comparison case)
+   (fzf-native-differential-case-dimensions case)
+   (fzf-native-differential-case-rendered-query case)
+   (mapcar
+    (lambda (candidate)
+      (list (fzf-native-differential-candidate-id candidate)
+            (fzf-native-differential-candidate-role candidate)
+            (fzf-native-differential-candidate-text candidate)))
+    (fzf-native-differential-case-candidates case))))
+
+(provide 'fzf-native-differential-generator)
+;;; fzf-native-differential-generator.el ends here

--- a/fuzz/fuzz.mk
+++ b/fuzz/fuzz.mk
@@ -9,40 +9,108 @@ FUZZ_EMACS ?= $(or $(strip $(EMACS)),\
 	$(firstword $(wildcard $(HOME)/emacs/nextstep/Emacs.app/Contents/MacOS/Emacs \
 		/Applications/Emacs.app/Contents/MacOS/Emacs)))
 FUZZ_SECONDS ?= 30
+FZF_NATIVE_FUZZ_SEED ?= 12648430
+FZF_NATIVE_FUZZ_ABI_CASES ?= 200
+FZF_NATIVE_FUZZ_SESSION_CASES ?= 100
 FUZZ_MAX_LEN ?= 4096
 FUZZ_VERBOSITY ?= 0
 FUZZ_RSS_LIMIT_MB ?= 2048
 FUZZ_SEED_DIR ?= fuzz/corpus
 FUZZ_DICTIONARY ?= fuzz/fzf-native.dict
 FUZZ_CORPUS_DIR ?= $(BUILD_DIR)/fuzz-corpus
+FUZZ_MERGED_CORPUS_DIR ?= $(BUILD_DIR)/fuzz-corpus-merged
 FUZZ_ARTIFACT_DIR ?= $(BUILD_DIR)/fuzz-artifacts
 FUZZ_BINARY := $(BUILD_DIR)/fzf-native-fuzz
 FUZZ_REPLAY_BINARY := $(BUILD_DIR)/fzf-native-fuzz-replay
 FUZZ_SESSION_SECONDS ?= $(FUZZ_SECONDS)
+FUZZ_SESSION_READER_SECONDS ?= $(FUZZ_SESSION_SECONDS)
 FUZZ_SESSION_MAX_LEN ?= 8192
 FUZZ_SESSION_SEED_DIR ?= fuzz/session-corpus
+FUZZ_SESSION_READER_SEED_DIR ?= $(FUZZ_SESSION_SEED_DIR)
 FUZZ_SESSION_CORPUS_DIR ?= $(BUILD_DIR)/fuzz-session-corpus
+FUZZ_SESSION_READER_CORPUS_DIR ?= $(BUILD_DIR)/fuzz-session-reader-corpus
+FUZZ_SESSION_MERGED_CORPUS_DIR ?= $(BUILD_DIR)/fuzz-session-corpus-merged
+FUZZ_SESSION_READER_MERGED_CORPUS_DIR ?= $(BUILD_DIR)/fuzz-session-reader-corpus-merged
 FUZZ_SESSION_ARTIFACT_DIR ?= $(BUILD_DIR)/fuzz-session-artifacts
+FUZZ_SESSION_READER_ARTIFACT_DIR ?= $(FUZZ_SESSION_ARTIFACT_DIR)/reader
 FUZZ_SESSION_BINARY := $(BUILD_DIR)/fzf-native-session-fuzz
+FUZZ_SESSION_READER_BINARY := $(BUILD_DIR)/fzf-native-session-reader-fuzz
 FUZZ_SESSION_REPLAY_BINARY := $(BUILD_DIR)/fzf-native-session-fuzz-replay
+FUZZ_SESSION_READER_REPLAY_BINARY := $(BUILD_DIR)/fzf-native-session-reader-fuzz-replay
 FUZZ_SESSION_TSAN_BINARY := $(BUILD_DIR)/fzf-native-session-fuzz-tsan
+FUZZ_SESSION_READER_TSAN_BINARY := $(BUILD_DIR)/fzf-native-session-reader-fuzz-tsan
 FUZZ_MODULE_DIR := $(BUILD_DIR)/fuzz-module
 FUZZ_MODULE := $(abspath $(FUZZ_MODULE_DIR)/fzf-native-module.so)
 FZF_REFERENCE ?= fzf
 FZF_REFERENCE_VERSION ?=
+FZF_SOURCE ?=
+FZF_NATIVE_UPSTREAM_CASES ?= 200
+FZF_NATIVE_UPSTREAM_START ?= 0
+FZF_NATIVE_UPSTREAM_PROFILE ?= common
+FZF_NATIVE_REVISION ?= $(shell git rev-parse --verify HEAD 2>/dev/null)$(shell \
+	test -z "$$(git status --porcelain --untracked-files=all 2>/dev/null)" || \
+	printf '%s' '-dirty')
+FUZZ_ALGO_DRIVER := $(BUILD_DIR)/fzf-native-algo-driver
+FUZZ_ALGO_DRIVER_SAN := $(BUILD_DIR)/fzf-native-algo-driver-san
+FUZZ_RAW_ORACLE := $(BUILD_DIR)/fzf-raw-oracle
+FUZZ_GO_CACHE := $(abspath $(BUILD_DIR)/go-cache)
 
 # The baseline matcher has no external runtime.  The stacked UTF-8 matcher
 # vendors utf8proc, so discover and link that source when it is present.  This
 # keeps the fuzz-infrastructure commit independently buildable while making
 # the exact PR40+PR41 composition build without branch-specific Makefile edits.
-FUZZ_UTF8PROC_SOURCE := $(firstword $(wildcard utf8proc-*/utf8proc.c))
+FUZZ_UTF8PROC_SOURCE := $(firstword $(wildcard $(UTF8PROC_SRC)))
 FUZZ_UTF8PROC_FLAGS := $(if $(FUZZ_UTF8PROC_SOURCE),-DUTF8PROC_STATIC,)
+
+# The raw differential lane uses two persistent peers with one framed binary
+# protocol.  FZF_SOURCE must point at the pinned source revision documented in
+# fuzz/oracle/README.org.  The oracle build script rejects any other revision.
+.PHONY: fuzz-algo-driver-build fuzz-algo-driver-san-build
+fuzz-algo-driver-build:
+	mkdir -p $(BUILD_DIR)
+	$(FUZZ_CC) -std=gnu11 -Wall -Wextra -O2 -g -I. \
+		$(FUZZ_UTF8PROC_FLAGS) \
+		-DFZF_NATIVE_REVISION=\"$(FZF_NATIVE_REVISION)\" \
+		-o $(FUZZ_ALGO_DRIVER) fuzz/fzf-native-algo-driver.c fzf.c \
+		$(FUZZ_UTF8PROC_SOURCE)
+
+fuzz-algo-driver-san-build:
+	mkdir -p $(BUILD_DIR)
+	$(FUZZ_CC) -std=gnu11 -Wall -Wextra -O1 -g -I. \
+		-fsanitize=address,undefined -fno-sanitize-recover=undefined \
+		-fno-omit-frame-pointer \
+		$(FUZZ_UTF8PROC_FLAGS) \
+		-DFZF_NATIVE_REVISION=\"$(FZF_NATIVE_REVISION)\" \
+		-o $(FUZZ_ALGO_DRIVER_SAN) fuzz/fzf-native-algo-driver.c fzf.c \
+		$(FUZZ_UTF8PROC_SOURCE)
+
+.PHONY: fuzz-oracle-build fuzz-oracle-test fuzz-oracle-test-san
+fuzz-oracle-build:
+	test -n "$(FZF_SOURCE)"
+	mkdir -p $(FUZZ_GO_CACHE)
+	GOCACHE=$(FUZZ_GO_CACHE) ./fuzz/oracle/build.sh \
+		"$(FZF_SOURCE)" "$(abspath $(FUZZ_RAW_ORACLE))"
+
+fuzz-oracle-test: fuzz-algo-driver-build fuzz-oracle-build
+	GOCACHE=$(FUZZ_GO_CACHE) \
+		FZF_NATIVE_ALGO_DRIVER=$(abspath $(FUZZ_ALGO_DRIVER)) \
+		FZF_RAW_ORACLE_BINARY=$(abspath $(FUZZ_RAW_ORACLE)) \
+		FZF_NATIVE_EXPECTED_REVISION="$(FZF_NATIVE_REVISION)" \
+		./fuzz/oracle/test.sh "$(FZF_SOURCE)"
+
+fuzz-oracle-test-san: fuzz-algo-driver-san-build fuzz-oracle-build
+	GOCACHE=$(FUZZ_GO_CACHE) \
+		FZF_NATIVE_ALGO_DRIVER=$(abspath $(FUZZ_ALGO_DRIVER_SAN)) \
+		FZF_RAW_ORACLE_BINARY=$(abspath $(FUZZ_RAW_ORACLE)) \
+		FZF_NATIVE_EXPECTED_REVISION="$(FZF_NATIVE_REVISION)" \
+		./fuzz/oracle/test.sh "$(FZF_SOURCE)"
 
 .PHONY: fuzz-build
 fuzz-build:
 	mkdir -p $(BUILD_DIR)
 	$(FUZZ_CC) -std=gnu11 -Wall -Wextra -O1 -g \
-		-fsanitize=fuzzer,address,undefined -fno-omit-frame-pointer \
+		-fsanitize=fuzzer,address,undefined -fno-sanitize-recover=undefined \
+		-fno-omit-frame-pointer \
 		-I. $(FUZZ_UTF8PROC_FLAGS) -o $(FUZZ_BINARY) \
 		fuzz/fzf-native-fuzz.c fzf.c fzf-additions.c \
 		$(FUZZ_UTF8PROC_SOURCE)
@@ -64,6 +132,7 @@ fuzz-replay-build:
 	mkdir -p $(BUILD_DIR)
 	$(FUZZ_CC) -std=gnu11 -Wall -Wextra -O1 -g \
 		-DFZF_FUZZ_STANDALONE -fsanitize=address,undefined \
+		-fno-sanitize-recover=undefined \
 		-fno-omit-frame-pointer -I. $(FUZZ_UTF8PROC_FLAGS) \
 		-o $(FUZZ_REPLAY_BINARY) fuzz/fzf-native-fuzz.c fzf.c \
 		fzf-additions.c $(FUZZ_UTF8PROC_SOURCE)
@@ -74,19 +143,37 @@ fuzz-replay: fuzz-matcher-replay fuzz-session-replay
 fuzz-matcher-replay: fuzz-replay-build
 	$(FUZZ_REPLAY_BINARY) $(FUZZ_SEED_DIR)/*
 
-# This target includes the real AsyncSession core.  Its bytecode reaches the
-# reader, scorer, worker pool, caches, request publication, and teardown.
-.PHONY: fuzz-session-build
-fuzz-session-build:
+# Both targets include the real AsyncSession core.  The state bytecode reaches
+# the scorer, worker pool, caches, request publication, and teardown at high
+# throughput.  The separate reader target covers blocking producer I/O without
+# making every state-machine input wait for a pipe reader.
+.PHONY: fuzz-session-build fuzz-session-state-build fuzz-session-reader-build
+fuzz-session-build: fuzz-session-state-build fuzz-session-reader-build
+
+fuzz-session-state-build:
 	mkdir -p $(BUILD_DIR)
 	$(FUZZ_CC) -std=gnu11 -Wall -Wextra -O1 -g \
-		-fsanitize=fuzzer,address,undefined -fno-omit-frame-pointer \
+		-fsanitize=fuzzer,address,undefined -fno-sanitize-recover=undefined \
+		-fno-omit-frame-pointer \
+		-DFZF_SESSION_FUZZ_MODE=FZF_SESSION_FUZZ_MODE_STATE \
 		-I. $(FUZZ_UTF8PROC_FLAGS) -pthread \
 		-o $(FUZZ_SESSION_BINARY) fuzz/fzf-native-session-fuzz.c fzf.c \
 		fzf-additions.c $(FUZZ_UTF8PROC_SOURCE)
 
-.PHONY: fuzz-session
-fuzz-session: fuzz-session-build
+fuzz-session-reader-build:
+	mkdir -p $(BUILD_DIR)
+	$(FUZZ_CC) -std=gnu11 -Wall -Wextra -O1 -g \
+		-fsanitize=fuzzer,address,undefined -fno-sanitize-recover=undefined \
+		-fno-omit-frame-pointer \
+		-DFZF_SESSION_FUZZ_MODE=FZF_SESSION_FUZZ_MODE_READER \
+		-I. $(FUZZ_UTF8PROC_FLAGS) -pthread \
+		-o $(FUZZ_SESSION_READER_BINARY) fuzz/fzf-native-session-fuzz.c \
+		fzf.c fzf-additions.c $(FUZZ_UTF8PROC_SOURCE)
+
+.PHONY: fuzz-session fuzz-session-state fuzz-session-reader
+fuzz-session: fuzz-session-state fuzz-session-reader
+
+fuzz-session-state: fuzz-session-state-build
 	mkdir -p $(FUZZ_SESSION_CORPUS_DIR) $(FUZZ_SESSION_ARTIFACT_DIR)
 	cp $(FUZZ_SESSION_SEED_DIR)/* $(FUZZ_SESSION_CORPUS_DIR)/
 	$(FUZZ_SESSION_BINARY) $(FUZZ_SESSION_CORPUS_DIR) \
@@ -96,33 +183,127 @@ fuzz-session: fuzz-session-build
 		-rss_limit_mb=$(FUZZ_RSS_LIMIT_MB) \
 		-max_total_time=$(FUZZ_SESSION_SECONDS) -print_final_stats=1
 
-.PHONY: fuzz-session-replay-build
-fuzz-session-replay-build:
+fuzz-session-reader: fuzz-session-reader-build
+	mkdir -p $(FUZZ_SESSION_READER_CORPUS_DIR) \
+		$(FUZZ_SESSION_READER_ARTIFACT_DIR)
+	cp $(FUZZ_SESSION_READER_SEED_DIR)/* $(FUZZ_SESSION_READER_CORPUS_DIR)/
+	$(FUZZ_SESSION_READER_BINARY) $(FUZZ_SESSION_READER_CORPUS_DIR) \
+		-max_len=$(FUZZ_SESSION_MAX_LEN) -dict=$(FUZZ_DICTIONARY) \
+		-verbosity=$(FUZZ_VERBOSITY) \
+		-artifact_prefix=$(FUZZ_SESSION_READER_ARTIFACT_DIR)/ \
+		-rss_limit_mb=$(FUZZ_RSS_LIMIT_MB) \
+		-max_total_time=$(FUZZ_SESSION_READER_SECONDS) -print_final_stats=1
+
+# Keep only inputs that add coverage for each independently instrumented
+# target.  The learned corpus directories remain stable for CI caching.
+.PHONY: fuzz-merge fuzz-matcher-merge fuzz-session-merge \
+	fuzz-session-state-merge fuzz-session-reader-merge
+fuzz-merge: fuzz-matcher-merge fuzz-session-merge
+
+fuzz-matcher-merge: fuzz-build
+	rm -rf $(FUZZ_MERGED_CORPUS_DIR)
+	mkdir -p $(FUZZ_MERGED_CORPUS_DIR) $(FUZZ_CORPUS_DIR)
+	$(FUZZ_BINARY) -merge=1 $(FUZZ_MERGED_CORPUS_DIR) \
+		$(FUZZ_SEED_DIR) $(FUZZ_CORPUS_DIR) \
+		-rss_limit_mb=$(FUZZ_RSS_LIMIT_MB) -verbosity=$(FUZZ_VERBOSITY)
+	rm -rf $(FUZZ_CORPUS_DIR)
+	mv $(FUZZ_MERGED_CORPUS_DIR) $(FUZZ_CORPUS_DIR)
+
+fuzz-session-merge: fuzz-session-state-merge fuzz-session-reader-merge
+
+fuzz-session-state-merge: fuzz-session-state-build
+	rm -rf $(FUZZ_SESSION_MERGED_CORPUS_DIR)
+	mkdir -p $(FUZZ_SESSION_MERGED_CORPUS_DIR) $(FUZZ_SESSION_CORPUS_DIR)
+	$(FUZZ_SESSION_BINARY) -merge=1 $(FUZZ_SESSION_MERGED_CORPUS_DIR) \
+		$(FUZZ_SESSION_SEED_DIR) $(FUZZ_SESSION_CORPUS_DIR) \
+		-rss_limit_mb=$(FUZZ_RSS_LIMIT_MB) -verbosity=$(FUZZ_VERBOSITY)
+	rm -rf $(FUZZ_SESSION_CORPUS_DIR)
+	mv $(FUZZ_SESSION_MERGED_CORPUS_DIR) $(FUZZ_SESSION_CORPUS_DIR)
+
+fuzz-session-reader-merge: fuzz-session-reader-build
+	rm -rf $(FUZZ_SESSION_READER_MERGED_CORPUS_DIR)
+	mkdir -p $(FUZZ_SESSION_READER_MERGED_CORPUS_DIR) \
+		$(FUZZ_SESSION_READER_CORPUS_DIR)
+	$(FUZZ_SESSION_READER_BINARY) -merge=1 \
+		$(FUZZ_SESSION_READER_MERGED_CORPUS_DIR) \
+		$(FUZZ_SESSION_READER_SEED_DIR) $(FUZZ_SESSION_READER_CORPUS_DIR) \
+		-rss_limit_mb=$(FUZZ_RSS_LIMIT_MB) -verbosity=$(FUZZ_VERBOSITY)
+	rm -rf $(FUZZ_SESSION_READER_CORPUS_DIR)
+	mv $(FUZZ_SESSION_READER_MERGED_CORPUS_DIR) \
+		$(FUZZ_SESSION_READER_CORPUS_DIR)
+
+.PHONY: fuzz-session-replay-build fuzz-session-state-replay-build \
+	fuzz-session-reader-replay-build
+fuzz-session-replay-build: fuzz-session-state-replay-build \
+	fuzz-session-reader-replay-build
+
+fuzz-session-state-replay-build:
 	mkdir -p $(BUILD_DIR)
 	$(FUZZ_CC) -std=gnu11 -Wall -Wextra -O1 -g \
-		-DFZF_SESSION_FUZZ_STANDALONE=1 -fsanitize=address,undefined \
+		-DFZF_SESSION_FUZZ_STANDALONE=1 \
+		-DFZF_SESSION_FUZZ_MODE=FZF_SESSION_FUZZ_MODE_STATE \
+		-fsanitize=address,undefined -fno-sanitize-recover=undefined \
 		-fno-omit-frame-pointer -I. $(FUZZ_UTF8PROC_FLAGS) -pthread \
 		-o $(FUZZ_SESSION_REPLAY_BINARY) fuzz/fzf-native-session-fuzz.c \
 		fzf.c fzf-additions.c $(FUZZ_UTF8PROC_SOURCE)
 
-.PHONY: fuzz-session-replay
-fuzz-session-replay: fuzz-session-replay-build
+fuzz-session-reader-replay-build:
+	mkdir -p $(BUILD_DIR)
+	$(FUZZ_CC) -std=gnu11 -Wall -Wextra -O1 -g \
+		-DFZF_SESSION_FUZZ_STANDALONE=1 \
+		-DFZF_SESSION_FUZZ_MODE=FZF_SESSION_FUZZ_MODE_READER \
+		-fsanitize=address,undefined -fno-sanitize-recover=undefined \
+		-fno-omit-frame-pointer -I. $(FUZZ_UTF8PROC_FLAGS) -pthread \
+		-o $(FUZZ_SESSION_READER_REPLAY_BINARY) \
+		fuzz/fzf-native-session-fuzz.c fzf.c fzf-additions.c \
+		$(FUZZ_UTF8PROC_SOURCE)
+
+.PHONY: fuzz-session-replay fuzz-session-state-replay \
+	fuzz-session-reader-replay
+fuzz-session-replay: fuzz-session-state-replay fuzz-session-reader-replay
+
+fuzz-session-state-replay: fuzz-session-state-replay-build
 	$(FUZZ_SESSION_REPLAY_BINARY) $(FUZZ_SESSION_SEED_DIR)/*
 
-.PHONY: fuzz-session-tsan-build
-fuzz-session-tsan-build:
+fuzz-session-reader-replay: fuzz-session-reader-replay-build
+	$(FUZZ_SESSION_READER_REPLAY_BINARY) $(FUZZ_SESSION_READER_SEED_DIR)/*
+
+.PHONY: fuzz-session-tsan-build fuzz-session-state-tsan-build \
+	fuzz-session-reader-tsan-build
+fuzz-session-tsan-build: fuzz-session-state-tsan-build \
+	fuzz-session-reader-tsan-build
+
+fuzz-session-state-tsan-build:
 	mkdir -p $(BUILD_DIR)
 	$(FUZZ_CC) -std=gnu11 -Wall -Wextra -O1 -g \
 		-DFZF_SESSION_FUZZ_STANDALONE=1 -DFZF_NATIVE_DEBUG=1 \
+		-DFZF_SESSION_FUZZ_MODE=FZF_SESSION_FUZZ_MODE_STATE \
 		-fsanitize=thread \
 		-fno-omit-frame-pointer -I. $(FUZZ_UTF8PROC_FLAGS) -pthread \
 		-o $(FUZZ_SESSION_TSAN_BINARY) fuzz/fzf-native-session-fuzz.c \
 		fzf.c fzf-additions.c $(FUZZ_UTF8PROC_SOURCE)
 
-.PHONY: fuzz-session-tsan
-fuzz-session-tsan: fuzz-session-tsan-build
+fuzz-session-reader-tsan-build:
+	mkdir -p $(BUILD_DIR)
+	$(FUZZ_CC) -std=gnu11 -Wall -Wextra -O1 -g \
+		-DFZF_SESSION_FUZZ_STANDALONE=1 -DFZF_NATIVE_DEBUG=1 \
+		-DFZF_SESSION_FUZZ_MODE=FZF_SESSION_FUZZ_MODE_READER \
+		-fsanitize=thread \
+		-fno-omit-frame-pointer -I. $(FUZZ_UTF8PROC_FLAGS) -pthread \
+		-o $(FUZZ_SESSION_READER_TSAN_BINARY) \
+		fuzz/fzf-native-session-fuzz.c fzf.c fzf-additions.c \
+		$(FUZZ_UTF8PROC_SOURCE)
+
+.PHONY: fuzz-session-tsan fuzz-session-state-tsan fuzz-session-reader-tsan
+fuzz-session-tsan: fuzz-session-state-tsan fuzz-session-reader-tsan
+
+fuzz-session-state-tsan: fuzz-session-state-tsan-build
 	TSAN_OPTIONS=halt_on_error=1:history_size=7 \
 		$(FUZZ_SESSION_TSAN_BINARY) $(FUZZ_SESSION_SEED_DIR)/*
+
+fuzz-session-reader-tsan: fuzz-session-reader-tsan-build
+	TSAN_OPTIONS=halt_on_error=1:history_size=7 \
+		$(FUZZ_SESSION_READER_TSAN_BINARY) $(FUZZ_SESSION_READER_SEED_DIR)/*
 
 .PHONY: fuzz-module
 fuzz-module:
@@ -133,7 +314,12 @@ fuzz-module:
 .PHONY: fuzz-elisp
 fuzz-elisp: fuzz-module
 	FZF_NATIVE_TEST_MODULE=$(FUZZ_MODULE) \
-		$(FUZZ_EMACS) -Q --batch -L . -l ./fuzz/fzf-native-fuzz-test.el \
+		FZF_NATIVE_FUZZ_SEED=$(FZF_NATIVE_FUZZ_SEED) \
+		FZF_NATIVE_FUZZ_ABI_CASES=$(FZF_NATIVE_FUZZ_ABI_CASES) \
+		FZF_NATIVE_FUZZ_SESSION_CASES=$(FZF_NATIVE_FUZZ_SESSION_CASES) \
+		$(FUZZ_EMACS) -Q --batch -L . \
+		--eval '(setq load-prefer-newer t)' \
+		-l ./fuzz/fzf-native-fuzz-test.el \
 		--eval '(ert-run-tests-batch-and-exit "^fzf-native-fuzz-")'
 
 .PHONY: fuzz-upstream
@@ -141,5 +327,71 @@ fuzz-upstream: fuzz-module
 	command -v $(FZF_REFERENCE)
 	FZF_NATIVE_TEST_MODULE=$(FUZZ_MODULE) FZF_REFERENCE=$(FZF_REFERENCE) \
 		FZF_REFERENCE_VERSION=$(FZF_REFERENCE_VERSION) \
-		$(FUZZ_EMACS) -Q --batch -L . -l ./fuzz/fzf-native-upstream-test.el \
+		FZF_REFERENCE_REVISION=$(FZF_REFERENCE_REVISION) \
+		FZF_NATIVE_FUZZ_SEED=$(FZF_NATIVE_FUZZ_SEED) \
+		FZF_NATIVE_UPSTREAM_CASES=$(FZF_NATIVE_UPSTREAM_CASES) \
+		FZF_NATIVE_UPSTREAM_START=$(FZF_NATIVE_UPSTREAM_START) \
+		FZF_NATIVE_UPSTREAM_PROFILE=$(FZF_NATIVE_UPSTREAM_PROFILE) \
+		$(FUZZ_EMACS) -Q --batch -L . \
+		--eval '(setq load-prefer-newer t)' \
+		-l ./fuzz/fzf-native-upstream-test.el \
 		--eval '(ert-run-tests-batch-and-exit "^fzf-native-fuzz-upstream-")'
+
+# Replay one persistent native session from any seed/serial boundary with:
+# make fuzz-upstream-session FZF_NATIVE_FUZZ_SEED=N \
+#   FZF_NATIVE_UPSTREAM_SESSION_START=N FZF_NATIVE_UPSTREAM_SESSION_CASES=1
+FZF_NATIVE_UPSTREAM_SESSION_CASES ?= 4
+FZF_NATIVE_UPSTREAM_SESSION_START ?= 0
+FZF_REFERENCE_REVISION ?=
+FUZZ_PINNED_FZF_REVISION := 1372d04f79bde0daa3bab4b96a068baafa808e67
+FUZZ_PINNED_FZF := $(BUILD_DIR)/fzf-pinned
+
+.PHONY: fuzz-pinned-fzf-build
+fuzz-pinned-fzf-build:
+	test -n "$(FZF_SOURCE)"
+	mkdir -p $(BUILD_DIR) $(FUZZ_GO_CACHE)
+	GOCACHE=$(FUZZ_GO_CACHE) ./fuzz/differential/build-pinned-fzf.sh \
+		"$(FZF_SOURCE)" "$(abspath $(FUZZ_PINNED_FZF))"
+
+.PHONY: fuzz-upstream-pinned
+fuzz-upstream-pinned: fuzz-module fuzz-pinned-fzf-build
+	FZF_NATIVE_TEST_MODULE=$(FUZZ_MODULE) \
+		FZF_REFERENCE=$(abspath $(FUZZ_PINNED_FZF)) \
+		FZF_REFERENCE_REVISION=$(FUZZ_PINNED_FZF_REVISION) \
+		FZF_NATIVE_FUZZ_SEED=$(FZF_NATIVE_FUZZ_SEED) \
+		FZF_NATIVE_UPSTREAM_CASES=$(FZF_NATIVE_UPSTREAM_CASES) \
+		FZF_NATIVE_UPSTREAM_START=$(FZF_NATIVE_UPSTREAM_START) \
+		FZF_NATIVE_UPSTREAM_PROFILE=$(FZF_NATIVE_UPSTREAM_PROFILE) \
+		FZF_NATIVE_UPSTREAM_SESSION_CASES=$(FZF_NATIVE_UPSTREAM_SESSION_CASES) \
+		FZF_NATIVE_UPSTREAM_SESSION_START=$(FZF_NATIVE_UPSTREAM_SESSION_START) \
+		$(FUZZ_EMACS) -Q --batch -L . \
+		--eval '(setq load-prefer-newer t)' \
+		-l ./fuzz/fzf-native-upstream-test.el \
+		--eval '(ert-run-tests-batch-and-exit "^fzf-native-fuzz-upstream-")'
+
+.PHONY: fuzz-upstream-session
+fuzz-upstream-session: fuzz-module
+	command -v $(FZF_REFERENCE)
+	FZF_NATIVE_TEST_MODULE=$(FUZZ_MODULE) FZF_REFERENCE=$(FZF_REFERENCE) \
+		FZF_REFERENCE_VERSION=$(FZF_REFERENCE_VERSION) \
+		FZF_REFERENCE_REVISION=$(FZF_REFERENCE_REVISION) \
+		FZF_NATIVE_FUZZ_SEED=$(FZF_NATIVE_FUZZ_SEED) \
+		FZF_NATIVE_UPSTREAM_SESSION_CASES=$(FZF_NATIVE_UPSTREAM_SESSION_CASES) \
+		FZF_NATIVE_UPSTREAM_SESSION_START=$(FZF_NATIVE_UPSTREAM_SESSION_START) \
+		$(FUZZ_EMACS) -Q --batch -L . \
+		--eval '(setq load-prefer-newer t)' \
+		-l ./fuzz/fzf-native-upstream-test.el \
+		--eval '(ert-run-tests-batch-and-exit "fzf-native-fuzz-upstream-session-rounds")'
+
+.PHONY: fuzz-upstream-session-pinned
+fuzz-upstream-session-pinned: fuzz-module fuzz-pinned-fzf-build
+	FZF_NATIVE_TEST_MODULE=$(FUZZ_MODULE) \
+		FZF_REFERENCE=$(abspath $(FUZZ_PINNED_FZF)) \
+		FZF_REFERENCE_REVISION=$(FUZZ_PINNED_FZF_REVISION) \
+		FZF_NATIVE_FUZZ_SEED=$(FZF_NATIVE_FUZZ_SEED) \
+		FZF_NATIVE_UPSTREAM_SESSION_CASES=$(FZF_NATIVE_UPSTREAM_SESSION_CASES) \
+		FZF_NATIVE_UPSTREAM_SESSION_START=$(FZF_NATIVE_UPSTREAM_SESSION_START) \
+		$(FUZZ_EMACS) -Q --batch -L . \
+		--eval '(setq load-prefer-newer t)' \
+		-l ./fuzz/fzf-native-upstream-test.el \
+		--eval '(ert-run-tests-batch-and-exit "fzf-native-fuzz-upstream-session-rounds")'

--- a/fuzz/fzf-native-algo-driver.c
+++ b/fuzz/fzf-native-algo-driver.c
@@ -1,0 +1,359 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Persistent raw-algorithm driver for differential tests.
+ *
+ * The wire format is shared with fuzz/oracle.  Frames use network byte order
+ * and preserve arbitrary pattern and candidate bytes.
+ */
+
+#include "fzf.h"
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum {
+  PROTOCOL_VERSION = 1,
+  OPCODE_INFO = 0,
+  OPCODE_MATCH = 1,
+  STATUS_OK = 0,
+  STATUS_BAD_REQUEST = 1,
+  STATUS_UNSUPPORTED = 2,
+  STATUS_INTERNAL = 3,
+  FRAME_CAP = 64 * 1024 * 1024,
+};
+
+#ifndef FZF_NATIVE_REVISION
+#define FZF_NATIVE_REVISION "unknown"
+#endif
+
+static uint32_t read_u32(const uint8_t *bytes) {
+  return ((uint32_t)bytes[0] << 24) | ((uint32_t)bytes[1] << 16) |
+         ((uint32_t)bytes[2] << 8) | (uint32_t)bytes[3];
+}
+
+static void write_u32(uint8_t *bytes, uint32_t value) {
+  bytes[0] = (uint8_t)(value >> 24);
+  bytes[1] = (uint8_t)(value >> 16);
+  bytes[2] = (uint8_t)(value >> 8);
+  bytes[3] = (uint8_t)value;
+}
+
+static void write_i64(uint8_t *bytes, int64_t value) {
+  uint64_t encoded = (uint64_t)value;
+  for (size_t i = 0; i < 8; i++)
+    bytes[i] = (uint8_t)(encoded >> (56 - i * 8));
+}
+
+static bool read_exact(void *buffer, size_t size) {
+  uint8_t *out = buffer;
+  while (size > 0) {
+    size_t got = fread(out, 1, size, stdin);
+    if (got > 0) {
+      out += got;
+      size -= got;
+      continue;
+    }
+    if (feof(stdin)) return false;
+    if (ferror(stdin) && errno == EINTR) {
+      clearerr(stdin);
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+static bool write_exact(const void *buffer, size_t size) {
+  const uint8_t *input = buffer;
+  while (size > 0) {
+    size_t put = fwrite(input, 1, size, stdout);
+    if (put > 0) {
+      input += put;
+      size -= put;
+      continue;
+    }
+    if (ferror(stdout) && errno == EINTR) {
+      clearerr(stdout);
+      continue;
+    }
+    return false;
+  }
+  return fflush(stdout) == 0;
+}
+
+static bool send_frame(const uint8_t *payload, size_t size) {
+  if (size > UINT32_MAX) return false;
+  uint8_t header[4];
+  write_u32(header, (uint32_t)size);
+  return write_exact(header, sizeof header) && write_exact(payload, size);
+}
+
+static bool send_error(uint8_t opcode, uint8_t status, const char *message) {
+  size_t message_len = strlen(message);
+  if (message_len > UINT32_MAX) return false;
+  size_t size = 7 + message_len;
+  uint8_t *payload = malloc(size);
+  if (!payload) return false;
+  payload[0] = PROTOCOL_VERSION;
+  payload[1] = opcode;
+  payload[2] = status;
+  write_u32(payload + 3, (uint32_t)message_len);
+  memcpy(payload + 7, message, message_len);
+  bool ok = send_frame(payload, size);
+  free(payload);
+  return ok;
+}
+
+static bool send_info(void) {
+  const char *revision = FZF_NATIVE_REVISION;
+  const char *compiler = __VERSION__;
+  size_t revision_len = strlen(revision);
+  size_t compiler_len = strlen(compiler);
+  if (revision_len > UINT32_MAX || compiler_len > UINT32_MAX) return false;
+  size_t size = 3 + 4 + revision_len + 4 + compiler_len;
+  uint8_t *payload = malloc(size);
+  if (!payload) return false;
+  size_t offset = 0;
+  payload[offset++] = PROTOCOL_VERSION;
+  payload[offset++] = OPCODE_INFO;
+  payload[offset++] = STATUS_OK;
+  write_u32(payload + offset, (uint32_t)revision_len);
+  offset += 4;
+  memcpy(payload + offset, revision, revision_len);
+  offset += revision_len;
+  write_u32(payload + offset, (uint32_t)compiler_len);
+  offset += 4;
+  memcpy(payload + offset, compiler, compiler_len);
+  bool ok = send_frame(payload, size);
+  free(payload);
+  return ok;
+}
+
+static char *lower_pattern(const uint8_t *input, size_t size,
+                           size_t *output_size) {
+  if (size > (SIZE_MAX - 1) / 4) return NULL;
+  size_t capacity = size * 4 + 1;
+  char *output = malloc(capacity);
+  if (!output) return NULL;
+
+  size_t input_offset = 0;
+  size_t output_offset = 0;
+  while (input_offset < size) {
+    utf8proc_int32_t codepoint;
+    utf8proc_ssize_t width = utf8proc_iterate(
+        input + input_offset, (utf8proc_ssize_t)(size - input_offset),
+        &codepoint);
+    if (width <= 0) {
+      output[output_offset++] = (char)input[input_offset++];
+      continue;
+    }
+    utf8proc_int32_t folded = utf8proc_case_fold(codepoint);
+    utf8proc_ssize_t encoded = utf8proc_encode_char(
+        folded, (utf8proc_uint8_t *)output + output_offset);
+    if (encoded <= 0) {
+      free(output);
+      return NULL;
+    }
+    output_offset += (size_t)encoded;
+    input_offset += (size_t)width;
+  }
+  output[output_offset] = '\0';
+  *output_size = output_offset;
+  return output;
+}
+
+static int compare_u32(const void *left, const void *right) {
+  uint32_t a = *(const uint32_t *)left;
+  uint32_t b = *(const uint32_t *)right;
+  return (a > b) - (a < b);
+}
+
+static fzf_algo_t select_algorithm(uint8_t algorithm, bool utf8) {
+  switch (algorithm) {
+    case 0:
+      return utf8 ? fzf_fuzzy_match_v1_utf8 : fzf_fuzzy_match_v1;
+    case 1:
+      return utf8 ? fzf_fuzzy_match_v2_utf8 : fzf_fuzzy_match_v2;
+    case 2:
+      return utf8 ? fzf_exact_match_utf8 : fzf_exact_match_naive;
+    case 4:
+      return utf8 ? fzf_prefix_match_utf8 : fzf_prefix_match;
+    case 5:
+      return utf8 ? fzf_suffix_match_utf8 : fzf_suffix_match;
+    case 6:
+      return utf8 ? fzf_equal_match_utf8 : fzf_equal_match;
+    default:
+      return NULL;
+  }
+}
+
+static bool send_match_result(uint8_t opcode, const fzf_result_t *result,
+                              fzf_position_t *positions) {
+  if (positions && positions->size > 1)
+    qsort(positions->data, positions->size, sizeof positions->data[0],
+          compare_u32);
+  size_t count = positions ? positions->size : 0;
+  if (count > (FRAME_CAP - 33) / 8) return false;
+  size_t size = 33 + count * 8;
+  uint8_t *payload = malloc(size);
+  if (!payload) return false;
+
+  payload[0] = PROTOCOL_VERSION;
+  payload[1] = opcode;
+  payload[2] = STATUS_OK;
+  payload[3] = result->start >= 0;
+  payload[4] = positions != NULL;
+  write_i64(payload + 5, result->start);
+  write_i64(payload + 13, result->end);
+  write_i64(payload + 21, result->score);
+  write_u32(payload + 29, (uint32_t)count);
+  for (size_t i = 0; i < count; i++)
+    write_i64(payload + 33 + i * 8, positions->data[i]);
+
+  bool ok = send_frame(payload, size);
+  free(payload);
+  return ok;
+}
+
+static bool handle_match(const uint8_t *payload, size_t size) {
+  if (size < 13)
+    return send_error(OPCODE_MATCH, STATUS_BAD_REQUEST,
+                      "short match request");
+  uint8_t algorithm = payload[2];
+  uint8_t scheme = payload[3];
+  uint8_t flags = payload[4];
+  uint32_t pattern_len = read_u32(payload + 5);
+  uint32_t candidate_len = read_u32(payload + 9);
+  if ((flags & ~7u) != 0)
+    return send_error(OPCODE_MATCH, STATUS_BAD_REQUEST, "invalid flags");
+  if ((uint64_t)pattern_len + candidate_len != size - 13)
+    return send_error(OPCODE_MATCH, STATUS_BAD_REQUEST, "invalid lengths");
+  if (scheme != 0)
+    return send_error(OPCODE_MATCH, STATUS_UNSUPPORTED,
+                      "fzf-native supports only the default scheme");
+  if ((flags & 4u) == 0)
+    return send_error(OPCODE_MATCH, STATUS_UNSUPPORTED,
+                      "fzf-native supports only forward matching");
+  if (algorithm == 3)
+    return send_error(OPCODE_MATCH, STATUS_UNSUPPORTED,
+                      "fzf-native lacks exact-boundary matching");
+
+  const uint8_t *pattern_bytes = payload + 13;
+  const uint8_t *candidate_bytes = pattern_bytes + pattern_len;
+  bool case_sensitive = (flags & 1u) != 0;
+  bool normalize = (flags & 2u) != 0;
+  size_t lowered_len = pattern_len;
+  char *owned_pattern = NULL;
+  if (case_sensitive) {
+    owned_pattern = malloc((size_t)pattern_len + 1);
+    if (owned_pattern) {
+      memcpy(owned_pattern, pattern_bytes, pattern_len);
+      owned_pattern[pattern_len] = '\0';
+    }
+  } else {
+    owned_pattern = lower_pattern(pattern_bytes, pattern_len, &lowered_len);
+  }
+  char *owned_candidate = malloc((size_t)candidate_len + 1);
+  if (!owned_pattern || !owned_candidate) {
+    free(owned_candidate);
+    free(owned_pattern);
+    return send_error(OPCODE_MATCH, STATUS_INTERNAL, "allocation failure");
+  }
+  memcpy(owned_candidate, candidate_bytes, candidate_len);
+  owned_candidate[candidate_len] = '\0';
+
+  bool utf8 = !is_ascii_utf8proc(owned_pattern, lowered_len) ||
+              !is_ascii_utf8proc(owned_candidate, candidate_len);
+  fzf_algo_t matcher = select_algorithm(algorithm, utf8);
+  if (!matcher) {
+    free(owned_candidate);
+    free(owned_pattern);
+    return send_error(OPCODE_MATCH, STATUS_BAD_REQUEST,
+                      "invalid algorithm");
+  }
+  fzf_string_t pattern = {
+      .data = owned_pattern,
+      .size = lowered_len,
+  };
+  fzf_string_t candidate = {
+      .data = owned_candidate,
+      .size = candidate_len,
+  };
+  fzf_slab_t *slab = fzf_make_default_slab();
+  fzf_position_t *positions = fzf_pos_array(0);
+  if (!slab || !positions) {
+    fzf_free_positions(positions);
+    fzf_free_slab(slab);
+    free(owned_candidate);
+    free(owned_pattern);
+    return send_error(OPCODE_MATCH, STATUS_INTERNAL, "allocation failure");
+  }
+
+  fzf_clear_allocation_failure();
+  fzf_result_t result = matcher(case_sensitive, normalize, &candidate,
+                                &pattern, positions, slab);
+  bool allocation_failed = fzf_allocation_failed();
+  bool ok = allocation_failed
+                ? send_error(OPCODE_MATCH, STATUS_INTERNAL,
+                             "matcher allocation failure")
+                : send_match_result(OPCODE_MATCH, &result, positions);
+  fzf_free_positions(positions);
+  fzf_free_slab(slab);
+  free(owned_candidate);
+  free(owned_pattern);
+  return ok;
+}
+
+static bool handle_frame(const uint8_t *payload, size_t size) {
+  if (size < 2)
+    return send_error(0xff, STATUS_BAD_REQUEST, "short request");
+  if (payload[0] != PROTOCOL_VERSION)
+    return send_error(payload[1], STATUS_BAD_REQUEST,
+                      "unsupported protocol version");
+  if (payload[1] == OPCODE_INFO) {
+    if (size != 2)
+      return send_error(OPCODE_INFO, STATUS_BAD_REQUEST,
+                        "invalid info request");
+    return send_info();
+  }
+  if (payload[1] == OPCODE_MATCH) return handle_match(payload, size);
+  return send_error(payload[1], STATUS_BAD_REQUEST, "invalid opcode");
+}
+
+int main(void) {
+  for (;;) {
+    uint8_t header[4];
+    int first;
+    for (;;) {
+      errno = 0;
+      first = fgetc(stdin);
+      if (first != EOF) break;
+      if (feof(stdin)) return 0;
+      if (ferror(stdin) && errno == EINTR) {
+        clearerr(stdin);
+        continue;
+      }
+      fprintf(stderr, "fzf-native-algo-driver: frame read error\n");
+      return 1;
+    }
+    header[0] = (uint8_t)first;
+    if (!read_exact(header + 1, sizeof header - 1)) {
+      fprintf(stderr, "fzf-native-algo-driver: truncated frame header\n");
+      return 1;
+    }
+    uint32_t size = read_u32(header);
+    if (size > FRAME_CAP) {
+      fprintf(stderr, "fzf-native-algo-driver: oversized frame\n");
+      return 1;
+    }
+    uint8_t *payload = malloc(size ? size : 1);
+    if (!payload) return 1;
+    bool ok = read_exact(payload, size) && handle_frame(payload, size);
+    free(payload);
+    if (!ok) return 1;
+  }
+}

--- a/fuzz/fzf-native-fuzz-test.el
+++ b/fuzz/fzf-native-fuzz-test.el
@@ -29,20 +29,50 @@
 (require 'cl-lib)
 (require 'ert)
 (require 'fzf-native)
+(require 'subr-x)
 
 (declare-function fzf-native-score "fzf-native-module"
                   (string query &optional slab))
 (declare-function fzf-native-score-all "fzf-native-module"
                   (collection query &optional slab))
+(declare-function fzf-native-highlight-one "fzf-native-module" (cand query))
+(declare-function fzf-native-make-slab "fzf-native-module" (size16 size32))
+(declare-function fzf-native-async-start "fzf-native-module"
+                  (command &optional directory))
+(declare-function fzf-native-async-stop "fzf-native-module" (handle))
+(declare-function fzf-native-async-submit "fzf-native-module"
+                  (handle query &optional limit))
+(declare-function fzf-native-async-snapshot "fzf-native-module"
+                  (handle &optional request-id))
+(declare-function fzf-native-async-status "fzf-native-module"
+                  (handle &optional request-id))
+(declare-function fzf-native--session-platform-p "fzf-native" ())
+(declare-function fzf-native--verify-initialized-module "fzf-native" ())
+(declare-function fzf-native--verify-session-abi "fzf-native" ())
 
 (let ((module (getenv "FZF_NATIVE_TEST_MODULE")))
   (if (and module (not (string-empty-p module)))
       (progn
         (module-load module)
+        (fzf-native--verify-initialized-module)
         (setq fzf-native-loaded t))
     (fzf-native-load-dyn)))
 
+(when (fzf-native--session-platform-p)
+  (dolist (function '(fzf-native-session-abi-version
+                      fzf-native-async-start
+                      fzf-native-async-stop
+                      fzf-native-async-submit
+                      fzf-native-async-snapshot
+                      fzf-native-async-status))
+    (unless (fboundp function)
+      (error "Required fzf-native session ABI function is missing: %S"
+             function))))
+
 (defvar fzf-native-fuzz--state 1)
+
+(defvar fzf-native-fuzz--allow-malformed t
+  "When non-nil, generated strings can contain arbitrary unibyte data.")
 
 (defun fzf-native-fuzz--env-integer (name default)
   "Read non-negative integer NAME, or return DEFAULT."
@@ -65,30 +95,50 @@
     (if (<= limit 0) 0 (% fzf-native-fuzz--state limit))))
 
 (defconst fzf-native-fuzz--candidate-pieces
-  ["a" "b" "c" "F" "K" "-" "_" "/" "." " " "\t"])
+  ["a" "b" "c" "F" "K" "-" "_" "/" "." " " "\t"
+   "é" "é" "σ" "Σ" "你" "中文" "😀" "𐐷" "K" "Ⱥ" "ⱥ"])
 
 (defconst fzf-native-fuzz--query-pieces
-  ["a" "b" "c" "f" "F" "k" "K" "foo" "bar"])
+  ["a" "b" "c" "f" "F" "k" "K" "foo" "bar"
+   "é" "é" "σ" "Σ" "你" "😀" "𐐷" "K" "Ⱥ" "ⱥ"])
+
+(defconst fzf-native-fuzz--raw-bytes
+  [1 9 32 65 127 128 191 192 193 224 237 240 245 254 255])
+
+(defun fzf-native-fuzz--unibyte-string ()
+  "Generate a short string with arbitrary bytes, including malformed UTF-8."
+  (apply #'unibyte-string
+         (cl-loop repeat (fzf-native-fuzz--random 9)
+                  collect (aref fzf-native-fuzz--raw-bytes
+                                (fzf-native-fuzz--random
+                                 (length fzf-native-fuzz--raw-bytes))))))
 
 (defun fzf-native-fuzz--candidate ()
-  "Generate one short ASCII candidate."
-  (let ((count (fzf-native-fuzz--random 12)) pieces)
-    (dotimes (_ count)
-      (push (aref fzf-native-fuzz--candidate-pieces
-                  (fzf-native-fuzz--random
-                   (length fzf-native-fuzz--candidate-pieces)))
-            pieces))
-    (apply #'concat (nreverse pieces))))
+  "Generate one short candidate across valid and malformed text classes."
+  (if (and fzf-native-fuzz--allow-malformed
+           (zerop (fzf-native-fuzz--random 8)))
+      (fzf-native-fuzz--unibyte-string)
+    (let ((count (fzf-native-fuzz--random 12)) pieces)
+      (dotimes (_ count)
+        (push (aref fzf-native-fuzz--candidate-pieces
+                    (fzf-native-fuzz--random
+                     (length fzf-native-fuzz--candidate-pieces)))
+              pieces))
+      (apply #'concat (nreverse pieces)))))
 
 (defun fzf-native-fuzz--literal ()
   "Generate a nonempty operator-free query literal."
-  (let ((count (1+ (fzf-native-fuzz--random 3))) pieces)
-    (dotimes (_ count)
-      (push (aref fzf-native-fuzz--query-pieces
-                  (fzf-native-fuzz--random
-                   (length fzf-native-fuzz--query-pieces)))
-            pieces))
-    (apply #'concat (nreverse pieces))))
+  (if (and fzf-native-fuzz--allow-malformed
+           (zerop (fzf-native-fuzz--random 16)))
+      (let ((raw (fzf-native-fuzz--unibyte-string)))
+        (if (string-empty-p raw) (unibyte-string 255) raw))
+    (let ((count (1+ (fzf-native-fuzz--random 3))) pieces)
+      (dotimes (_ count)
+        (push (aref fzf-native-fuzz--query-pieces
+                    (fzf-native-fuzz--random
+                     (length fzf-native-fuzz--query-pieces)))
+              pieces))
+      (apply #'concat (nreverse pieces)))))
 
 (defun fzf-native-fuzz--term ()
   "Generate one extended-search term."
@@ -117,6 +167,15 @@
                   (substring-no-properties string))
                 (append collection nil))
         #'string<))
+
+(defun fzf-native-fuzz--common-part-positions (string)
+  "Return character positions highlighted on STRING by fzf-native."
+  (cl-loop for index below (length string)
+           for face = (get-text-property index 'face string)
+           when (or (eq face 'completions-common-part)
+                    (and (listp face)
+                         (memq 'completions-common-part face)))
+           collect index))
 
 (defun fzf-native-fuzz--scalar-matches (collection query)
   "Return members of COLLECTION with positive scalar scores for QUERY."
@@ -174,10 +233,170 @@
             (should (equal list-full vector-full))
             (should (equal list-full
                            (fzf-native-fuzz--keys highlighted)))
+            (dolist (candidate highlighted)
+              (let ((scalar-highlight
+                     (fzf-native-highlight-one
+                      (substring-no-properties candidate) query)))
+                (should
+                 (equal
+                  (fzf-native-fuzz--common-part-positions candidate)
+                  (fzf-native-fuzz--common-part-positions
+                   scalar-highlight)))))
             (dolist (candidate highlight-input)
               (should-not
                (text-property-not-all 0 (length candidate) 'face nil
                                       candidate)))))))))
+
+(ert-deftest fzf-native-fuzz-public-abi-rejects-invalid-values ()
+  "Generate invalid types and arities across public native entry points."
+  (let ((bad-strings
+         (vector nil t 17 1.5 'fzf-native-bad '("list") ["vector"]
+                 (make-hash-table)))
+        (bad-collections
+         (vector t 17 1.5 'fzf-native-bad '("valid" . "bad-tail")
+                 (make-hash-table)))
+        (bad-pointers
+         (vector t 17 1.5 'fzf-native-bad '("list") ["vector"]
+                 (make-hash-table)))
+        (bad-sizes
+         (vector nil t -1 1.5 'fzf-native-bad '("list") ["vector"]
+                 (make-hash-table))))
+    (fzf-native-fuzz--seed
+     (fzf-native-fuzz--env-integer "FZF_NATIVE_FUZZ_SEED" 12648430))
+    (dotimes (_ (fzf-native-fuzz--env-integer
+                 "FZF_NATIVE_FUZZ_ABI_CASES" 200))
+      (let ((bad-string
+             (aref bad-strings
+                   (fzf-native-fuzz--random (length bad-strings))))
+            (bad-collection
+             (aref bad-collections
+                   (fzf-native-fuzz--random (length bad-collections))))
+            (bad-pointer
+             (aref bad-pointers
+                   (fzf-native-fuzz--random (length bad-pointers))))
+            (bad-size
+             (aref bad-sizes
+                   (fzf-native-fuzz--random (length bad-sizes)))))
+        (pcase (fzf-native-fuzz--random 11)
+          (0 (should-error (fzf-native-score bad-string "a")))
+          (1 (should-error (fzf-native-score "a" bad-string)))
+          (2 (should-error (fzf-native-score "a" "a" bad-pointer)))
+          (3 (should-error (fzf-native-score-all bad-collection "a")))
+          (4 (should
+              (listp
+               (fzf-native-score-all (list "a" bad-string) "a"))))
+          (5 (should-error (fzf-native-make-slab bad-size 1)))
+          (6 (should-error (fzf-native-make-slab 1 bad-size)))
+          (7 (when (fboundp 'fzf-native-async-submit)
+               (should-error (fzf-native-async-submit bad-pointer "a" 1))))
+          (8 (when (fboundp 'fzf-native-async-status)
+               (should-error (fzf-native-async-status bad-pointer))))
+          (9 (when (fboundp 'fzf-native-async-start)
+               (should-error (fzf-native-async-start bad-string))))
+          (10 (when (fboundp 'fzf-native-async-submit)
+                (let ((handle
+                       (fzf-native-async-start "printf '%s\\n' value")))
+                  (unwind-protect
+                      (should-error
+                       (fzf-native-async-submit handle bad-string 1))
+                    (fzf-native-async-stop handle))))))))
+    (should-error (fzf-native-score "only-one-argument"))
+    (should-error (fzf-native-score "a" "a" nil nil))
+    (should-error (fzf-native-score-all '("a")))
+    (should-error (fzf-native-make-slab 1 2 3))))
+
+(ert-deftest fzf-native-fuzz-public-abi-rejects-embedded-nul ()
+  "Keep the public module's explicit embedded-NUL boundary fail-closed."
+  (let ((nul (concat "before" "\0" "after")))
+    (should-error (fzf-native-score nul "a"))
+    (should-error (fzf-native-score "a" nul))
+    (should-error (fzf-native-score-all (list nul) "a"))
+    (should-error (fzf-native-score-all '("a") nul))))
+
+(defun fzf-native-fuzz--wait-for-producer (handle)
+  "Return the terminal producer status for HANDLE, or signal on timeout."
+  (let ((deadline (+ (float-time) 10.0)) status)
+    (while (and (< (float-time) deadline)
+                (progn
+                  (setq status (fzf-native-async-status handle))
+                  (not (plist-get status :reader-done))))
+      (sleep-for 0.01))
+    (unless (plist-get status :reader-done)
+      (error "Timed out while waiting for the generated producer"))
+    status))
+
+(defun fzf-native-fuzz--wait-for-request (handle request-id)
+  "Return the terminal snapshot for REQUEST-ID on HANDLE."
+  (let ((deadline (+ (float-time) 10.0)) snapshot)
+    (while (and (< (float-time) deadline)
+                (progn
+                  (setq snapshot
+                        (fzf-native-async-snapshot handle request-id))
+                  (memq (plist-get snapshot :state) '(queued running))))
+      (sleep-for 0.01))
+    (unless (eq (plist-get snapshot :state) 'complete)
+      (error "Request %S did not complete: %S" request-id snapshot))
+    snapshot))
+
+(ert-deftest fzf-native-fuzz-interactive-abi-matches-batch-membership ()
+  "Compare generated persistent-session rounds with the batch native API."
+  (skip-unless (fzf-native--session-platform-p))
+  (should (fzf-native--verify-session-abi))
+  (let* ((seed (fzf-native-fuzz--env-integer
+                "FZF_NATIVE_FUZZ_SEED" 12648430))
+         (rounds (fzf-native-fuzz--env-integer
+                  "FZF_NATIVE_FUZZ_SESSION_CASES" 100))
+         (fzf-native-fuzz--allow-malformed nil)
+         collection
+         (input (make-temp-file "fzf-native-abi-fuzz-"))
+         handle)
+    (fzf-native-fuzz--seed (logxor seed #x51a7e))
+    (setq collection (cl-loop repeat 128
+                              collect (fzf-native-fuzz--candidate)))
+    (unwind-protect
+        (progn
+          (let ((coding-system-for-write 'utf-8-unix))
+            (write-region (concat (mapconcat #'identity collection "\n") "\n")
+                          nil input nil 'silent))
+          (setq handle
+                (fzf-native-async-start
+                 (concat "cat " (shell-quote-argument input))))
+          (let ((producer (fzf-native-fuzz--wait-for-producer handle)))
+            (should (eq (plist-get producer :producer-state) 'complete))
+            (should (= (plist-get producer :pool-generation)
+                       (length collection))))
+          (dotimes (iteration rounds)
+            (let* ((fzf-native-case-mode
+                    (aref [smart ignore respect]
+                          (fzf-native-fuzz--random 3)))
+                   (fzf-native-fuzzy
+                    (not (zerop (fzf-native-fuzz--random 2))))
+                   (fzf-native-async-highlight nil)
+                   (fzf-native-filter-only-min-pool nil)
+                   (fzf-native-filter-only-length nil)
+                   (query (fzf-native-fuzz--query))
+                   (expected
+                    (fzf-native-fuzz--keys
+                     (fzf-native-fuzz--score-all
+                      (fzf-native-fuzz--copies collection) query nil)))
+                   (request-id (fzf-native-async-submit handle query 0))
+                   (snapshot
+                    (fzf-native-fuzz--wait-for-request handle request-id))
+                   (actual
+                    (fzf-native-fuzz--keys
+                     (plist-get snapshot :candidates))))
+              (ert-info ((format
+                          "seed=%d round=%d mode=%S fuzzy=%S query=%S"
+                          seed iteration fzf-native-case-mode
+                          fzf-native-fuzzy query))
+                (should-not (plist-get snapshot :stale))
+                (should (equal expected actual)))))
+          (fzf-native-async-stop handle)
+          (setq handle nil))
+      (when handle
+        (ignore-errors (fzf-native-async-stop handle)))
+      (when (file-exists-p input)
+        (delete-file input)))))
 
 (provide 'fzf-native-fuzz-test)
 ;;; fzf-native-fuzz-test.el ends here

--- a/fuzz/fzf-native-fuzz.c
+++ b/fuzz/fzf-native-fuzz.c
@@ -25,6 +25,24 @@ static void fuzz_fail(const char *property) {
   abort();
 }
 
+static bool valid_utf8(const char *text, size_t len) {
+  size_t offset = 0;
+  while (offset < len) {
+    utf8proc_int32_t codepoint;
+    utf8proc_ssize_t width = utf8proc_iterate(
+        (const utf8proc_uint8_t *)text + offset,
+        (utf8proc_ssize_t)(len - offset), &codepoint);
+    if (width <= 0) return false;
+    offset += (size_t)width;
+  }
+  return true;
+}
+
+static size_t visible_character_count(const char *text) {
+  size_t bytes = strlen(text);
+  return valid_utf8(text, bytes) ? utf8_strlen(text, bytes) : bytes;
+}
+
 static fzf_slab_t *make_selected_slab(uint8_t options) {
   static const size_t caps16[] = {1, 8, 64, 1024, 8192, 100 * 1024};
   static const size_t caps32[] = {1, 8, 64, 256, 1024, 2048};
@@ -34,11 +52,12 @@ static fzf_slab_t *make_selected_slab(uint8_t options) {
 
 static void check_positions(const char *candidate, bool matched,
                             const fzf_position_t *positions) {
-  (void)matched;
+  if (!matched && positions && positions->size != 0)
+    fuzz_fail("a failed match returned highlight positions");
   if (!positions)
     return;
 
-  size_t limit = strlen(candidate);
+  size_t limit = visible_character_count(candidate);
   for (size_t i = 0; i < positions->size; i++) {
     if (positions->data[i] >= limit)
       fuzz_fail("a highlight position is outside the candidate");
@@ -59,6 +78,32 @@ static void check_position_order(const fzf_position_t *positions) {
   }
 }
 
+static fzf_algo_t utf8_variant(fzf_algo_t algorithm) {
+  if (algorithm == fzf_fuzzy_match_v2) return fzf_fuzzy_match_v2_utf8;
+  if (algorithm == fzf_fuzzy_match_v1) return fzf_fuzzy_match_v1_utf8;
+  if (algorithm == fzf_exact_match_naive) return fzf_exact_match_utf8;
+  if (algorithm == fzf_prefix_match) return fzf_prefix_match_utf8;
+  if (algorithm == fzf_suffix_match) return fzf_suffix_match_utf8;
+  if (algorithm == fzf_equal_match) return fzf_equal_match_utf8;
+  return algorithm;
+}
+
+static const char *algo_name(fzf_algo_t algorithm) {
+  if (algorithm == fzf_fuzzy_match_v2) return "fuzzy-v2";
+  if (algorithm == fzf_fuzzy_match_v2_utf8) return "fuzzy-v2-utf8";
+  if (algorithm == fzf_fuzzy_match_v1) return "fuzzy-v1";
+  if (algorithm == fzf_fuzzy_match_v1_utf8) return "fuzzy-v1-utf8";
+  if (algorithm == fzf_exact_match_naive) return "exact";
+  if (algorithm == fzf_exact_match_utf8) return "exact-utf8";
+  if (algorithm == fzf_prefix_match) return "prefix";
+  if (algorithm == fzf_prefix_match_utf8) return "prefix-utf8";
+  if (algorithm == fzf_suffix_match) return "suffix";
+  if (algorithm == fzf_suffix_match_utf8) return "suffix-utf8";
+  if (algorithm == fzf_equal_match) return "equal";
+  if (algorithm == fzf_equal_match_utf8) return "equal-utf8";
+  return "unknown";
+}
+
 static bool pattern_has_inverse(const fzf_pattern_t *pattern) {
   for (size_t i = 0; i < pattern->size; i++) {
     const fzf_term_set_t *set = pattern->ptr[i];
@@ -68,6 +113,121 @@ static bool pattern_has_inverse(const fzf_pattern_t *pattern) {
     }
   }
   return false;
+}
+
+static bool extension_preserves_term(const fzf_term_t *term, bool prepend) {
+  if (term->inv || !term->fn || !term->text) return false;
+  const fzf_string_t *text = (const fzf_string_t *)term->text;
+  if (!valid_utf8(text->data, text->size)) return false;
+
+  if (term->fn == fzf_fuzzy_match_v1 ||
+      term->fn == fzf_fuzzy_match_v1_utf8 ||
+      term->fn == fzf_fuzzy_match_v2 ||
+      term->fn == fzf_fuzzy_match_v2_utf8 ||
+      term->fn == fzf_exact_match_naive ||
+      term->fn == fzf_exact_match_utf8)
+    return true;
+  if (prepend)
+    return term->fn == fzf_suffix_match ||
+           term->fn == fzf_suffix_match_utf8;
+  return term->fn == fzf_prefix_match ||
+         term->fn == fzf_prefix_match_utf8;
+}
+
+static bool extension_preserves_pattern(const fzf_pattern_t *pattern,
+                                        bool prepend) {
+  for (size_t i = 0; i < pattern->size; i++) {
+    const fzf_term_set_t *set = pattern->ptr[i];
+    for (size_t j = 0; j < set->size; j++)
+      if (!extension_preserves_term(&set->ptr[j], prepend)) return false;
+  }
+  return true;
+}
+
+static bool pattern_contains_codepoint(const fzf_pattern_t *pattern,
+                                       utf8proc_int32_t wanted) {
+  for (size_t i = 0; i < pattern->size; i++) {
+    const fzf_term_set_t *set = pattern->ptr[i];
+    for (size_t j = 0; j < set->size; j++) {
+      const fzf_string_t *text = (const fzf_string_t *)set->ptr[j].text;
+      size_t offset = 0;
+      while (text && offset < text->size) {
+        utf8proc_int32_t codepoint;
+        utf8proc_ssize_t width = utf8proc_iterate(
+            (const utf8proc_uint8_t *)text->data + offset,
+            (utf8proc_ssize_t)(text->size - offset), &codepoint);
+        if (width <= 0 || codepoint == wanted) return true;
+        offset += (size_t)width;
+      }
+    }
+  }
+  return false;
+}
+
+static bool extension_keeps_slab_path(const fzf_pattern_t *pattern,
+                                      size_t candidate_units,
+                                      size_t extended_units,
+                                      const fzf_slab_t *slab) {
+  if (!slab) return true;
+  for (size_t i = 0; i < pattern->size; i++) {
+    const fzf_term_set_t *set = pattern->ptr[i];
+    for (size_t j = 0; j < set->size; j++) {
+      const fzf_term_t *term = &set->ptr[j];
+      if (term->fn != fzf_fuzzy_match_v2 &&
+          term->fn != fzf_fuzzy_match_v2_utf8)
+        continue;
+      const fzf_string_t *text = (const fzf_string_t *)term->text;
+      size_t pattern_units = utf8_strlen(text->data, text->size);
+      bool old_fallback = candidate_units != 0 &&
+          pattern_units > slab->I16.cap / candidate_units;
+      bool new_fallback = extended_units != 0 &&
+          pattern_units > slab->I16.cap / extended_units;
+      if (old_fallback != new_fallback) return false;
+    }
+  }
+  return true;
+}
+
+static void check_candidate_extension(const char *candidate,
+                                      fzf_pattern_t *pattern,
+                                      int32_t score, fzf_slab_t *slab) {
+  static const char *extensions[] = {
+      "x", " ", "\xc3\xa9", "\xf0\x9f\x9a\x80",
+  };
+  size_t length = strlen(candidate);
+  if (score <= 0 || !valid_utf8(candidate, length)) return;
+  char *extended = malloc(length + 5);
+  if (!extended) abort();
+
+  bool append_safe = extension_preserves_pattern(pattern, false);
+  bool prepend_safe = extension_preserves_pattern(pattern, true);
+  for (size_t i = 0; i < sizeof extensions / sizeof extensions[0]; i++) {
+    size_t extension_len = strlen(extensions[i]);
+    if (append_safe) {
+      memcpy(extended, candidate, length);
+      memcpy(extended + length, extensions[i], extension_len + 1);
+      if (fzf_get_score(extended, pattern, slab) <= 0)
+        fuzz_fail("appending text destroyed a prefix-safe match");
+    }
+    if (prepend_safe) {
+      memcpy(extended, extensions[i], extension_len);
+      memcpy(extended + extension_len, candidate, length + 1);
+      if (fzf_get_score(extended, pattern, slab) <= 0)
+        fuzz_fail("prepending text destroyed a suffix-safe match");
+    }
+  }
+
+  static const char nonmatching_scalar[] = "\xf4\x8f\xbf\xbf";
+  if (append_safe && is_ascii_utf8proc(candidate, length) &&
+      !pattern_contains_codepoint(pattern, 0x10ffff) &&
+      extension_keeps_slab_path(pattern, length, length + 1, slab)) {
+    memcpy(extended, candidate, length);
+    memcpy(extended + length, nonmatching_scalar,
+           sizeof nonmatching_scalar);
+    if (fzf_get_score(extended, pattern, slab) != score)
+      fuzz_fail("ASCII-to-UTF-8 dispatch changed a prefix-safe score");
+  }
+  free(extended);
 }
 
 #ifndef FZF_NATIVE_UTF8_MATCHING
@@ -99,13 +259,16 @@ static void check_term(const char *candidate, const fzf_term_t *term,
 
   fzf_string_t input = {.data = candidate, .size = strlen(candidate)};
   fzf_string_t *pattern = (fzf_string_t *)term->text;
+  fzf_algo_t algorithm = term->fn;
+  if (!is_ascii_utf8proc(input.data, input.size))
+    algorithm = utf8_variant(algorithm);
   fzf_result_t without_positions =
-      term->fn(term->case_sensitive, false, &input, pattern, NULL, slab);
+      algorithm(term->case_sensitive, false, &input, pattern, NULL, slab);
   fzf_position_t *positions = fzf_pos_array(0);
   if (!positions)
     abort();
-  fzf_result_t with_positions = term->fn(term->case_sensitive, false, &input,
-                                         pattern, positions, slab);
+  fzf_result_t with_positions = algorithm(
+      term->case_sensitive, false, &input, pattern, positions, slab);
 
   /* Fuzzy v2 may backtrack to a more precise START only when positions are
      requested.  Membership and score must not depend on observability. */
@@ -116,12 +279,26 @@ static void check_term(const char *candidate, const fzf_term_t *term,
     fuzz_fail("a failed term returned highlight positions");
   check_positions(candidate, with_positions.start >= 0, positions);
   check_position_order(positions);
+  if (with_positions.start >= 0 && valid_utf8(input.data, input.size) &&
+      valid_utf8(pattern->data, pattern->size)) {
+    size_t pattern_characters = utf8_strlen(pattern->data, pattern->size);
+    if (positions->size != pattern_characters) {
+      fprintf(stderr,
+              "%s returned %zu positions for a %zu-character pattern\n",
+              algo_name(algorithm), positions->size, pattern_characters);
+      fuzz_fail("a matched term returned the wrong position count");
+    }
+  }
   fzf_free_positions(positions);
 
-  if (term->fn == fzf_fuzzy_match_v2) {
-    fzf_result_t v1 = fzf_fuzzy_match_v1(
+  if (algorithm == fzf_fuzzy_match_v2 ||
+      algorithm == fzf_fuzzy_match_v2_utf8) {
+    fzf_algo_t v1 = algorithm == fzf_fuzzy_match_v2_utf8
+                        ? fzf_fuzzy_match_v1_utf8
+                        : fzf_fuzzy_match_v1;
+    fzf_result_t v1_result = v1(
         term->case_sensitive, false, &input, pattern, NULL, slab);
-    if ((v1.start >= 0) != (with_positions.start >= 0))
+    if ((v1_result.start >= 0) != (with_positions.start >= 0))
       fuzz_fail("fuzzy v1 and v2 disagree on match membership");
   }
 }
@@ -146,6 +323,9 @@ static int32_t score_query(const char *candidate, const char *query,
 
 static void check_case_monotonicity(const char *candidate, const char *query,
                                     bool fuzzy, fzf_slab_t *slab) {
+  if (!valid_utf8(candidate, strlen(candidate)) ||
+      !valid_utf8(query, strlen(query)))
+    return;
   bool inverse = false;
   int32_t respect = score_query(candidate, query, CaseRespect, fuzzy, slab,
                                 &inverse);
@@ -185,6 +365,203 @@ static void check_whitespace_equivalence(const char *candidate,
       fuzz_fail("trailing query whitespace changed a score");
     free(trailing);
   }
+
+  for (size_t i = 0; i < len; i++) {
+    if (query[i] != ' ' || (i > 0 && query[i - 1] == '\\')) continue;
+    char *expanded = malloc(len + 3);
+    if (!expanded) abort();
+    memcpy(expanded, query, i);
+    memcpy(expanded + i, "   ", 3);
+    memcpy(expanded + i + 3, query + i + 1, len - i);
+    if (score_query(candidate, expanded, case_mode, fuzzy, slab, NULL) !=
+        expected_score)
+      fuzz_fail("expanding query whitespace changed a score");
+    free(expanded);
+    break;
+  }
+}
+
+typedef struct {
+  const char *data;
+  size_t size;
+} fuzz_query_token_t;
+
+static bool split_simple_query(const char *query, fuzz_query_token_t **tokens,
+                               size_t *count) {
+  *tokens = NULL;
+  *count = 0;
+  if (strstr(query, "\\ ")) return false;
+  size_t len = strlen(query);
+  size_t token_count = 0;
+  for (size_t pos = 0; pos < len;) {
+    while (pos < len && query[pos] == ' ') pos++;
+    if (pos == len) break;
+    token_count++;
+    while (pos < len && query[pos] != ' ') pos++;
+  }
+  if (token_count == 0) return true;
+
+  fuzz_query_token_t *result = malloc(token_count * sizeof *result);
+  if (!result) abort();
+  size_t index = 0;
+  for (size_t pos = 0; pos < len;) {
+    while (pos < len && query[pos] == ' ') pos++;
+    if (pos == len) break;
+    size_t start = pos;
+    while (pos < len && query[pos] != ' ') pos++;
+    if (query[pos - 1] == '\\') {
+      free(result);
+      return false;
+    }
+    result[index++] =
+        (fuzz_query_token_t){.data = query + start, .size = pos - start};
+  }
+  *tokens = result;
+  *count = token_count;
+  return true;
+}
+
+static bool token_is_bar(const fuzz_query_token_t *token) {
+  return token->size == 1 && token->data[0] == '|';
+}
+
+static void copy_token(char *output, size_t *offset,
+                       const fuzz_query_token_t *token) {
+  memcpy(output + *offset, token->data, token->size);
+  *offset += token->size;
+}
+
+static bool pattern_is_simple_and(const fzf_pattern_t *pattern,
+                                  const fuzz_query_token_t *tokens,
+                                  size_t count) {
+  if (count < 2 || pattern->size != count) return false;
+  for (size_t i = 0; i < count; i++)
+    if (token_is_bar(&tokens[i]) || pattern->ptr[i]->size != 1) return false;
+  return true;
+}
+
+static bool pattern_is_simple_or(const fzf_pattern_t *pattern,
+                                 const fuzz_query_token_t *tokens,
+                                 size_t count) {
+  if (count < 3 || count % 2 == 0 || pattern->size != 1 ||
+      pattern->ptr[0]->size != (count + 1) / 2)
+    return false;
+  for (size_t i = 0; i < count; i++)
+    if (token_is_bar(&tokens[i]) != (i % 2 == 1)) return false;
+  return true;
+}
+
+static bool token_is_plain_literal(const fuzz_query_token_t *token) {
+  if (token->size == 0 || token_is_bar(token)) return false;
+  char first = token->data[0];
+  char last = token->data[token->size - 1];
+  return first != '!' && first != '\'' && first != '^' && last != '$';
+}
+
+static void require_score(const char *candidate, const char *query,
+                          fzf_case_types case_mode, bool fuzzy,
+                          fzf_slab_t *slab, int32_t expected,
+                          const char *property) {
+  if (score_query(candidate, query, case_mode, fuzzy, slab, NULL) != expected)
+    fuzz_fail(property);
+}
+
+static void require_membership(const char *candidate, const char *query,
+                               fzf_case_types case_mode, bool fuzzy,
+                               fzf_slab_t *slab, bool expected,
+                               const char *property) {
+  int32_t score = score_query(candidate, query, case_mode, fuzzy, slab, NULL);
+  if ((score > 0) != expected) fuzz_fail(property);
+}
+
+static void check_query_structure(const char *candidate, const char *query,
+                                  fzf_case_types case_mode, bool fuzzy,
+                                  const fzf_pattern_t *pattern,
+                                  fzf_slab_t *slab, int32_t score) {
+  fuzz_query_token_t *tokens = NULL;
+  size_t count = 0;
+  if (!split_simple_query(query, &tokens, &count)) return;
+
+  if (pattern_is_simple_and(pattern, tokens, count)) {
+    size_t output_len = count - 1;
+    for (size_t i = 0; i < count; i++) output_len += tokens[i].size;
+    char *reversed = malloc(output_len + 1);
+    if (!reversed) abort();
+    size_t offset = 0;
+    for (size_t i = count; i-- > 0;) {
+      if (offset) reversed[offset++] = ' ';
+      copy_token(reversed, &offset, &tokens[i]);
+    }
+    reversed[offset] = '\0';
+    require_score(candidate, reversed, case_mode, fuzzy, slab, score,
+                  "reordering AND terms changed a score");
+    free(reversed);
+  }
+
+  if (pattern_is_simple_or(pattern, tokens, count)) {
+    size_t branches = (count + 1) / 2;
+    size_t output_len = (branches - 1) * 3;
+    for (size_t i = 0; i < count; i += 2) output_len += tokens[i].size;
+    char *reversed = malloc(output_len + 1);
+    if (!reversed) abort();
+    size_t offset = 0;
+    for (size_t branch = branches; branch-- > 0;) {
+      if (offset) {
+        memcpy(reversed + offset, " | ", 3);
+        offset += 3;
+      }
+      copy_token(reversed, &offset, &tokens[branch * 2]);
+    }
+    reversed[offset] = '\0';
+    require_membership(candidate, reversed, case_mode, fuzzy, slab, score > 0,
+                       "reordering OR branches changed membership");
+    free(reversed);
+  }
+
+  if (count == 1 && pattern->size == 1 && pattern->ptr[0]->size == 1 &&
+      !token_is_bar(&tokens[0])) {
+    size_t token_len = tokens[0].size;
+    char *duplicate_or = malloc(token_len * 2 + 4);
+    char *duplicate_and = malloc(token_len * 2 + 2);
+    if (!duplicate_or || !duplicate_and) abort();
+    memcpy(duplicate_or, tokens[0].data, token_len);
+    memcpy(duplicate_or + token_len, " | ", 3);
+    memcpy(duplicate_or + token_len + 3, tokens[0].data, token_len);
+    duplicate_or[token_len * 2 + 3] = '\0';
+    memcpy(duplicate_and, tokens[0].data, token_len);
+    duplicate_and[token_len] = ' ';
+    memcpy(duplicate_and + token_len + 1, tokens[0].data, token_len);
+    duplicate_and[token_len * 2 + 1] = '\0';
+    require_score(candidate, duplicate_or, case_mode, fuzzy, slab, score,
+                  "duplicating an OR branch changed a score");
+    require_membership(candidate, duplicate_and, case_mode, fuzzy, slab,
+                       score > 0,
+                       "duplicating an AND term changed membership");
+    free(duplicate_and);
+    free(duplicate_or);
+
+    if (token_is_plain_literal(&tokens[0])) {
+      char *literal = malloc(token_len + 1);
+      char *quoted = malloc(token_len + 2);
+      if (!literal || !quoted) abort();
+      memcpy(literal, tokens[0].data, token_len);
+      literal[token_len] = '\0';
+      quoted[0] = '\'';
+      memcpy(quoted + 1, tokens[0].data, token_len);
+      quoted[token_len + 1] = '\0';
+      int32_t exact = score_query(candidate, literal, case_mode, false, slab,
+                                  NULL);
+      require_score(candidate, quoted, case_mode, true, slab, exact,
+                    "quoted exact and global exact scores differ");
+      int32_t fuzzy_score = score_query(candidate, literal, case_mode, true,
+                                        slab, NULL);
+      require_score(candidate, quoted, case_mode, false, slab, fuzzy_score,
+                    "quoted fuzzy and global fuzzy scores differ");
+      free(quoted);
+      free(literal);
+    }
+  }
+  free(tokens);
 }
 
 static void check_bounded_entry_points(const char *candidate,
@@ -300,6 +677,10 @@ static void run_one(const uint8_t *data, size_t size) {
   if (score != fzf_get_score(candidate, pattern, default_slab))
     fuzz_fail("repeated scoring is not deterministic");
 
+  check_candidate_extension(candidate, pattern, score, default_slab);
+  check_query_structure(candidate, query, case_mode, fuzzy, pattern,
+                        default_slab, score);
+
   check_bounded_entry_points(candidate, candidate_size, pattern,
                              default_slab, score);
 
@@ -308,20 +689,19 @@ static void run_one(const uint8_t *data, size_t size) {
   check_positions(candidate, score > 0, positions);
   fzf_free_positions(positions);
 
-  /* Exercise the filter-only matcher as part of the public C surface.  The
-     baseline implementation intentionally has historical whitespace/anchor
-     differences from the scorer; this test-only layer must not redefine
-     those semantics. */
+  /* Filtering and scoring implement the same match predicate. */
 #ifdef FZF_NATIVE_HAS_MATCH_SLAB
-  (void)fzf_has_match(candidate, pattern, default_slab);
+  bool fast_match = fzf_has_match(candidate, pattern, default_slab);
 #else
-  (void)fzf_has_match(candidate, pattern);
+  bool fast_match = fzf_has_match(candidate, pattern);
 #endif
+  if (fast_match != (score > 0))
+    fuzz_fail("fzf_has_match disagrees with fzf_get_score");
 
-  /* Exercise the documented small-slab fallback under sanitizers.  The base
-     implementation has historical score differences between algorithms, so
-     this additive layer deliberately asserts safety rather than score parity. */
+  /* A slab can select a different algorithm, but not different membership. */
   int32_t selected_score = fzf_get_score(candidate, pattern, selected_slab);
+  if ((selected_score > 0) != (score > 0))
+    fuzz_fail("slab fallback changed match membership");
   positions = fzf_get_positions(candidate, pattern, selected_slab);
   check_positions(candidate, selected_score > 0, positions);
   fzf_free_positions(positions);

--- a/fuzz/fzf-native-session-fuzz.c
+++ b/fuzz/fzf-native-session-fuzz.c
@@ -1,11 +1,33 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later
- * Coverage-guided state-machine fuzzer for fzf-native interactive sessions.
+ * Coverage-guided fuzzers for fzf-native interactive sessions.
  *
  * This target includes the real native module implementation through the same
- * plain-C path as fzf-native-ctest.c.  A compact bytecode drives candidate
- * growth, request submission, cancellation, polling, cache reuse, worker
- * scoring, publication, and teardown without requiring an Emacs process.
+ * plain-C path as fzf-native-ctest.c.  State mode uses a compact bytecode to
+ * drive candidate growth, request submission, cancellation, polling, cache
+ * reuse, worker scoring, publication, and teardown without requiring an Emacs
+ * process.  Reader mode separately exercises the real blocking producer path.
+ * Keeping the modes separate lets libFuzzer mutate session state at high
+ * throughput without paying for a pipe, reader thread, and blocking teardown
+ * on every input.
  */
+
+#define FZF_SESSION_FUZZ_MODE_STATE 1
+#define FZF_SESSION_FUZZ_MODE_READER 2
+
+#ifndef FZF_SESSION_FUZZ_MODE
+#define FZF_SESSION_FUZZ_MODE FZF_SESSION_FUZZ_MODE_STATE
+#endif
+
+#if FZF_SESSION_FUZZ_MODE != FZF_SESSION_FUZZ_MODE_STATE && \
+    FZF_SESSION_FUZZ_MODE != FZF_SESSION_FUZZ_MODE_READER
+#error "FZF_SESSION_FUZZ_MODE must be STATE (1) or READER (2)"
+#endif
+
+#if FZF_SESSION_FUZZ_MODE == FZF_SESSION_FUZZ_MODE_READER
+#define FZF_SESSION_FUZZ_MODE_NAME "reader"
+#else
+#define FZF_SESSION_FUZZ_MODE_NAME "state"
+#endif
 
 #define FZF_NATIVE_CTEST 1
 #include "../fzf-native-module.c"
@@ -19,11 +41,13 @@ enum {
   SESSION_FUZZ_MAX_CANDIDATES = 4097,
 };
 
+#if FZF_SESSION_FUZZ_MODE == FZF_SESSION_FUZZ_MODE_STATE
 typedef struct {
   const uint8_t *data;
   size_t size;
   size_t offset;
 } FuzzInput;
+#endif
 
 typedef struct {
   AsyncSession *session;
@@ -64,6 +88,7 @@ static void session_fuzz_check_candidate_analyzer(
     session_fuzz_fail(NULL, "candidate classification disagrees with scalar oracle");
 }
 
+#if FZF_SESSION_FUZZ_MODE == FZF_SESSION_FUZZ_MODE_STATE
 static uint8_t fuzz_take(FuzzInput *input) {
   return input->offset < input->size ? input->data[input->offset++] : 0;
 }
@@ -71,6 +96,7 @@ static uint8_t fuzz_take(FuzzInput *input) {
 static size_t fuzz_remaining(const FuzzInput *input) {
   return input->offset < input->size ? input->size - input->offset : 0;
 }
+#endif
 
 static AsyncSession *session_fuzz_create(uint8_t options) {
   AsyncSession *s = calloc(1, sizeof *s);
@@ -119,6 +145,7 @@ static AsyncSession *session_fuzz_create(uint8_t options) {
   return s;
 }
 
+#if FZF_SESSION_FUZZ_MODE == FZF_SESSION_FUZZ_MODE_READER
 static bool session_fuzz_write_all(int fd, const uint8_t *data, size_t size) {
   size_t offset = 0;
   while (offset < size) {
@@ -298,7 +325,9 @@ static void session_fuzz_reader_probe(const uint8_t *data, size_t size) {
   session_fuzz_reader_reference_free(&reference);
   async_session_destroy(s);
 }
+#endif
 
+#if FZF_SESSION_FUZZ_MODE == FZF_SESSION_FUZZ_MODE_STATE
 static char *fuzz_copy_string(FuzzInput *input, size_t requested,
                               size_t *out_len) {
   size_t len = requested < fuzz_remaining(input)
@@ -806,12 +835,16 @@ static void session_fuzz_run(const uint8_t *data, size_t size) {
   }
   async_session_destroy(session);
 }
+#endif
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   session_fuzz_check_candidate_analyzer(data, size);
+#if FZF_SESSION_FUZZ_MODE == FZF_SESSION_FUZZ_MODE_READER
   if (size <= SESSION_FUZZ_MAX_INPUT)
     session_fuzz_reader_probe(data, size);
+#else
   session_fuzz_run(data, size);
+#endif
   return 0;
 }
 
@@ -849,7 +882,8 @@ int main(int argc, char **argv) {
   if (argc < 2) return 2;
   for (int i = 1; i < argc; i++)
     if (session_fuzz_replay_file(argv[i]) != 0) return 1;
-  printf("Replayed %d interactive session corpus files.\n", argc - 1);
+  printf("Replayed %d interactive session %s corpus files.\n", argc - 1,
+         FZF_SESSION_FUZZ_MODE_NAME);
   return 0;
 }
 #endif

--- a/fuzz/fzf-native-session-fuzz.c
+++ b/fuzz/fzf-native-session-fuzz.c
@@ -284,6 +284,7 @@ static void session_fuzz_reader_probe(const uint8_t *data, size_t size) {
     for (size_t attempt = 0;
          atomic_load_explicit(&s->test_reader_poll_epoch,
                               memory_order_acquire) < target_epoch &&
+         !atomic_load_explicit(&s->reader_done, memory_order_acquire) &&
          attempt < 20000;
          attempt++)
       nanosleep(&pause, NULL);

--- a/fuzz/fzf-native-upstream-test.el
+++ b/fuzz/fzf-native-upstream-test.el
@@ -272,6 +272,13 @@ UPSTREAM-OUTPUT selects Go's malformed-byte output representation."
   "Return sorted membership for IDENTITIES."
   (sort (copy-sequence identities) #'<))
 
+(defun fzf-native-upstream--membership-difference (left right)
+  "Return sorted identities present in exactly one of LEFT and RIGHT."
+  (sort
+   (append (cl-set-difference left right :test #'=)
+           (cl-set-difference right left :test #'=))
+   #'<))
+
 (defun fzf-native-upstream--record-exception (table exception)
   "Record EXCEPTION in count TABLE."
   (let ((name (plist-get exception :name)))
@@ -435,6 +442,16 @@ Each specification has the form (KEY VALUES)."
                            :valid-utf8)
                    return case))
          (forged (copy-fzf-native-differential-case common))
+         (malformed-candidate
+          (cl-find-if
+           (lambda (candidate)
+             (fzf-native-differential--malformed-utf8-string-p
+              (fzf-native-differential-candidate-text candidate)))
+           (fzf-native-differential-case-candidates malformed)))
+         (malformed-identity
+          (fzf-native-differential-candidate-id
+           (or malformed-candidate
+               (car (fzf-native-differential-case-candidates malformed)))))
          boundary-exception ranking-exception malformed-exception)
     (setf (fzf-native-differential-case-dimensions forged)
           (plist-put
@@ -462,7 +479,9 @@ Each specification has the form (KEY VALUES)."
     (should (eq (plist-get ranking-exception :disposition)
                 'parity-debt))
     (setq malformed-exception
-          (fzf-native-differential-classify malformed 'membership))
+          (fzf-native-differential-classify
+           malformed 'membership
+           (list :differing-identities (list malformed-identity))))
     (should (eq (plist-get malformed-exception :name)
                 'malformed-utf8-decoder))
     (should (eq (plist-get malformed-exception :disposition)
@@ -483,7 +502,61 @@ Each specification has the form (KEY VALUES)."
       (should (stringp (plist-get entry :remove-when))))
     (should
      (equal (plist-get malformed-exception :scope)
-            "Only malformed-byte membership or positions with :valid-utf8 nil."))))
+            "Only differing malformed inputs for membership or positions."))))
+
+(ert-deftest fzf-native-fuzz-upstream-malformed-exceptions-are-difference-scoped ()
+  "Do not let an unrelated malformed candidate waive a valid difference."
+  (let* ((malformed-bytes (unibyte-string #xff))
+         (valid-candidate
+          (make-fzf-native-differential-candidate
+           :id 1 :text "valid" :role 'match))
+         (malformed-candidate
+          (make-fzf-native-differential-candidate
+           :id 2 :text malformed-bytes :role 'decoy))
+         (query
+          (make-fzf-native-differential-query
+           :sets nil :normalize nil :forward t))
+         (candidate-case
+          (make-fzf-native-differential-case
+           :query query
+           :rendered-query ""
+           :candidates (list valid-candidate malformed-candidate)
+           :dimensions '(:valid-utf8 nil)))
+         (query-case (copy-fzf-native-differential-case candidate-case))
+         exception)
+    (setf (fzf-native-differential-case-rendered-query query-case)
+          malformed-bytes)
+    ;; Candidate 2 is an unrelated malformed decoy when valid candidate 1 is
+    ;; the identity missing from one result.
+    (let ((difference
+           (fzf-native-upstream--membership-difference '(2) '(1 2))))
+      (should (equal difference '(1)))
+      (should-not
+       (fzf-native-differential-classify
+        candidate-case 'membership
+        (list :differing-identities difference))))
+    (setq exception
+          (fzf-native-differential-classify
+           candidate-case 'membership '(:differing-identities (2))))
+    (should (eq (plist-get exception :name) 'malformed-utf8-decoder))
+    (should-not
+     (fzf-native-differential-classify candidate-case 'membership))
+    (should-not
+     (fzf-native-differential-classify
+      candidate-case 'membership '(:differing-identities (99))))
+    (should-not
+     (fzf-native-differential-classify
+      candidate-case 'membership '(:differing-identities (1 2))))
+    ;; A malformed query can change how a known valid candidate is matched,
+    ;; but missing and unknown identity context must still fail closed.
+    (should
+     (fzf-native-differential-classify
+      query-case 'membership '(:differing-identities (1))))
+    (should-not
+     (fzf-native-differential-classify query-case 'membership))
+    (should-not
+     (fzf-native-differential-classify
+      query-case 'membership '(:differing-identities (99))))))
 
 (defconst fzf-native-upstream--session-candidate-bodies
   '("alpha"
@@ -759,7 +832,12 @@ Each specification has the form (KEY VALUES)."
             (should (memq 0 upstream-membership)))
           (unless membership-equal
             (let ((exception
-                   (fzf-native-differential-classify case 'membership)))
+                   (fzf-native-differential-classify
+                    case 'membership
+                    (list
+                     :differing-identities
+                     (fzf-native-upstream--membership-difference
+                      native-membership upstream-membership)))))
               (if exception
                   (progn
                     (fzf-native-upstream--record-exception exceptions exception)

--- a/fuzz/fzf-native-upstream-test.el
+++ b/fuzz/fzf-native-upstream-test.el
@@ -547,11 +547,15 @@ Each specification has the form (KEY VALUES)."
     (should-not
      (fzf-native-differential-classify
       candidate-case 'membership '(:differing-identities (1 2))))
-    ;; A malformed query can change how a known valid candidate is matched,
-    ;; but missing and unknown identity context must still fail closed.
-    (should
+    ;; A malformed query alone cannot attribute a valid-candidate difference
+    ;; to decoder policy.  A malformed differing candidate remains in scope,
+    ;; while missing and unknown identity context still fail closed.
+    (should-not
      (fzf-native-differential-classify
       query-case 'membership '(:differing-identities (1))))
+    (should
+     (fzf-native-differential-classify
+      query-case 'membership '(:differing-identities (2))))
     (should-not
      (fzf-native-differential-classify query-case 'membership))
     (should-not

--- a/fuzz/fzf-native-upstream-test.el
+++ b/fuzz/fzf-native-upstream-test.el
@@ -22,25 +22,57 @@
 
 ;;; Commentary:
 
-;; Compare randomized native-module results with the upstream fzf executable.
+;; Compare structured native-module results with the upstream fzf executable.
 
 ;;; Code:
 
 (require 'cl-lib)
 (require 'ert)
 (require 'fzf-native)
+(require 'subr-x)
+
+(let ((directory
+       (expand-file-name
+        "differential"
+        (file-name-directory (or load-file-name buffer-file-name)))))
+  (add-to-list 'load-path directory))
+
+(require 'fzf-native-differential-generator)
+(require 'fzf-native-differential-exceptions)
 
 (declare-function fzf-native-score-all "fzf-native-module"
                   (collection query &optional slab))
+(declare-function fzf-native-async-start "fzf-native-module"
+                  (command &optional directory))
+(declare-function fzf-native-async-stop "fzf-native-module" (handle))
+(declare-function fzf-native-async-submit "fzf-native-module"
+                  (handle query &optional limit))
+(declare-function fzf-native-async-snapshot "fzf-native-module"
+                  (handle &optional request-id))
+(declare-function fzf-native-async-status "fzf-native-module"
+                  (handle &optional request-id))
+(declare-function fzf-native--session-platform-p "fzf-native" ())
+(declare-function fzf-native--verify-initialized-module "fzf-native" ())
+(declare-function fzf-native--verify-session-abi "fzf-native" ())
 
 (let ((module (getenv "FZF_NATIVE_TEST_MODULE")))
   (if (and module (not (string-empty-p module)))
       (progn
         (module-load module)
+        (fzf-native--verify-initialized-module)
         (setq fzf-native-loaded t))
     (fzf-native-load-dyn)))
 
-(defvar fzf-native-upstream--state 1)
+(when (fzf-native--session-platform-p)
+  (dolist (function '(fzf-native-session-abi-version
+                      fzf-native-async-start
+                      fzf-native-async-stop
+                      fzf-native-async-submit
+                      fzf-native-async-snapshot
+                      fzf-native-async-status))
+    (unless (fboundp function)
+      (error "Required fzf-native session ABI function is missing: %S"
+             function))))
 
 (defun fzf-native-upstream--env-integer (name default)
   "Read non-negative integer NAME, or return DEFAULT."
@@ -49,75 +81,82 @@
         (string-to-number value)
       default)))
 
-(defun fzf-native-upstream--seed (seed)
-  "Initialize the deterministic generator with SEED."
-  (setq fzf-native-upstream--state (logand (max seed 1) #xffffffff)))
+(defun fzf-native-upstream--profile ()
+  "Return the requested differential profile."
+  (let ((name (or (getenv "FZF_NATIVE_UPSTREAM_PROFILE") "common")))
+    (pcase name
+      ("common" 'common)
+      ("parity" 'parity)
+      ("long" 'long)
+      (_ (error "Unknown FZF_NATIVE_UPSTREAM_PROFILE: %s" name)))))
 
-(defun fzf-native-upstream--random (limit)
-  "Return a deterministic integer in [0, LIMIT)."
-  (let ((x fzf-native-upstream--state))
-    (setq x (logxor x (ash x 13)))
-    (setq x (logxor x (ash x -17)))
-    (setq x (logxor x (ash x 5)))
-    (setq fzf-native-upstream--state (logand x #xffffffff))
-    (if (<= limit 0) 0 (% fzf-native-upstream--state limit))))
+(defun fzf-native-upstream--verify-reference (fzf)
+  "Verify the configured version and revision of FZF.
 
-(defconst fzf-native-upstream--pieces
-  ["a" "b" "c" "F" "K" "-" "_" "/" "." " " "\t"])
+`FZF_REFERENCE_VERSION' is an optional output prefix.
+`FZF_REFERENCE_REVISION' is an optional literal substring."
+  (let ((expected-version (getenv "FZF_REFERENCE_VERSION"))
+        (expected-revision (getenv "FZF_REFERENCE_REVISION"))
+        (actual (car (process-lines fzf "--version"))))
+    (when (and expected-version (not (string-empty-p expected-version)))
+      (should (string-prefix-p expected-version actual)))
+    (when (and expected-revision (not (string-empty-p expected-revision)))
+      (should (string-search expected-revision actual)))
+    actual))
 
-(defconst fzf-native-upstream--literals
-  ["a" "b" "f" "F" "k" "K" "foo" "bar" "src" "main"])
+(defun fzf-native-upstream--case-rng (seed serial)
+  "Return an independent deterministic generator for SEED and SERIAL."
+  (fzf-native-differential-rng-create
+   (logand (logxor seed #xa5a5a5a5
+                   (* (1+ serial) #x9e3779b9))
+           #xffffffff)))
 
-(defun fzf-native-upstream--candidate ()
-  "Generate one candidate accepted by fzf's NUL-delimited input."
-  (let ((count (fzf-native-upstream--random 12)) pieces)
-    (dotimes (_ count)
-      (push (aref fzf-native-upstream--pieces
-                  (fzf-native-upstream--random
-                   (length fzf-native-upstream--pieces)))
-            pieces))
-    (apply #'concat (nreverse pieces))))
+(defun fzf-native-upstream--generated-case (seed serial profile)
+  "Generate PROFILE case SERIAL through the public replay mapping for SEED."
+  (fzf-native-differential-generate-case
+   (fzf-native-upstream--case-rng seed serial) seed serial profile))
 
-(defun fzf-native-upstream--term ()
-  "Generate one extended-search term."
-  (concat (aref ["" "" "'" "^"]
-                (fzf-native-upstream--random 4))
-          (aref fzf-native-upstream--literals
-                (fzf-native-upstream--random
-                 (length fzf-native-upstream--literals)))
-          ""))
+(defun fzf-native-upstream--candidate-texts (case)
+  "Return candidate text from CASE in producer order."
+  (mapcar #'fzf-native-differential-candidate-text
+          (fzf-native-differential-case-candidates case)))
 
-(defun fzf-native-upstream--query ()
-  "Generate a small extended-search query."
-  (let ((count (1+ (fzf-native-upstream--random 4))) terms)
-    (dotimes (i count)
-      (push (fzf-native-upstream--term) terms)
-      (when (and (< i (1- count))
-                 (zerop (fzf-native-upstream--random 4)))
-        (push "|" terms)))
-    (mapconcat #'identity (nreverse terms) " ")))
-
-(defun fzf-native-upstream--keys (strings)
-  "Return a sorted, property-free multiset for STRINGS."
-  (sort (mapcar #'substring-no-properties (append strings nil)) #'string<))
-
-(defun fzf-native-upstream--fzf (fzf collection query case-mode fuzzy)
-  "Return matches from FZF for COLLECTION and QUERY using CASE-MODE and FUZZY."
-  (let ((args (append
-               (list "--read0" "--print0" "--no-sort" "--no-color"
-                     "--no-multi-line" "--literal"
-                     (concat "--filter=" query))
-               (pcase case-mode
-                 ('ignore '("--ignore-case"))
-                 ('respect '("--no-ignore-case"))
-                 (_ '("--smart-case")))
-               (unless fuzzy '("--exact"))))
-        (output (generate-new-buffer " *fzf-native-upstream*")))
+(defun fzf-native-upstream--fzf (fzf case)
+  "Return raw matches from FZF for CASE."
+  (let* ((query (fzf-native-differential-case-query case))
+         (collection (fzf-native-upstream--candidate-texts case))
+         (valid-utf8
+          (plist-get (fzf-native-differential-case-dimensions case)
+                     :valid-utf8))
+         (args
+          (append
+           (list "--read0" "--print0" "--no-color" "--no-multi-line"
+                 (concat "--filter="
+                         (fzf-native-differential-case-rendered-query case)))
+           (when (eq (fzf-native-differential-case-comparison case)
+                     'membership)
+             '("--no-sort"))
+           (unless (fzf-native-differential-query-normalize query)
+             '("--literal"))
+           (pcase (fzf-native-differential-query-case-mode query)
+             ('ignore '("--ignore-case"))
+             ('respect '("--no-ignore-case"))
+             (_ '("--smart-case")))
+           (unless (fzf-native-differential-query-fuzzy query)
+             '("--exact"))))
+         (output (generate-new-buffer " *fzf-native-upstream*")))
     (unwind-protect
         (with-temp-buffer
+          (unless valid-utf8
+            (set-buffer-multibyte nil))
           (insert (mapconcat #'identity collection "\0") "\0")
-          (let ((coding-system-for-write 'no-conversion)
-                (coding-system-for-read 'no-conversion)
+          (with-current-buffer output
+            (unless valid-utf8
+              (set-buffer-multibyte nil)))
+          (let ((coding-system-for-write
+                 (if valid-utf8 'utf-8-unix 'binary))
+                (coding-system-for-read
+                 (if valid-utf8 'utf-8-unix 'binary))
                 (status (apply #'call-process-region
                                (point-min) (point-max) fzf nil output nil
                                args)))
@@ -127,48 +166,629 @@
             (butlast (split-string (buffer-string) "\0" nil))))
       (kill-buffer output))))
 
-(ert-deftest fzf-native-fuzz-upstream-ascii-match-set ()
-  "Compare randomized ASCII match multisets with a pinned fzf CLI."
+(defun fzf-native-upstream--native (case)
+  "Return raw fzf-native matches for CASE."
+  (let* ((query (fzf-native-differential-case-query case))
+         (fzf-native-case-mode
+          (fzf-native-differential-query-case-mode query))
+         (fzf-native-fuzzy
+          (fzf-native-differential-query-fuzzy query))
+         (fzf-native-batch-highlight nil)
+         (fzf-native-filter-only-min-pool nil)
+         (fzf-native-filter-only-length nil))
+    (fzf-native-score-all
+     (mapcar #'copy-sequence (fzf-native-upstream--candidate-texts case))
+     (fzf-native-differential-case-rendered-query case))))
+
+(defun fzf-native-upstream--utf8-sequence-length (string index)
+  "Return valid UTF-8 sequence length in unibyte STRING at INDEX, or nil."
+  (let* ((size (length string))
+         (first (aref string index))
+         (second (and (< (1+ index) size) (aref string (1+ index)))))
+    (cond
+     ((<= first #x7f) 1)
+     ((and (<= #xc2 first) (<= first #xdf)
+           second (fzf-native-differential--utf8-continuation-p second))
+      2)
+     ((and (<= #xe0 first) (<= first #xef)
+           (< (+ index 2) size)
+           (cond
+            ((= first #xe0) (and (<= #xa0 second) (<= second #xbf)))
+            ((= first #xed) (and (<= #x80 second) (<= second #x9f)))
+            (t (fzf-native-differential--utf8-continuation-p second)))
+           (fzf-native-differential--utf8-continuation-p
+            (aref string (+ index 2))))
+      3)
+     ((and (<= #xf0 first) (<= first #xf4)
+           (< (+ index 3) size)
+           (cond
+            ((= first #xf0) (and (<= #x90 second) (<= second #xbf)))
+            ((= first #xf4) (and (<= #x80 second) (<= second #x8f)))
+            (t (fzf-native-differential--utf8-continuation-p second)))
+           (fzf-native-differential--utf8-continuation-p
+            (aref string (+ index 2)))
+           (fzf-native-differential--utf8-continuation-p
+            (aref string (+ index 3))))
+      4))))
+
+(defun fzf-native-upstream--go-output-bytes (string)
+  "Return Go range/output bytes for possibly malformed unibyte STRING."
+  (let ((string (if (multibyte-string-p string)
+                    (encode-coding-string string 'raw-text t)
+                  string)))
+    (let ((index 0)
+          (size (length string))
+          (replacement (unibyte-string #xef #xbf #xbd))
+          pieces)
+      (while (< index size)
+        (let ((sequence-length
+               (fzf-native-upstream--utf8-sequence-length string index)))
+          (if sequence-length
+              (progn
+                (push (substring string index (+ index sequence-length))
+                      pieces)
+                (setq index (+ index sequence-length)))
+            (push replacement pieces)
+            (setq index (1+ index)))))
+      (apply #'concat (nreverse pieces)))))
+
+(defun fzf-native-upstream--identity-table (case &optional upstream-output)
+  "Return a text-to-identity-queue table for CASE.
+
+When UPSTREAM-OUTPUT is non-nil, key malformed input by Go's output bytes."
+  (let ((table (make-hash-table :test #'equal)))
+    (dolist (candidate (fzf-native-differential-case-candidates case))
+      (let* ((raw (fzf-native-differential-candidate-text candidate))
+             (text (if (and upstream-output
+                            (not (plist-get
+                                  (fzf-native-differential-case-dimensions
+                                   case)
+                                  :valid-utf8)))
+                       (fzf-native-upstream--go-output-bytes raw)
+                     raw))
+             (identities (gethash text table)))
+        (puthash text
+                 (append identities
+                         (list (fzf-native-differential-candidate-id
+                                candidate)))
+                 table)))
+    table))
+
+(defun fzf-native-upstream--identities (case strings &optional upstream-output)
+  "Map returned STRINGS to stable candidate identities from CASE.
+
+UPSTREAM-OUTPUT selects Go's malformed-byte output representation."
+  (let ((table (fzf-native-upstream--identity-table case upstream-output))
+        result)
+    (dolist (string (append strings nil) (nreverse result))
+      (let* ((plain (substring-no-properties string))
+             (queue (gethash plain table)))
+        (unless queue
+          (error "Matcher returned an unknown candidate: %S" plain))
+        (puthash plain (cdr queue) table)
+        (push (car queue) result)))))
+
+(defun fzf-native-upstream--membership (identities)
+  "Return sorted membership for IDENTITIES."
+  (sort (copy-sequence identities) #'<))
+
+(defun fzf-native-upstream--record-exception (table exception)
+  "Record EXCEPTION in count TABLE."
+  (let ((name (plist-get exception :name)))
+    (puthash name (1+ (gethash name table 0)) table)))
+
+(defun fzf-native-upstream--accepted-exception-p (exception)
+  "Return non-nil only for a documented, accepted EXCEPTION."
+  (eq (plist-get exception :disposition) 'accepted))
+
+(defun fzf-native-upstream--exception-alist (table)
+  "Return sorted exception counts from TABLE."
+  (let (entries)
+    (maphash (lambda (name count) (push (cons name count) entries)) table)
+    (sort entries (lambda (left right)
+                    (string< (symbol-name (car left))
+                             (symbol-name (car right)))))))
+
+(defun fzf-native-upstream--dimension-value (case key)
+  "Return dimension KEY from CASE, including query options."
+  (let ((query (fzf-native-differential-case-query case))
+        (dimensions (fzf-native-differential-case-dimensions case)))
+    (pcase key
+      (:case-mode (fzf-native-differential-query-case-mode query))
+      (:fuzzy (fzf-native-differential-query-fuzzy query))
+      (_ (plist-get dimensions key)))))
+
+(defun fzf-native-upstream--assert-pairwise-coverage (cases specifications)
+  "Assert pairwise SPECIFICATIONS coverage across CASES.
+
+Each specification has the form (KEY VALUES)."
+  (cl-loop
+   for tail on specifications
+   for left = (car tail)
+   do
+   (dolist (right (cdr tail))
+     (dolist (left-value (cadr left))
+       (dolist (right-value (cadr right))
+         (should
+          (cl-some
+           (lambda (case)
+             (and
+              (equal (fzf-native-upstream--dimension-value
+                      case (car left))
+                     left-value)
+              (equal (fzf-native-upstream--dimension-value
+                      case (car right))
+                     right-value)))
+           cases)))))))
+
+(ert-deftest fzf-native-fuzz-upstream-generator-is-deterministic ()
+  "Cover query, text, length, rank, and identity dimensions deterministically."
+  (let* ((seed 424242)
+         (left
+          (cl-loop for serial below 6000
+                   collect (fzf-native-upstream--generated-case
+                            seed serial 'common)))
+         (right
+          (cl-loop for serial below 6000
+                   collect (fzf-native-upstream--generated-case
+                            seed serial 'common)))
+         (replay-start 733)
+         (replay-count 20)
+         (replay
+          (cl-loop for serial from replay-start
+                   below (+ replay-start replay-count)
+                   collect (fzf-native-upstream--generated-case
+                            seed serial 'common)))
+         (long-cases
+          (cl-loop for serial below 3
+                   collect (fzf-native-upstream--generated-case
+                            seed serial 'long)))
+         text-classes length-targets query-shapes primary-kinds rank-shapes)
+    (should
+     (equal (mapcar #'fzf-native-differential-case-description left)
+            (mapcar #'fzf-native-differential-case-description right)))
+    (should
+     (equal
+      (mapcar #'fzf-native-differential-case-description replay)
+      (mapcar #'fzf-native-differential-case-description
+              (seq-take (nthcdr replay-start left) replay-count))))
+    (dolist (case left)
+      (let ((dimensions (fzf-native-differential-case-dimensions case))
+            (ids (mapcar #'fzf-native-differential-candidate-id
+                         (fzf-native-differential-case-candidates case)))
+            (texts (fzf-native-upstream--candidate-texts case)))
+        (push (plist-get dimensions :text-class) text-classes)
+        (push (plist-get dimensions :needle-length) length-targets)
+        (push (plist-get dimensions :query-shape) query-shapes)
+        (push (plist-get dimensions :primary-kind) primary-kinds)
+        (push (plist-get dimensions :rank-shape) rank-shapes)
+        (should (equal ids (number-sequence 0 (1- (length ids)))))
+        (should (> (length texts)
+                   (length (delete-dups (copy-sequence texts)))))
+        (should-not
+         (string-search "\0"
+                        (fzf-native-differential-case-rendered-query case)))))
+    (dolist (class '(ascii unicode malformed))
+      (should (memq class text-classes)))
+    (dolist (target '(1 2 7 31 32 63 64))
+      (should (memq target length-targets)))
+    (dolist (shape '(empty single and or inverse mixed))
+      (should (memq shape query-shapes)))
+    (dolist (kind '(fuzzy exact prefix suffix equal))
+      (should (memq kind primary-kinds)))
+    (dolist (shape '(front middle tail ambiguous))
+      (should (memq shape rank-shapes)))
+    (fzf-native-upstream--assert-pairwise-coverage
+     (cl-remove-if
+      (lambda (case)
+        (eq (fzf-native-upstream--dimension-value case :query-shape)
+            'empty))
+      left)
+     '((:text-class (ascii unicode malformed))
+       (:query-shape (single and or inverse mixed))
+       (:primary-kind (fuzzy exact prefix suffix equal))
+       (:case-mode (smart ignore respect))
+       (:fuzzy (nil t))
+       (:rank-shape (front middle tail ambiguous))
+       (:needle-length (1 2 7 31 32 63 64))))
+    (cl-loop for case in long-cases
+             for expected in '(999 1000 1001)
+             for primary = (caar
+                            (fzf-native-differential-query-sets
+                             (fzf-native-differential-case-query case)))
+             do (should
+                 (= expected
+                    (length
+                     (fzf-native-differential-term-literal primary)))))))
+
+(ert-deftest fzf-native-fuzz-upstream-exceptions-are-narrow ()
+  "Reject broad exceptions for ordinary common-profile membership."
+  (let* ((seed 73)
+         (common
+          (cl-loop for serial below 100
+                   for case = (fzf-native-upstream--generated-case
+                               seed serial 'common)
+                   when (plist-get
+                         (fzf-native-differential-case-dimensions case)
+                         :valid-utf8)
+                   return case))
+         (boundary
+          (cl-loop for serial below 1000
+                   for case = (fzf-native-upstream--generated-case
+                               seed serial 'parity)
+                   when (fzf-native-differential--case-has-kind-p
+                         case 'boundary-exact)
+                   return case))
+         (ranking
+          (cl-loop for serial below 1000
+                   for case = (fzf-native-upstream--generated-case
+                               seed serial 'parity)
+                   when (eq (fzf-native-differential-case-comparison case)
+                            'ranking)
+                   return case))
+         (malformed
+          (cl-loop for serial below 1000
+                   for case = (fzf-native-upstream--generated-case
+                               seed serial 'common)
+                   unless (plist-get
+                           (fzf-native-differential-case-dimensions case)
+                           :valid-utf8)
+                   return case))
+         (forged (copy-fzf-native-differential-case common))
+         boundary-exception ranking-exception malformed-exception)
+    (setf (fzf-native-differential-case-dimensions forged)
+          (plist-put
+           (copy-sequence
+            (fzf-native-differential-case-dimensions forged))
+           :valid-utf8 nil))
+    (should-not
+     (fzf-native-differential-classify common 'membership))
+    (should-not
+     (fzf-native-differential-classify forged 'membership))
+    (setq boundary-exception
+          (fzf-native-differential-classify boundary 'membership))
+    (should (eq (plist-get boundary-exception :name)
+                'exact-boundary-syntax))
+    (should (eq (plist-get boundary-exception :disposition)
+                'parity-debt))
+    (should-not
+     (fzf-native-differential-classify
+      ranking 'ranking '(:membership-equal nil)))
+    (setq ranking-exception
+          (fzf-native-differential-classify
+           ranking 'ranking '(:membership-equal t)))
+    (should (eq (plist-get ranking-exception :name)
+                'score-ranking-revision))
+    (should (eq (plist-get ranking-exception :disposition)
+                'parity-debt))
+    (setq malformed-exception
+          (fzf-native-differential-classify malformed 'membership))
+    (should (eq (plist-get malformed-exception :name)
+                'malformed-utf8-decoder))
+    (should (eq (plist-get malformed-exception :disposition)
+                'accepted))
+    (should
+     (equal
+      (mapcar (lambda (entry) (plist-get entry :name))
+              (cl-remove-if-not
+               (lambda (entry)
+                 (eq (plist-get entry :disposition) 'accepted))
+               fzf-native-differential-exceptions))
+      '(malformed-utf8-decoder)))
+    (dolist (entry fzf-native-differential-exceptions)
+      (should
+       (equal (plist-get entry :upstream-revision)
+              fzf-native-differential-upstream-revision))
+      (should (stringp (plist-get entry :owner)))
+      (should (stringp (plist-get entry :remove-when))))
+    (should
+     (equal (plist-get malformed-exception :scope)
+            "Only malformed-byte membership or positions with :valid-utf8 nil."))))
+
+(defconst fzf-native-upstream--session-candidate-bodies
+  '("alpha"
+    "alphabet soup"
+    "alphanumeric"
+    "alpine trail"
+    "beta alpha"
+    "beta"
+    "gamma"
+    "FOO alpha"
+    "foo beta"
+    "Food"
+    "prefix FOO suffix"
+    "σ alpha"
+    "Σ beta"
+    "κόσμος"
+    "中文 alpha"
+    "中間 beta"
+    "😀 alpha"
+    "café"
+    "CAFÉ beta"
+    "kelvin k"
+    "Kelvin K"
+    "literal pipe"
+    "inverse bang")
+  "Stable candidate bodies for persistent-session comparisons.")
+
+(defconst fzf-native-upstream--session-rounds
+  '((:name broad :query "a" :case-mode smart :fuzzy t)
+    (:name narrow :query "al" :case-mode smart :fuzzy t)
+    (:name narrower :query "alp" :case-mode smart :fuzzy t)
+    (:name broaden :query "a" :case-mode smart :fuzzy t)
+    (:name repeat :query "a" :case-mode smart :fuzzy t)
+    (:name or :query "alpha | beta" :case-mode smart :fuzzy t)
+    (:name inverse :query "a !beta" :case-mode smart :fuzzy t)
+    (:name case-ignore :query "FOO" :case-mode ignore :fuzzy t)
+    (:name case-respect :query "FOO" :case-mode respect :fuzzy t)
+    (:name global-exact :query "alpha" :case-mode smart :fuzzy nil)
+    (:name unicode-fold :query "σ" :case-mode ignore :fuzzy t)
+    (:name unicode-case :query "Σ" :case-mode respect :fuzzy t)
+    (:name unicode-cjk :query "中" :case-mode smart :fuzzy t)
+    (:name unicode-kelvin :query "K" :case-mode ignore :fuzzy t))
+  "Ordered query rounds for one persistent native session.")
+
+(defun fzf-native-upstream--shuffle (rng values)
+  "Return a deterministic shuffled copy of VALUES using RNG."
+  (let ((items (vconcat values)))
+    (cl-loop for index downfrom (1- (length items)) above 0
+             for swap = (fzf-native-differential-random rng (1+ index))
+             do (cl-rotatef (aref items index) (aref items swap)))
+    (append items nil)))
+
+(defun fzf-native-upstream--session-candidates (seed serial)
+  "Return a deterministic candidate pool for SEED and SERIAL."
+  (let ((rng (fzf-native-upstream--case-rng seed serial)) decoys)
+    (dotimes (index 7)
+      (push (format "noise-%08x-%02d-%02d"
+                    (fzf-native-differential-random rng #xffffffff)
+                    serial index)
+            decoys))
+    (cl-loop
+     for text in
+     (fzf-native-upstream--shuffle
+      rng (append fzf-native-upstream--session-candidate-bodies decoys))
+     for id from 0
+     collect (make-fzf-native-differential-candidate
+              :id id :text text :role 'session))))
+
+(defun fzf-native-upstream--session-case
+    (seed serial round candidates)
+  "Return an oracle case for SEED, SERIAL, ROUND, and CANDIDATES."
+  (let ((query
+         (make-fzf-native-differential-query
+          :sets nil
+          :case-mode (plist-get round :case-mode)
+          :fuzzy (plist-get round :fuzzy)
+          :normalize nil
+          :forward t)))
+    (make-fzf-native-differential-case
+     :seed seed
+     :serial serial
+     :profile 'session
+     :query query
+     :rendered-query (plist-get round :query)
+     :candidates candidates
+     :dimensions (list :round (plist-get round :name)
+                       :valid-utf8 t
+                       :producer-eof t)
+     :comparison 'membership)))
+
+(defun fzf-native-upstream--wait-for-producer-eof (handle &optional timeout)
+  "Wait for producer EOF on HANDLE for at most TIMEOUT seconds."
+  (let ((deadline (+ (float-time) (or timeout 10.0))) status)
+    (while (and (< (float-time) deadline)
+                (progn
+                  (setq status (fzf-native-async-status handle))
+                  (not (plist-get status :reader-done))))
+      (sleep-for 0.01))
+    (unless (and status (plist-get status :reader-done))
+      (error "Timed out waiting for fzf-native producer EOF: %S" status))
+    status))
+
+(defun fzf-native-upstream--wait-for-session-request
+    (handle request-id &optional timeout)
+  "Wait for REQUEST-ID on HANDLE for at most TIMEOUT seconds."
+  (let ((deadline (+ (float-time) (or timeout 10.0))) status)
+    (while (and (< (float-time) deadline)
+                (progn
+                  (setq status (fzf-native-async-status handle request-id))
+                  (or (memq (plist-get status :state) '(queued running))
+                      (and (eq (plist-get status :state) 'complete)
+                           (plist-get status :stale)))))
+      (sleep-for 0.01))
+    (when (or (memq (plist-get status :state) '(queued running))
+              (and (eq (plist-get status :state) 'complete)
+                   (plist-get status :stale)))
+      (error "Timed out waiting for fzf-native request %d: %S"
+             request-id status))
+    (fzf-native-async-snapshot handle request-id)))
+
+(defun fzf-native-upstream--write-session-input (file candidates)
+  "Write CANDIDATES as UTF-8 lines to FILE."
+  (let ((coding-system-for-write 'utf-8-unix))
+    (with-temp-file file
+      (dolist (candidate candidates)
+        (insert (fzf-native-differential-candidate-text candidate) "\n")))))
+
+(ert-deftest fzf-native-fuzz-upstream-session-rounds ()
+  "Compare identity sets from one native session with fresh fzf processes."
   (let* ((fzf (or (getenv "FZF_REFERENCE") (executable-find "fzf")))
-         (expected-version (getenv "FZF_REFERENCE_VERSION"))
+         (cat (executable-find "cat"))
+         (seed (fzf-native-upstream--env-integer
+                "FZF_NATIVE_FUZZ_SEED" 12648430))
+         (cases (fzf-native-upstream--env-integer
+                 "FZF_NATIVE_UPSTREAM_SESSION_CASES" 4))
+         (start (fzf-native-upstream--env-integer
+                 "FZF_NATIVE_UPSTREAM_SESSION_START" 0)))
+    (skip-unless (and fzf cat
+                      (fboundp 'fzf-native-async-start)
+                      (fboundp 'fzf-native-async-submit)
+                      (fboundp 'fzf-native-async-snapshot)))
+    (should (> cases 0))
+    (fzf-native-upstream--verify-reference fzf)
+    (dotimes (iteration cases)
+      (let* ((serial (+ start iteration))
+             (candidates
+              (fzf-native-upstream--session-candidates seed serial))
+             (input (make-temp-file "fzf-native-upstream-session-"
+                                    nil ".txt"))
+             (starts (make-temp-file "fzf-native-upstream-starts-"
+                                     nil ".txt"))
+             handle
+             (last-request-id 0))
+        (unwind-protect
+            (let ((fzf-native-max-line-length nil)
+                  (fzf-native-async-cache-size 40)
+                  (fzf-native-async-cache-bytes (* 4 1024 1024))
+                  (fzf-native-async-batch-cache-bytes (* 4 1024 1024))
+                  (fzf-native-filter-only-min-pool nil)
+                  (fzf-native-filter-only-length nil)
+                  (fzf-native-async-highlight nil))
+              (fzf-native-upstream--write-session-input input candidates)
+              (setq handle
+                    (fzf-native-async-start
+                     (format "printf 'start\\n' >> %s; exec %s -- %s"
+                             (shell-quote-argument starts)
+                             (shell-quote-argument cat)
+                             (shell-quote-argument input))))
+              (let ((producer
+                     (fzf-native-upstream--wait-for-producer-eof handle)))
+                (should (eq (plist-get producer :producer-state) 'complete))
+                (should (= (plist-get producer :producer-exit-status) 0))
+                (should (= (plist-get producer :pool-generation)
+                           (length candidates)))
+                (with-temp-buffer
+                  (insert-file-contents-literally starts)
+                  (should (equal (buffer-string) "start\n"))))
+              (cl-loop
+               for round in fzf-native-upstream--session-rounds
+               for round-index from 0
+               do
+               (let* ((case
+                       (fzf-native-upstream--session-case
+                        seed serial round candidates))
+                      (query (plist-get round :query))
+                      (fzf-native-case-mode (plist-get round :case-mode))
+                      (fzf-native-fuzzy (plist-get round :fuzzy))
+                      (request-id
+                       (fzf-native-async-submit handle query 0))
+                      (snapshot
+                       (fzf-native-upstream--wait-for-session-request
+                        handle request-id))
+                      ;; Ranking remains explicit parity debt.  This lane is
+                      ;; strict about the complete set of candidate identities.
+                      (native
+                       (fzf-native-upstream--membership
+                        (fzf-native-upstream--identities
+                         case (plist-get snapshot :candidates))))
+                      (upstream
+                       (fzf-native-upstream--membership
+                        (fzf-native-upstream--identities
+                         case (fzf-native-upstream--fzf fzf case) t))))
+                 (ert-info
+                     ((format
+                       "seed=%d serial=%d round=%d name=%S query=%S mode=%S fuzzy=%S"
+                       seed serial round-index (plist-get round :name)
+                       query fzf-native-case-mode fzf-native-fuzzy))
+                   (if (eq (plist-get round :name) 'repeat)
+                       (should (= request-id last-request-id))
+                     (should (> request-id last-request-id)))
+                   (should (eq (plist-get snapshot :state) 'complete))
+                   (should (= (plist-get snapshot :result-request-id)
+                              request-id))
+                   (should-not (plist-get snapshot :stale))
+                   (should (plist-get snapshot :reader-done))
+                   (should (eq (plist-get snapshot :producer-state)
+                               'complete))
+                   (should (= (plist-get snapshot :pool-generation)
+                              (length candidates)))
+                   (should (= (plist-get snapshot :result-pool-generation)
+                              (length candidates)))
+                   (should (= (plist-get snapshot :total)
+                              (length candidates)))
+                   (should (= (plist-get snapshot :filtered)
+                              (length native)))
+                   (should (equal (plist-get snapshot :query) query))
+                   (should (eq (plist-get snapshot :case-mode)
+                               fzf-native-case-mode))
+                   (should (eq (plist-get snapshot :fuzzy)
+                               fzf-native-fuzzy))
+                   (should upstream)
+                   (should (equal native upstream)))
+                 (setq last-request-id request-id))))
+          (when handle
+            (fzf-native-async-stop handle))
+          (when (file-exists-p input)
+            (delete-file input))
+          (when (file-exists-p starts)
+            (delete-file starts)))))))
+
+(ert-deftest fzf-native-fuzz-upstream-structured-query-results ()
+  "Compare deterministic parsed-query results with a pinned fzf CLI."
+  (let* ((fzf (or (getenv "FZF_REFERENCE") (executable-find "fzf")))
          (seed (fzf-native-upstream--env-integer
                 "FZF_NATIVE_FUZZ_SEED" 12648430))
          (cases (fzf-native-upstream--env-integer
                  "FZF_NATIVE_UPSTREAM_CASES" 200))
-         (fixed '("" "a" "A" "alpha" " foo" "foo " "foo.bar"
-                  "src/main.c" "src-test")))
+         (start (fzf-native-upstream--env-integer
+                 "FZF_NATIVE_UPSTREAM_START" 0))
+         (profile (fzf-native-upstream--profile))
+         (exceptions (make-hash-table :test #'eq)))
     (skip-unless fzf)
-    (when (and expected-version (not (string-empty-p expected-version)))
-      (let ((actual (car (process-lines fzf "--version"))))
-        (should (string-prefix-p expected-version actual))))
-    (fzf-native-upstream--seed (logxor seed #xa5a5a5a5))
+    (fzf-native-upstream--verify-reference fzf)
     (dotimes (iteration cases)
-      (let* ((fzf-native-case-mode
-              (aref [smart ignore respect]
-                    (fzf-native-upstream--random 3)))
-             (fzf-native-fuzzy
-              (not (zerop (fzf-native-upstream--random 2))))
-             (collection
-              (append fixed
-                      (cl-loop repeat (fzf-native-upstream--random 24)
-                               collect (fzf-native-upstream--candidate))))
-             (query (fzf-native-upstream--query))
-             (fzf-native-batch-highlight nil)
-             (fzf-native-filter-only-min-pool nil)
-             (fzf-native-filter-only-length nil)
-             (native
-              (fzf-native-upstream--keys
-               (fzf-native-score-all
-                (mapcar #'copy-sequence collection) query)))
-             (upstream
-              (fzf-native-upstream--keys
-               (fzf-native-upstream--fzf
-                fzf collection query fzf-native-case-mode
-                fzf-native-fuzzy))))
-        (ert-info ((format "seed=%d iteration=%d mode=%S fuzzy=%S query=%S collection=%S"
-                           seed iteration fzf-native-case-mode
-                           fzf-native-fuzzy query collection))
-          (should (equal native upstream)))))))
+      (let* ((serial (+ start iteration))
+             (case
+              (fzf-native-upstream--generated-case seed serial profile))
+             (native-order
+              (fzf-native-upstream--identities
+               case (fzf-native-upstream--native case)))
+             (upstream-order
+             (fzf-native-upstream--identities
+               case (fzf-native-upstream--fzf fzf case) t))
+             (native-membership
+              (fzf-native-upstream--membership native-order))
+             (upstream-membership
+              (fzf-native-upstream--membership upstream-order))
+             (membership-equal
+              (equal native-membership upstream-membership)))
+        (ert-info ((fzf-native-differential-case-description case))
+          (when (plist-get (fzf-native-differential-case-dimensions case)
+                           :valid-utf8)
+            (should (memq 0 upstream-membership)))
+          (unless membership-equal
+            (let ((exception
+                   (fzf-native-differential-classify case 'membership)))
+              (if exception
+                  (progn
+                    (fzf-native-upstream--record-exception exceptions exception)
+                    (unless (fzf-native-upstream--accepted-exception-p exception)
+                      (should (equal native-membership upstream-membership))))
+                (should (equal native-membership upstream-membership)))))
+          (when (and membership-equal
+                     (eq (fzf-native-differential-case-comparison case)
+                         'ranking)
+                     (not (equal native-order upstream-order)))
+            (let ((exception
+                   (fzf-native-differential-classify
+                    case 'ranking '(:membership-equal t))))
+              (if exception
+                  (progn
+                    (fzf-native-upstream--record-exception exceptions exception)
+                    (unless (fzf-native-upstream--accepted-exception-p exception)
+                      (should (equal native-order upstream-order))))
+                (should (equal native-order upstream-order))))))))
+    (let ((summary (fzf-native-upstream--exception-alist exceptions)))
+      (when (eq profile 'common)
+        (dolist (count summary)
+          (let ((entry
+                 (cl-find (car count) fzf-native-differential-exceptions
+                          :key (lambda (item) (plist-get item :name)))))
+            (should (fzf-native-upstream--accepted-exception-p entry)))))
+      (message
+       "fzf-native upstream differential seed=%d start=%d profile=%S cases=%d exceptions=%S"
+       seed start profile cases summary))))
 
 (provide 'fzf-native-upstream-test)
 ;;; fzf-native-upstream-test.el ends here

--- a/fuzz/oracle/README.org
+++ b/fuzz/oracle/README.org
@@ -1,0 +1,212 @@
+#+title: Raw fzf oracle
+
+* Purpose
+
+This program runs the raw matching algorithms from a pinned junegunn/fzf source tree.
+It keeps one process active for many requests.
+It does not copy or reimplement the upstream algorithms.
+
+The pinned upstream commit is =1372d04f79bde0daa3bab4b96a068baafa808e67=.
+The =go.mod= file also pins the corresponding Go pseudo-version.
+The INFO response reports the Go version.
+The build and test scripts require Go =1.27.1=.
+
+This oracle covers raw matching only.
+It does not cover the fzf query parser, result ranking, or interactive state.
+
+* Build
+
+Check out the pinned fzf commit in a separate directory.
+Then run this command:
+
+#+begin_src sh
+./fuzz/oracle/build.sh /path/to/fzf /tmp/fzf-raw-oracle
+#+end_src
+
+The build script checks the commit of the source tree.
+It archives that commit into a temporary directory.
+It copies the required Go modules into a temporary vendor directory.
+It removes local paths and Go build identifiers from the executable.
+It copies the dependency checksums from the pinned source tree.
+Dirty source files cannot change the oracle.
+Two builds in the same build environment produce identical executable files.
+The script does not change the source tree or the committed =go.mod= file.
+
+* Run
+
+Start one process for each scoring scheme that the client uses:
+
+#+begin_src sh
+/tmp/fzf-raw-oracle --scheme=default
+/tmp/fzf-raw-oracle --scheme=path
+/tmp/fzf-raw-oracle --scheme=history
+#+end_src
+
+The upstream initialization function changes package-global scoring data.
+Thus, one process accepts only the scheme that its =--scheme= option selects.
+
+The process reads framed requests from standard input.
+It writes one framed response to standard output for each complete request.
+A bad request produces an error response and does not stop the process.
+A truncated frame or an input error stops the process.
+
+* Frame format
+
+All integers use network byte order.
+Each message starts with an unsigned 32-bit payload length.
+The payload follows this length immediately.
+The maximum payload length is 64 MiB.
+
+Every request starts with these fields:
+
+| Size | Field |
+|------+-------|
+| 1 | Protocol version. The value is =1=. |
+| 1 | Operation code. |
+
+** INFO request
+
+The INFO operation code is =0=.
+The request contains only the common two-byte prefix.
+
+A successful INFO response contains these fields:
+
+| Size | Field |
+|------+-------|
+| 1 | Protocol version. |
+| 1 | Operation code =0=. |
+| 1 | Status =0=. |
+| 4 | Implementation-revision length. |
+| variable | The ASCII implementation revision. |
+| 4 | Build-runtime string length. |
+| variable | The UTF-8 build-runtime string. |
+
+** MATCH request
+
+The MATCH operation code is =1=.
+The request contains these fields:
+
+| Size | Field |
+|------+-------|
+| 1 | Protocol version =1=. |
+| 1 | Operation code =1=. |
+| 1 | Algorithm identifier. |
+| 1 | Scheme identifier. |
+| 1 | Match flags. |
+| 4 | Pattern length. |
+| 4 | Candidate length. |
+| variable | Pattern bytes. |
+| variable | Candidate bytes. |
+
+The algorithm identifiers have these values:
+
+| Value | Algorithm |
+|-------+-----------|
+| 0 | =FuzzyMatchV1= |
+| 1 | =FuzzyMatchV2= |
+| 2 | =ExactMatchNaive= |
+| 3 | =ExactMatchBoundary= |
+| 4 | =PrefixMatch= |
+| 5 | =SuffixMatch= |
+| 6 | =EqualMatch= |
+
+The scheme identifiers are =0= for default, =1= for path, and =2= for history.
+The request scheme must match the process scheme.
+
+The match flags use these bits:
+
+| Bit | Meaning |
+|-----+---------|
+| 0 | Use a case-sensitive match. |
+| 1 | Normalize the pattern and candidate. |
+| 2 | Search in the forward direction. |
+
+All other flag bits must be zero.
+The oracle converts a case-insensitive pattern to lowercase before the match.
+If bit 1 is set, the oracle also normalizes the pattern.
+These operations satisfy the upstream algorithm contract.
+
+A successful MATCH response contains these fields:
+
+| Size | Field |
+|------+-------|
+| 1 | Protocol version =1=. |
+| 1 | Operation code =1=. |
+| 1 | Status =0=. |
+| 1 | Membership. The value is =0= or =1=. |
+| 1 | Position presence. The value is =0= or =1=. |
+| 8 | Signed match-start index. |
+| 8 | Signed match-end index. |
+| 8 | Signed score. |
+| 4 | Position count. |
+| 8 each | Signed position indexes in ascending order. |
+
+Indexes count decoded Go code points, not UTF-8 bytes or grapheme clusters.
+Malformed UTF-8 bytes decode according to =utf8.DecodeRune= in Go.
+Different malformed bytes can therefore compare as the same replacement code point.
+
+The position-presence field distinguishes a nil upstream position list from an empty list.
+Some contiguous match algorithms return a nil list.
+Clients can derive those positions from the half-open match range.
+
+** Error response
+
+An error response contains these fields:
+
+| Size | Field |
+|------+-------|
+| 1 | Protocol version =1=. |
+| 1 | The request operation code. The fallback value is =255=. |
+| 1 | Status. The value is =1= for a bad request, =2= for an unsupported request, or =3= for an internal error. |
+| 4 | Error-string length. |
+| variable | The UTF-8 error string. |
+
+* Checks
+
+Run the complete sanitizer check from the repository root:
+
+#+begin_src sh
+make FZF_SOURCE=/path/to/fzf FUZZ_CC=clang fuzz-oracle-test-san
+#+end_src
+
+The Make target builds both persistent executables.
+It supplies the executable paths and the expected native revision to the checks.
+
+Run the oracle-only checks with this command:
+
+#+begin_src sh
+./fuzz/oracle/test.sh /path/to/fzf
+#+end_src
+
+The direct command skips native differential checks by default.
+
+The checks include a persistent two-request exchange and exact wire-byte comparisons.
+They also cover V2 alignment, nil positions, malformed UTF-8, bad requests, and frame limits.
+Each exchange has a five-second time limit.
+The process also has a five-second exit time limit.
+The checks compare two separate oracle builds for identical bytes.
+
+Set =FZF_NATIVE_ALGO_DRIVER= to the path of the native peer for differential checks.
+Also set =FZF_RAW_ORACLE_BINARY= and =FZF_NATIVE_EXPECTED_REVISION=.
+The matrix sends each request to both persistent executables.
+They compare strict Unicode results and a matrix of membership results.
+Named checks record score, alignment, normalization, and malformed UTF-8 gaps.
+Delete each gap check after fzf-native gains parity for that case.
+
+The default raw membership matrix runs 20,000 deterministic cases.
+It includes ASCII, valid Unicode, case folds, and V2 fallback boundaries.
+It rejects every membership difference.
+Use these variables to replay part of the matrix:
+
+| Variable | Default | Meaning |
+|----------+---------+---------|
+| =FZF_RAW_MATRIX_SEED= | =20260906= | Generator seed. |
+| =FZF_RAW_MATRIX_START= | =0= | First serial number. |
+| =FZF_RAW_MATRIX_CASES= | =20000= | Number of cases. |
+| =FZF_RAW_MATRIX_FULL_RESULTS= | unset | Set to =1= to fail on score, range, or position debt. |
+
+The full-result mode is a parity audit.
+It currently fails on known score and position debt.
+The audit runs all selected cases before it reports the failure.
+The failure gives the first eight differences in a compact format.
+Use the reported serial number with =FZF_RAW_MATRIX_START= to run one case.

--- a/fuzz/oracle/build.sh
+++ b/fuzz/oracle/build.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+pin=1372d04f79bde0daa3bab4b96a068baafa808e67
+go_pin=go1.27.1
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "usage: $0 FZF_SOURCE [OUTPUT]" >&2
+  exit 2
+fi
+
+source_dir=$(CDPATH= cd -- "$1" && pwd)
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+output=${2:-"$script_dir/fzf-raw-oracle"}
+case "$output" in
+  /*) ;;
+  *) output="$PWD/$output" ;;
+esac
+
+source_commit=$(git -C "$source_dir" rev-parse HEAD)
+if [ "$source_commit" != "$pin" ]; then
+  echo "fzf source is at $source_commit; expected $pin" >&2
+  exit 2
+fi
+
+go_version=$(go env GOVERSION)
+if [ "$go_version" != "$go_pin" ]; then
+  echo "Go version is $go_version; expected $go_pin" >&2
+  exit 2
+fi
+
+temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/fzf-raw-oracle.XXXXXX")
+trap 'rm -rf "$temp_dir"' EXIT HUP INT TERM
+
+build_dir=$temp_dir/build
+"$script_dir/prepare.sh" "$source_dir" "$build_dir"
+
+cd "$build_dir"
+GOWORK=off go build -mod=vendor -trimpath -buildvcs=false \
+  -ldflags=-buildid= -o "$output" .

--- a/fuzz/oracle/go.mod
+++ b/fuzz/oracle/go.mod
@@ -1,0 +1,5 @@
+module github.com/dangduc/fzf-native/fuzz/oracle
+
+go 1.23.0
+
+require github.com/junegunn/fzf v0.74.4-0.20260906022717-1372d04f79bd

--- a/fuzz/oracle/main.go
+++ b/fuzz/oracle/main.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+	schemeName := flag.String("scheme", "default", "fixed scoring scheme: default, path, or history")
+	flag.Parse()
+	if flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "fzf-raw-oracle does not accept positional arguments")
+		os.Exit(2)
+	}
+
+	scheme, err := parseScheme(*schemeName)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	oracle, err := newRawOracle(scheme)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	if err := (&server{oracle: oracle}).serve(os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/fuzz/oracle/native_integration_test.go
+++ b/fuzz/oracle/native_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -26,7 +27,100 @@ type nativePeer struct {
 	command *exec.Cmd
 	input   io.WriteCloser
 	output  io.Reader
-	stderr  bytes.Buffer
+	stderr  synchronizedCapture
+}
+
+type synchronizedCapture struct {
+	mu       sync.Mutex
+	contents bytes.Buffer
+}
+
+func (c *synchronizedCapture) Write(data []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.contents.Write(data)
+}
+
+func (c *synchronizedCapture) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.contents.String()
+}
+
+func TestSynchronizedCaptureConcurrentWriteAndString(t *testing.T) {
+	const (
+		writers    = 4
+		readers    = 4
+		iterations = 512
+		chunk      = "stderr\n"
+	)
+
+	var capture synchronizedCapture
+	start := make(chan struct{})
+	writersDone := make(chan struct{})
+	failures := make(chan error, writers+readers)
+
+	var writerGroup sync.WaitGroup
+	writerGroup.Add(writers)
+	for writer := 0; writer < writers; writer++ {
+		go func() {
+			defer writerGroup.Done()
+			<-start
+			for iteration := 0; iteration < iterations; iteration++ {
+				written, err := capture.Write([]byte(chunk))
+				if err != nil || written != len(chunk) {
+					failures <- fmt.Errorf("capture write = %d, %v", written, err)
+					return
+				}
+				runtime.Gosched()
+			}
+		}()
+	}
+	go func() {
+		writerGroup.Wait()
+		close(writersDone)
+	}()
+
+	var readerGroup sync.WaitGroup
+	readerGroup.Add(readers)
+	for reader := 0; reader < readers; reader++ {
+		go func() {
+			defer readerGroup.Done()
+			<-start
+			for {
+				snapshot := capture.String()
+				if len(snapshot)%len(chunk) != 0 {
+					failures <- fmt.Errorf("partial capture snapshot length %d", len(snapshot))
+					return
+				}
+				for offset := 0; offset < len(snapshot); offset += len(chunk) {
+					if snapshot[offset:offset+len(chunk)] != chunk {
+						failures <- fmt.Errorf("corrupt capture snapshot at byte %d", offset)
+						return
+					}
+				}
+				select {
+				case <-writersDone:
+					return
+				default:
+					runtime.Gosched()
+				}
+			}
+		}()
+	}
+
+	close(start)
+	<-writersDone
+	readerGroup.Wait()
+	close(failures)
+	for err := range failures {
+		t.Error(err)
+	}
+
+	wantLength := writers * iterations * len(chunk)
+	if got := len(capture.String()); got != wantLength {
+		t.Fatalf("final capture length = %d, want %d", got, wantLength)
+	}
 }
 
 type infoResponse struct {

--- a/fuzz/oracle/native_integration_test.go
+++ b/fuzz/oracle/native_integration_test.go
@@ -1,0 +1,933 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	peerDeadline           = 5 * time.Second
+	fullResultExampleLimit = 8
+)
+
+type nativePeer struct {
+	command *exec.Cmd
+	input   io.WriteCloser
+	output  io.Reader
+	stderr  bytes.Buffer
+}
+
+type infoResponse struct {
+	revision string
+	runtime  string
+}
+
+func startNativePeer(t *testing.T, path string) *nativePeer {
+	return startNativePeerWithArgs(t, path)
+}
+
+func startNativePeerWithArgs(t *testing.T, path string, args ...string) *nativePeer {
+	t.Helper()
+	peer := &nativePeer{command: exec.Command(path, args...)}
+	var err error
+	peer.input, err = peer.command.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	peer.output, err = peer.command.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	peer.command.Stderr = &peer.stderr
+	if err := peer.command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	return peer
+}
+
+func (p *nativePeer) exchange(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	type exchangeResult struct {
+		payload []byte
+		err     error
+	}
+	done := make(chan exchangeResult, 1)
+	go func() {
+		if err := writeFrame(p.input, payload); err != nil {
+			done <- exchangeResult{err: fmt.Errorf("write request: %w", err)}
+			return
+		}
+		response, err := readFrame(p.output)
+		done <- exchangeResult{payload: response, err: err}
+	}()
+	timer := time.NewTimer(peerDeadline)
+	defer stopTimer(timer)
+	select {
+	case result := <-done:
+		if result.err != nil {
+			t.Fatalf("native exchange: %v\nstderr: %s", result.err, p.stderr.String())
+		}
+		return result.payload
+	case <-timer.C:
+		if p.command.Process != nil {
+			_ = p.command.Process.Kill()
+		}
+		t.Fatal("native exchange exceeded the five-second deadline")
+		return nil
+	}
+}
+
+func (p *nativePeer) close(t *testing.T) {
+	t.Helper()
+	if err := p.closeWithin(peerDeadline); err != nil {
+		t.Errorf("%v\nstderr: %s", err, p.stderr.String())
+	}
+}
+
+func stopTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}
+
+func (p *nativePeer) closeWithin(deadline time.Duration) error {
+	closeErr := p.input.Close()
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- p.command.Wait()
+	}()
+
+	timer := time.NewTimer(deadline)
+	defer stopTimer(timer)
+	select {
+	case waitErr := <-waitDone:
+		if closeErr != nil && waitErr != nil {
+			return fmt.Errorf("close native input: %v; native peer failed: %w", closeErr, waitErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close native input: %w", closeErr)
+		}
+		if waitErr != nil {
+			return fmt.Errorf("native peer failed: %w", waitErr)
+		}
+		return nil
+	case <-timer.C:
+		if p.command.Process != nil {
+			_ = p.command.Process.Kill()
+		}
+		return fmt.Errorf("native peer did not exit within %s", deadline)
+	}
+}
+
+func TestNativePeerCloseHasDeadline(t *testing.T) {
+	const helperArgument = "fzf-oracle-close-hang-helper"
+	if len(os.Args) > 1 && os.Args[len(os.Args)-1] == helperArgument {
+		payload, err := readFrame(os.Stdin)
+		if err != nil || !bytes.Equal(payload, []byte{protocolVersion, opcodeInfo}) {
+			os.Exit(2)
+		}
+		if err := writeFrame(os.Stdout, infoPayload()); err != nil {
+			os.Exit(2)
+		}
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+
+	peer := startNativePeerWithArgs(t, os.Args[0],
+		"-test.run=^TestNativePeerCloseHasDeadline$", "--", helperArgument)
+	if _, err := decodeInfoResponse(peer.exchange(t, []byte{protocolVersion, opcodeInfo})); err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	err := peer.closeWithin(100 * time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "did not exit within") {
+		t.Fatalf("close got %v; want a deadline error", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("bounded close took %s", elapsed)
+	}
+}
+
+func TestStopTimerDrainsExpiredTimer(t *testing.T) {
+	timer := time.NewTimer(0)
+	<-timer.C
+	stopTimer(timer)
+	select {
+	case <-timer.C:
+		t.Fatal("stopped timer still had a value")
+	default:
+	}
+}
+
+func decodeMatchResponse(payload []byte) (matchResponse, byte, error) {
+	if len(payload) < 3 {
+		return matchResponse{}, 0, fmt.Errorf("response has %d bytes; need at least 3", len(payload))
+	}
+	if payload[0] != protocolVersion || payload[1] != opcodeMatch {
+		return matchResponse{}, payload[2], fmt.Errorf("unexpected response prefix %x", payload[:3])
+	}
+	status := payload[2]
+	if status != statusOK {
+		if len(payload) < 7 {
+			return matchResponse{}, status, fmt.Errorf("error response has %d bytes; need at least 7", len(payload))
+		}
+		messageLength := binary.BigEndian.Uint32(payload[3:7])
+		if uint64(messageLength)+7 != uint64(len(payload)) {
+			return matchResponse{}, status, fmt.Errorf("error response length is inconsistent")
+		}
+		return matchResponse{}, status, fmt.Errorf("native status %d: %s", status, payload[7:])
+	}
+	if len(payload) < 33 {
+		return matchResponse{}, status, fmt.Errorf("success response has %d bytes; need at least 33", len(payload))
+	}
+	if payload[3] > 1 || payload[4] > 1 {
+		return matchResponse{}, status, fmt.Errorf("invalid Boolean fields %d and %d", payload[3], payload[4])
+	}
+	count := binary.BigEndian.Uint32(payload[29:33])
+	want := uint64(33) + uint64(count)*8
+	if want != uint64(len(payload)) {
+		return matchResponse{}, status, fmt.Errorf("success response has %d bytes; positions require %d", len(payload), want)
+	}
+	var positions []int64
+	if payload[4] != 0 {
+		positions = make([]int64, int(count))
+	} else if count != 0 {
+		return matchResponse{}, status, fmt.Errorf("absent positions have count %d", count)
+	}
+	response := matchResponse{
+		matched:          payload[3] != 0,
+		positionsPresent: payload[4] != 0,
+		start:            int64(binary.BigEndian.Uint64(payload[5:13])),
+		end:              int64(binary.BigEndian.Uint64(payload[13:21])),
+		score:            int64(binary.BigEndian.Uint64(payload[21:29])),
+		positions:        positions,
+	}
+	for index := range response.positions {
+		offset := 33 + index*8
+		response.positions[index] = int64(binary.BigEndian.Uint64(payload[offset : offset+8]))
+	}
+	return response, status, nil
+}
+
+func decodeInfoResponse(payload []byte) (infoResponse, error) {
+	if len(payload) < 7 || payload[0] != protocolVersion || payload[1] != opcodeInfo || payload[2] != statusOK {
+		return infoResponse{}, fmt.Errorf("invalid INFO response prefix: %x", payload)
+	}
+	revisionLength := uint64(binary.BigEndian.Uint32(payload[3:7]))
+	if revisionLength > uint64(len(payload)-7) {
+		return infoResponse{}, fmt.Errorf("INFO revision length exceeds payload")
+	}
+	runtimeOffset := uint64(7) + revisionLength
+	if runtimeOffset+4 > uint64(len(payload)) {
+		return infoResponse{}, fmt.Errorf("INFO response lacks runtime length")
+	}
+	runtimeLength := uint64(binary.BigEndian.Uint32(payload[runtimeOffset : runtimeOffset+4]))
+	if runtimeOffset+4+runtimeLength != uint64(len(payload)) {
+		return infoResponse{}, fmt.Errorf("INFO runtime length is inconsistent")
+	}
+	return infoResponse{
+		revision: string(payload[7:runtimeOffset]),
+		runtime:  string(payload[runtimeOffset+4:]),
+	}, nil
+}
+
+func TestNativePeerMatchesRawOracle(t *testing.T) {
+	driver := os.Getenv("FZF_NATIVE_ALGO_DRIVER")
+	if driver == "" {
+		t.Skip("set FZF_NATIVE_ALGO_DRIVER to check the native peer")
+	}
+
+	peer := startNativePeer(t, driver)
+	defer peer.close(t)
+	info, err := decodeInfoResponse(peer.exchange(t, []byte{protocolVersion, opcodeInfo}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRevision := os.Getenv("FZF_NATIVE_EXPECTED_REVISION")
+	if wantRevision == "" {
+		t.Fatal("FZF_NATIVE_EXPECTED_REVISION is required with FZF_NATIVE_ALGO_DRIVER")
+	}
+	if info.revision != wantRevision || info.runtime == "" {
+		t.Fatalf("native INFO got revision=%q runtime=%q; want revision=%q", info.revision, info.runtime, wantRevision)
+	}
+
+	oracle, err := newRawOracle(schemeDefault)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name      string
+		algorithm algorithmID
+		flags     byte
+		pattern   []byte
+		candidate []byte
+	}{
+		{"cjk-v2", algorithmV2, flagCaseSensitive | flagForward, []byte("中文"), []byte("测试中文")},
+		{"supplementary-v1", algorithmV1, flagCaseSensitive | flagForward, []byte("😀"), []byte("a😀b")},
+		{"case-fold-expands-v2", algorithmV2, flagForward, []byte("Ⱥ"), []byte("xⱥ")},
+		{"kelvin-fold-v2", algorithmV2, flagForward, []byte("K"), []byte("xk")},
+		{"sigma-fold-v2", algorithmV2, flagForward, []byte("Σ"), []byte("xσ")},
+		{"embedded-nul-v2", algorithmV2, flagCaseSensitive | flagForward, []byte{'a', 0}, []byte{'x', 'a', 0}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := matchRequest{
+				algorithm: testCase.algorithm,
+				scheme:    schemeDefault,
+				flags:     testCase.flags,
+				pattern:   testCase.pattern,
+				candidate: testCase.candidate,
+			}
+			want, err := oracle.match(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			payload := matchRequestPayload(request.algorithm, request.scheme, request.flags, request.pattern, request.candidate)
+			got, _, err := decodeMatchResponse(peer.exchange(t, payload))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("native result %+v does not match upstream result %+v", got, want)
+			}
+		})
+	}
+}
+
+func TestBuiltOracleProcessIsPersistent(t *testing.T) {
+	binary := os.Getenv("FZF_RAW_ORACLE_BINARY")
+	if binary == "" {
+		t.Skip("set FZF_RAW_ORACLE_BINARY to check the built oracle process")
+	}
+
+	// fzf scoring schemes mutate package-global tables that are not fully
+	// reset by a later Init call.  Keep each scheme in its own built process
+	// and compare with pinned results instead of mixing schemes in this process.
+	for _, testCase := range []struct {
+		name       string
+		scheme     schemeID
+		matchScore int64
+	}{
+		{"default", schemeDefault, 84},
+		{"path", schemePath, 84},
+		{"history", schemeHistory, 80},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			peer := startNativePeerWithArgs(t, binary, "--scheme="+testCase.name)
+			defer peer.close(t)
+
+			info, err := decodeInfoResponse(peer.exchange(t, []byte{protocolVersion, opcodeInfo}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.revision != pinnedUpstreamCommit || info.runtime == "" {
+				t.Fatalf("oracle INFO got revision=%q runtime=%q", info.revision, info.runtime)
+			}
+			for _, candidate := range []string{"src/fzf", "测试中文"} {
+				request := matchRequest{
+					algorithm: algorithmV2,
+					scheme:    testCase.scheme,
+					flags:     flagCaseSensitive | flagForward,
+					pattern:   []byte("fzf"),
+					candidate: []byte(candidate),
+				}
+				want := matchResponse{start: -1, end: -1}
+				if candidate == "src/fzf" {
+					want = matchResponse{
+						matched: true, positionsPresent: true,
+						start: 4, end: 7, score: testCase.matchScore,
+						positions: []int64{4, 5, 6},
+					}
+				}
+				got, _, err := decodeMatchResponse(peer.exchange(t,
+					matchRequestPayload(request.algorithm, request.scheme, request.flags, request.pattern, request.candidate)))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("built process result %+v does not match in-process result %+v", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestNativePeerKnownAlignmentAndNormalizationGaps(t *testing.T) {
+	driver := os.Getenv("FZF_NATIVE_ALGO_DRIVER")
+	if driver == "" {
+		t.Skip("set FZF_NATIVE_ALGO_DRIVER to check the native peer")
+	}
+	peer := startNativePeer(t, driver)
+	defer peer.close(t)
+	oracle, err := newRawOracle(schemeDefault)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name           string
+		flags          byte
+		pattern        []byte
+		candidate      []byte
+		wantUpstream   matchResponse
+		wantNativePeer matchResponse
+	}{
+		{
+			name:      "v2-alignment",
+			flags:     flagForward,
+			pattern:   []byte("/a"),
+			candidate: []byte("a//a"),
+			wantUpstream: matchResponse{
+				matched: true, positionsPresent: true, start: 2, end: 4, score: 59, positions: []int64{2, 3},
+			},
+			wantNativePeer: matchResponse{
+				matched: true, positionsPresent: true, start: 1, end: 4, score: 56, positions: []int64{1, 3},
+			},
+		},
+		{
+			name:      "latin-normalization",
+			flags:     flagCaseSensitive | flagNormalize | flagForward,
+			pattern:   []byte("cafe"),
+			candidate: []byte("café"),
+			wantUpstream: matchResponse{
+				matched: true, positionsPresent: true, start: 0, end: 4, score: 114, positions: []int64{0, 1, 2, 3},
+			},
+			wantNativePeer: matchResponse{
+				matched: false, positionsPresent: true, start: -1, end: -1, score: 0, positions: []int64{},
+			},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := matchRequest{
+				algorithm: algorithmV2,
+				scheme:    schemeDefault,
+				flags:     testCase.flags,
+				pattern:   testCase.pattern,
+				candidate: testCase.candidate,
+			}
+			upstream, err := oracle.match(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			native, _, err := decodeMatchResponse(peer.exchange(t,
+				matchRequestPayload(request.algorithm, request.scheme, request.flags, request.pattern, request.candidate)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(upstream, testCase.wantUpstream) {
+				t.Fatalf("upstream gap shape changed: got %+v; want %+v", upstream, testCase.wantUpstream)
+			}
+			if !reflect.DeepEqual(native, testCase.wantNativePeer) {
+				t.Fatalf("native gap shape changed: got %+v; want %+v", native, testCase.wantNativePeer)
+			}
+		})
+	}
+}
+
+func TestNativePeerKnownScoreGaps(t *testing.T) {
+	driver := os.Getenv("FZF_NATIVE_ALGO_DRIVER")
+	if driver == "" {
+		t.Skip("set FZF_NATIVE_ALGO_DRIVER to check the native peer")
+	}
+
+	peer := startNativePeer(t, driver)
+	defer peer.close(t)
+	oracle, err := newRawOracle(schemeDefault)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name          string
+		flags         byte
+		pattern       []byte
+		candidate     []byte
+		upstreamScore int64
+		nativeScore   int64
+	}{
+		{"ascii-boundary-bonus", flagCaseSensitive | flagForward, []byte("fzf"), []byte("src/fzf"), 84, 80},
+		{"unicode-fold-boundary-bonus", flagForward, []byte("Ⱥ"), []byte("ⱥ"), 36, 32},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := matchRequest{
+				algorithm: algorithmV2,
+				scheme:    schemeDefault,
+				flags:     testCase.flags,
+				pattern:   testCase.pattern,
+				candidate: testCase.candidate,
+			}
+			upstream, err := oracle.match(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			native, _, err := decodeMatchResponse(peer.exchange(t,
+				matchRequestPayload(request.algorithm, request.scheme, request.flags, request.pattern, request.candidate)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if upstream.score != testCase.upstreamScore || native.score != testCase.nativeScore {
+				t.Fatalf("score gap changed: upstream=%d native=%d; want upstream=%d native=%d",
+					upstream.score, native.score, testCase.upstreamScore, testCase.nativeScore)
+			}
+			upstream.score = 0
+			native.score = 0
+			if !reflect.DeepEqual(native, upstream) {
+				t.Fatalf("non-score result changed: native=%+v upstream=%+v", native, upstream)
+			}
+		})
+	}
+}
+
+func TestNativePeerKnownContiguousResultGaps(t *testing.T) {
+	driver := os.Getenv("FZF_NATIVE_ALGO_DRIVER")
+	if driver == "" {
+		t.Skip("set FZF_NATIVE_ALGO_DRIVER to check the native peer")
+	}
+	peer := startNativePeer(t, driver)
+	defer peer.close(t)
+	oracle, err := newRawOracle(schemeDefault)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name           string
+		algorithm      algorithmID
+		pattern        []byte
+		candidate      []byte
+		wantUpstream   matchResponse
+		wantNativePeer matchResponse
+	}{
+		{
+			name: "exact-position-representation", algorithm: algorithmExact,
+			pattern: []byte("ab"), candidate: []byte("xabx"),
+			wantUpstream:   matchResponse{matched: true, start: 1, end: 3, score: 36},
+			wantNativePeer: matchResponse{matched: true, positionsPresent: true, start: 1, end: 3, score: 36, positions: []int64{1, 2}},
+		},
+		{
+			name: "suffix-position-representation", algorithm: algorithmSuffix,
+			pattern: []byte("ab"), candidate: []byte("xab"),
+			wantUpstream:   matchResponse{matched: true, start: 1, end: 3, score: 36},
+			wantNativePeer: matchResponse{matched: true, positionsPresent: true, start: 1, end: 3, score: 36, positions: []int64{1, 2}},
+		},
+		{
+			name: "prefix-score-and-position-representation", algorithm: algorithmPrefix,
+			pattern: []byte("ab"), candidate: []byte("abx"),
+			wantUpstream:   matchResponse{matched: true, start: 0, end: 2, score: 62},
+			wantNativePeer: matchResponse{matched: true, positionsPresent: true, start: 0, end: 2, score: 56, positions: []int64{0, 1}},
+		},
+		{
+			name: "equal-score-and-position-representation", algorithm: algorithmEqual,
+			pattern: []byte("ab"), candidate: []byte("ab"),
+			wantUpstream:   matchResponse{matched: true, start: 0, end: 2, score: 62},
+			wantNativePeer: matchResponse{matched: true, positionsPresent: true, start: 0, end: 2, score: 56, positions: []int64{0, 1}},
+		},
+		{
+			name: "v1-empty-pattern-position-representation", algorithm: algorithmV1,
+			pattern: []byte{}, candidate: []byte("abc"),
+			wantUpstream:   matchResponse{matched: true, start: 0, end: 0, score: 0},
+			wantNativePeer: matchResponse{matched: true, positionsPresent: true, start: 0, end: 0, score: 0, positions: []int64{}},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := matchRequest{
+				algorithm: testCase.algorithm,
+				scheme:    schemeDefault,
+				flags:     flagCaseSensitive | flagForward,
+				pattern:   testCase.pattern,
+				candidate: testCase.candidate,
+			}
+			upstream, err := oracle.match(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			native, _, err := decodeMatchResponse(peer.exchange(t,
+				matchRequestPayload(request.algorithm, request.scheme, request.flags, request.pattern, request.candidate)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(upstream, testCase.wantUpstream) {
+				t.Fatalf("upstream gap shape changed: got %+v; want %+v", upstream, testCase.wantUpstream)
+			}
+			if !reflect.DeepEqual(native, testCase.wantNativePeer) {
+				t.Fatalf("native gap shape changed: got %+v; want %+v", native, testCase.wantNativePeer)
+			}
+		})
+	}
+}
+
+func TestNativePeerMembershipMatrix(t *testing.T) {
+	driver := os.Getenv("FZF_NATIVE_ALGO_DRIVER")
+	if driver == "" {
+		t.Skip("set FZF_NATIVE_ALGO_DRIVER to check the native peer")
+	}
+	peer := startNativePeer(t, driver)
+	defer peer.close(t)
+	oracle, err := newRawOracle(schemeDefault)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name      string
+		algorithm algorithmID
+		pattern   string
+		candidate string
+	}{
+		{"v1-match", algorithmV1, "ab", "a_b"},
+		{"v1-miss", algorithmV1, "ab", "ba"},
+		{"v2-match", algorithmV2, "ab", "a_b"},
+		{"v2-miss", algorithmV2, "ab", "ba"},
+		{"exact-match", algorithmExact, "ab", "xabx"},
+		{"exact-miss", algorithmExact, "ab", "axb"},
+		{"prefix-match", algorithmPrefix, "ab", "abx"},
+		{"prefix-miss", algorithmPrefix, "ab", "xab"},
+		{"suffix-match", algorithmSuffix, "ab", "xab"},
+		{"suffix-miss", algorithmSuffix, "ab", "abx"},
+		{"equal-match", algorithmEqual, "ab", "ab"},
+		{"equal-miss", algorithmEqual, "ab", "xab"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := matchRequest{
+				algorithm: testCase.algorithm,
+				scheme:    schemeDefault,
+				flags:     flagCaseSensitive | flagForward,
+				pattern:   []byte(testCase.pattern),
+				candidate: []byte(testCase.candidate),
+			}
+			upstream, err := oracle.match(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			native, _, err := decodeMatchResponse(peer.exchange(t,
+				matchRequestPayload(request.algorithm, request.scheme, request.flags, request.pattern, request.candidate)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if native.matched != upstream.matched {
+				t.Fatalf("membership differs: native=%t upstream=%t", native.matched, upstream.matched)
+			}
+		})
+	}
+}
+
+func TestNativePeerReportsCurrentCapabilityBoundary(t *testing.T) {
+	driver := os.Getenv("FZF_NATIVE_ALGO_DRIVER")
+	if driver == "" {
+		t.Skip("set FZF_NATIVE_ALGO_DRIVER to check the native peer")
+	}
+	peer := startNativePeer(t, driver)
+	defer peer.close(t)
+
+	unsupported := []struct {
+		name      string
+		algorithm algorithmID
+		scheme    schemeID
+		flags     byte
+	}{
+		{"exact-boundary", algorithmExactBoundary, schemeDefault, flagForward},
+		{"path-scheme", algorithmV2, schemePath, flagForward},
+		{"backward-search", algorithmV2, schemeDefault, 0},
+	}
+	for _, testCase := range unsupported {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := matchRequestPayload(testCase.algorithm, testCase.scheme, testCase.flags, []byte("a"), []byte("a"))
+			_, status, err := decodeMatchResponse(peer.exchange(t, request))
+			if status != statusUnsupported || err == nil {
+				t.Fatalf("got status %d and error %v; want unsupported status", status, err)
+			}
+		})
+	}
+}
+
+func TestMalformedUTF8DifferenceIsExplicit(t *testing.T) {
+	driver := os.Getenv("FZF_NATIVE_ALGO_DRIVER")
+	if driver == "" {
+		t.Skip("set FZF_NATIVE_ALGO_DRIVER to check the native peer")
+	}
+	peer := startNativePeer(t, driver)
+	defer peer.close(t)
+
+	request := matchRequest{
+		algorithm: algorithmV2,
+		scheme:    schemeDefault,
+		flags:     flagCaseSensitive | flagForward,
+		pattern:   []byte{0xff},
+		candidate: []byte{0xfe},
+	}
+	oracle, err := newRawOracle(schemeDefault)
+	if err != nil {
+		t.Fatal(err)
+	}
+	upstream, err := oracle.match(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	native, _, err := decodeMatchResponse(peer.exchange(t,
+		matchRequestPayload(request.algorithm, request.scheme, request.flags, request.pattern, request.candidate)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !upstream.matched || native.matched {
+		t.Fatalf("malformed UTF-8 exception changed: upstream=%+v native=%+v", upstream, native)
+	}
+}
+
+type rawMatrixRNG uint64
+
+func (r *rawMatrixRNG) next() uint64 {
+	x := uint64(*r)
+	x ^= x << 13
+	x ^= x >> 7
+	x ^= x << 17
+	*r = rawMatrixRNG(x)
+	return x
+}
+
+func rawMatrixEnv(t *testing.T, name string, fallback uint64) uint64 {
+	t.Helper()
+	value := os.Getenv(name)
+	if value == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		t.Fatalf("%s must be an unsigned decimal integer: %v", name, err)
+	}
+	return parsed
+}
+
+func rawMatrixRequest(seed, serial uint64) matchRequest {
+	if serial%20000 == 0 {
+		return matchRequest{
+			algorithm: algorithmEqual,
+			scheme:    schemeDefault,
+			flags:     flagForward,
+			pattern:   []byte("- "),
+			candidate: []byte("- "),
+		}
+	}
+
+	state := rawMatrixRNG(seed ^ ((serial + 1) * 0x9e3779b97f4a7c15))
+	if state == 0 {
+		state = 0x6a09e667f3bcc909
+	}
+	algorithms := [...]algorithmID{
+		algorithmV1, algorithmV2, algorithmExact,
+		algorithmPrefix, algorithmSuffix, algorithmEqual,
+	}
+	alphabet := []byte("abAB/_- .:")
+	request := matchRequest{
+		algorithm: algorithms[state.next()%uint64(len(algorithms))],
+		scheme:    schemeDefault,
+		flags:     flagForward,
+	}
+	if state.next()%2 != 0 {
+		request.flags |= flagCaseSensitive
+	}
+	if serial%5000 == 1 {
+		length := [...]int{999, 1000, 1001}[(serial/5000)%3]
+		request.algorithm = algorithmV2
+		request.flags = flagCaseSensitive | flagForward
+		request.pattern = bytes.Repeat([]byte("a"), length)
+		request.candidate = append([]byte("/"), request.pattern...)
+		return request
+	}
+	if serial%1024 == 4 {
+		pairs := [...][2]string{
+			{"k", "K"}, {"ⱥ", "Ⱥ"}, {"σ", "Σ"},
+			{"你", "你"}, {"😀", "😀"}, {"𐐷", "𐐏"},
+		}
+		pair := pairs[(serial/1024)%uint64(len(pairs))]
+		request.flags = flagForward
+		request.pattern = []byte(pair[0])
+		request.candidate = []byte(pair[1])
+		return request
+	}
+	if serial%16 == 3 {
+		atoms := [...]string{
+			"a", "B", "/", "_", " ", "é", "σ", "你", "😀", "K", "Ⱥ", "ⱥ", "𐐷",
+		}
+		patternLength := int(state.next() % 7)
+		candidateLength := int(state.next() % 14)
+		for index := 0; index < patternLength; index++ {
+			request.pattern = append(request.pattern,
+				[]byte(atoms[state.next()%uint64(len(atoms))])...)
+		}
+		for index := 0; index < candidateLength; index++ {
+			request.candidate = append(request.candidate,
+				[]byte(atoms[state.next()%uint64(len(atoms))])...)
+		}
+		return request
+	}
+	patternLength := int(state.next() % 7)
+	candidateLength := int(state.next() % 14)
+	request.pattern = make([]byte, patternLength)
+	request.candidate = make([]byte, candidateLength)
+	for index := range request.pattern {
+		request.pattern[index] = alphabet[state.next()%uint64(len(alphabet))]
+	}
+	for index := range request.candidate {
+		request.candidate[index] = alphabet[state.next()%uint64(len(alphabet))]
+	}
+	return request
+}
+
+type fullResultAudit struct {
+	differenceCount uint64
+	examples        []string
+}
+
+func compactBytes(value []byte) string {
+	const prefixLimit = 12
+	prefix := value
+	suffix := ""
+	if len(prefix) > prefixLimit {
+		prefix = prefix[:prefixLimit]
+		suffix = "..."
+	}
+	return fmt.Sprintf("len=%d hex=%x%s", len(value), prefix, suffix)
+}
+
+func compactResponse(response matchResponse) string {
+	positionSummary := "absent"
+	if response.positionsPresent {
+		positionSummary = fmt.Sprintf("count=%d", len(response.positions))
+		if len(response.positions) != 0 {
+			positionSummary += fmt.Sprintf(" first=%d last=%d",
+				response.positions[0], response.positions[len(response.positions)-1])
+		}
+	}
+	return fmt.Sprintf("matched=%t start=%d end=%d score=%d positions=(%s)",
+		response.matched, response.start, response.end, response.score, positionSummary)
+}
+
+func compactMatrixDifference(seed, serial uint64, request matchRequest,
+	upstream, native matchResponse) string {
+	return fmt.Sprintf(
+		"seed=%d serial=%d algorithm=%d scheme=%d flags=0x%02x pattern=(%s) candidate=(%s) upstream=(%s) native=(%s)",
+		seed, serial, request.algorithm, request.scheme, request.flags,
+		compactBytes(request.pattern), compactBytes(request.candidate),
+		compactResponse(upstream), compactResponse(native))
+}
+
+func (audit *fullResultAudit) add(seed, serial uint64, request matchRequest,
+	upstream, native matchResponse) {
+	audit.differenceCount++
+	if len(audit.examples) < fullResultExampleLimit {
+		audit.examples = append(audit.examples,
+			compactMatrixDifference(seed, serial, request, upstream, native))
+	}
+}
+
+func TestFullResultAuditUsesCompactBoundedExamples(t *testing.T) {
+	request := matchRequest{
+		algorithm: algorithmV2,
+		flags:     flagCaseSensitive | flagForward,
+		pattern:   bytes.Repeat([]byte("a"), 1001),
+		candidate: append([]byte("/"), bytes.Repeat([]byte("a"), 1001)...),
+	}
+	positions := make([]int64, 1001)
+	for index := range positions {
+		positions[index] = int64(index + 1)
+	}
+	upstream := matchResponse{matched: true, positionsPresent: true,
+		start: 1, end: 1002, score: 10, positions: positions}
+	native := upstream
+	native.score = 9
+
+	var audit fullResultAudit
+	for serial := uint64(0); serial < fullResultExampleLimit+3; serial++ {
+		audit.add(7, serial, request, upstream, native)
+	}
+	if audit.differenceCount != fullResultExampleLimit+3 {
+		t.Fatalf("difference count is %d", audit.differenceCount)
+	}
+	if len(audit.examples) != fullResultExampleLimit {
+		t.Fatalf("example count is %d", len(audit.examples))
+	}
+	for _, example := range audit.examples {
+		if len(example) > 500 || strings.Contains(example, "[1 2 3") {
+			t.Fatalf("diagnostic is not compact: %q", example)
+		}
+	}
+}
+
+func TestNativePeerDeterministicMembershipMatrix(t *testing.T) {
+	driver := os.Getenv("FZF_NATIVE_ALGO_DRIVER")
+	if driver == "" {
+		t.Skip("set FZF_NATIVE_ALGO_DRIVER to check the native peer")
+	}
+	oracleBinary := os.Getenv("FZF_RAW_ORACLE_BINARY")
+	if oracleBinary == "" {
+		t.Fatal("FZF_RAW_ORACLE_BINARY is required with FZF_NATIVE_ALGO_DRIVER")
+	}
+	seed := rawMatrixEnv(t, "FZF_RAW_MATRIX_SEED", 20260906)
+	start := rawMatrixEnv(t, "FZF_RAW_MATRIX_START", 0)
+	caseCount := rawMatrixEnv(t, "FZF_RAW_MATRIX_CASES", 20000)
+	fullResults := os.Getenv("FZF_RAW_MATRIX_FULL_RESULTS") == "1"
+
+	nativePeer := startNativePeer(t, driver)
+	defer nativePeer.close(t)
+	oraclePeer := startNativePeerWithArgs(t, oracleBinary, "--scheme=default")
+	defer oraclePeer.close(t)
+	oracleInfo, err := decodeInfoResponse(
+		oraclePeer.exchange(t, []byte{protocolVersion, opcodeInfo}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oracleInfo.revision != pinnedUpstreamCommit || oracleInfo.runtime != runtime.Version() {
+		t.Fatalf("oracle INFO got revision=%q runtime=%q", oracleInfo.revision, oracleInfo.runtime)
+	}
+	var audit fullResultAudit
+	for iteration := uint64(0); iteration < caseCount; iteration++ {
+		serial := start + iteration
+		if serial < start {
+			t.Fatal("raw matrix serial overflow")
+		}
+		request := rawMatrixRequest(seed, serial)
+		payload := matchRequestPayload(request.algorithm, request.scheme, request.flags,
+			request.pattern, request.candidate)
+		upstream, _, err := decodeMatchResponse(oraclePeer.exchange(t, payload))
+		if err != nil {
+			t.Fatalf("seed=%d serial=%d upstream error: %v", seed, serial, err)
+		}
+		native, _, err := decodeMatchResponse(nativePeer.exchange(t, payload))
+		if err != nil {
+			t.Fatalf("seed=%d serial=%d native error: %v", seed, serial, err)
+		}
+		if native.matched != upstream.matched {
+			t.Fatalf("membership differs: %s",
+				compactMatrixDifference(seed, serial, request, upstream, native))
+		}
+		if fullResults && !reflect.DeepEqual(native, upstream) {
+			audit.add(seed, serial, request, upstream, native)
+		}
+	}
+	if audit.differenceCount != 0 {
+		t.Fatalf("full-result debt in %d of %d cases; first %d differences:\n%s\nreplay one case with FZF_RAW_MATRIX_SEED=%d FZF_RAW_MATRIX_START=SERIAL FZF_RAW_MATRIX_CASES=1 FZF_RAW_MATRIX_FULL_RESULTS=1",
+			audit.differenceCount, caseCount, len(audit.examples),
+			strings.Join(audit.examples, "\n"), seed)
+	}
+	t.Logf("raw matrix seed=%d start=%d cases=%d full-results=%t",
+		seed, start, caseCount, fullResults)
+}

--- a/fuzz/oracle/oracle.go
+++ b/fuzz/oracle/oracle.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/junegunn/fzf/src/algo"
+	"github.com/junegunn/fzf/src/util"
+)
+
+const pinnedUpstreamCommit = "1372d04f79bde0daa3bab4b96a068baafa808e67"
+
+type algorithmID byte
+
+const (
+	algorithmV1 algorithmID = iota
+	algorithmV2
+	algorithmExact
+	algorithmExactBoundary
+	algorithmPrefix
+	algorithmSuffix
+	algorithmEqual
+)
+
+type schemeID byte
+
+const (
+	schemeDefault schemeID = iota
+	schemePath
+	schemeHistory
+)
+
+const (
+	flagCaseSensitive byte = 1 << iota
+	flagNormalize
+	flagForward
+	validMatchFlags = flagCaseSensitive | flagNormalize | flagForward
+)
+
+type matchRequest struct {
+	algorithm algorithmID
+	scheme    schemeID
+	flags     byte
+	pattern   []byte
+	candidate []byte
+}
+
+type matchResponse struct {
+	matched          bool
+	positionsPresent bool
+	start            int64
+	end              int64
+	score            int64
+	positions        []int64
+}
+
+type rawOracle struct {
+	scheme schemeID
+	slab   *util.Slab
+}
+
+func parseScheme(value string) (schemeID, error) {
+	switch value {
+	case "default":
+		return schemeDefault, nil
+	case "path":
+		return schemePath, nil
+	case "history":
+		return schemeHistory, nil
+	default:
+		return 0, fmt.Errorf("unknown scheme %q", value)
+	}
+}
+
+func (s schemeID) String() string {
+	switch s {
+	case schemeDefault:
+		return "default"
+	case schemePath:
+		return "path"
+	case schemeHistory:
+		return "history"
+	default:
+		return "unknown"
+	}
+}
+
+func newRawOracle(scheme schemeID) (*rawOracle, error) {
+	if !algo.Init(scheme.String()) {
+		return nil, fmt.Errorf("cannot initialize scheme %d", scheme)
+	}
+	return &rawOracle{
+		scheme: scheme,
+		slab:   util.MakeSlab(100*1024, 2048),
+	}, nil
+}
+
+func selectAlgorithm(id algorithmID) (algo.Algo, error) {
+	switch id {
+	case algorithmV1:
+		return algo.FuzzyMatchV1, nil
+	case algorithmV2:
+		return algo.FuzzyMatchV2, nil
+	case algorithmExact:
+		return algo.ExactMatchNaive, nil
+	case algorithmExactBoundary:
+		return algo.ExactMatchBoundary, nil
+	case algorithmPrefix:
+		return algo.PrefixMatch, nil
+	case algorithmSuffix:
+		return algo.SuffixMatch, nil
+	case algorithmEqual:
+		return algo.EqualMatch, nil
+	default:
+		return nil, fmt.Errorf("unknown algorithm %d", id)
+	}
+}
+
+func (o *rawOracle) match(request matchRequest) (matchResponse, error) {
+	if request.scheme != o.scheme {
+		return matchResponse{}, fmt.Errorf(
+			"request scheme %s does not match process scheme %s",
+			request.scheme.String(), o.scheme.String())
+	}
+	if request.flags&^validMatchFlags != 0 {
+		return matchResponse{}, fmt.Errorf("unknown match flags 0x%02x", request.flags&^validMatchFlags)
+	}
+
+	matchAlgorithm, err := selectAlgorithm(request.algorithm)
+	if err != nil {
+		return matchResponse{}, err
+	}
+
+	caseSensitive := request.flags&flagCaseSensitive != 0
+	normalize := request.flags&flagNormalize != 0
+	forward := request.flags&flagForward != 0
+	patternText := string(request.pattern)
+	if !caseSensitive {
+		patternText = strings.ToLower(patternText)
+	}
+	pattern := []rune(patternText)
+	if normalize {
+		pattern = algo.NormalizeRunes(pattern)
+	}
+
+	candidate := util.ToChars(request.candidate)
+	result, rawPositions := matchAlgorithm(
+		caseSensitive, normalize, forward, &candidate, pattern, true, o.slab)
+
+	response := matchResponse{
+		matched: result.Start >= 0,
+		start:   int64(result.Start),
+		end:     int64(result.End),
+		score:   int64(result.Score),
+	}
+	if rawPositions != nil {
+		response.positionsPresent = true
+		positions := append([]int(nil), (*rawPositions)...)
+		sort.Ints(positions)
+		response.positions = make([]int64, len(positions))
+		for index, position := range positions {
+			response.positions[index] = int64(position)
+		}
+	}
+	return response, nil
+}

--- a/fuzz/oracle/prepare.sh
+++ b/fuzz/oracle/prepare.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 FZF_SOURCE BUILD_DIRECTORY" >&2
+  exit 2
+fi
+
+source_dir=$(CDPATH= cd -- "$1" && pwd)
+build_dir=$2
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+upstream_dir=$build_dir/upstream
+
+mkdir -p "$build_dir" "$upstream_dir"
+git -C "$source_dir" archive 1372d04f79bde0daa3bab4b96a068baafa808e67 |
+  tar -x -C "$upstream_dir"
+
+cp "$script_dir"/*.go "$script_dir/go.mod" "$build_dir/"
+cp "$upstream_dir/go.sum" "$build_dir/go.sum"
+
+cd "$build_dir"
+go mod edit -replace="github.com/junegunn/fzf=$upstream_dir"
+GOWORK=off go mod tidy
+GOWORK=off go mod vendor
+
+# The local replacement makes the build independent of the network. Remove
+# its temporary path from the final module data after Go copies the source.
+awk -v path="$upstream_dir" '
+  $0 == "# github.com/junegunn/fzf => " path { next }
+  index($0, "# github.com/junegunn/fzf ") == 1 {
+    suffix = " => " path
+    if (length($0) >= length(suffix) &&
+        substr($0, length($0) - length(suffix) + 1) == suffix) {
+      print substr($0, 1, length($0) - length(suffix))
+      next
+    }
+  }
+  { print }
+' vendor/modules.txt >vendor/modules.txt.new
+mv vendor/modules.txt.new vendor/modules.txt
+go mod edit -dropreplace=github.com/junegunn/fzf

--- a/fuzz/oracle/protocol.go
+++ b/fuzz/oracle/protocol.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"runtime"
+)
+
+const (
+	protocolVersion byte = 1
+
+	opcodeInfo  byte = 0
+	opcodeMatch byte = 1
+
+	statusOK          byte = 0
+	statusBadRequest  byte = 1
+	statusUnsupported byte = 2
+	statusInternal    byte = 3
+
+	maxFrameSize    = 64 * 1024 * 1024
+	matchHeaderSize = 13
+)
+
+type server struct {
+	oracle *rawOracle
+}
+
+func readFrame(reader io.Reader) ([]byte, error) {
+	var header [4]byte
+	_, err := io.ReadFull(reader, header[:])
+	if err != nil {
+		return nil, err
+	}
+	length := binary.BigEndian.Uint32(header[:])
+	if length > maxFrameSize {
+		return nil, fmt.Errorf("frame length %d exceeds limit %d", length, maxFrameSize)
+	}
+	payload := make([]byte, int(length))
+	if _, err := io.ReadFull(reader, payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func writeFrame(writer io.Writer, payload []byte) error {
+	if len(payload) > maxFrameSize {
+		return fmt.Errorf("response length %d exceeds limit %d", len(payload), maxFrameSize)
+	}
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], uint32(len(payload)))
+	if _, err := writer.Write(header[:]); err != nil {
+		return err
+	}
+	_, err := writer.Write(payload)
+	return err
+}
+
+func appendUint32(buffer []byte, value uint32) []byte {
+	var encoded [4]byte
+	binary.BigEndian.PutUint32(encoded[:], value)
+	return append(buffer, encoded[:]...)
+}
+
+func appendInt64(buffer []byte, value int64) []byte {
+	var encoded [8]byte
+	binary.BigEndian.PutUint64(encoded[:], uint64(value))
+	return append(buffer, encoded[:]...)
+}
+
+func appendBytes(buffer []byte, value []byte) []byte {
+	buffer = appendUint32(buffer, uint32(len(value)))
+	return append(buffer, value...)
+}
+
+func errorPayload(opcode, status byte, err error) []byte {
+	payload := []byte{protocolVersion, opcode, status}
+	return appendBytes(payload, []byte(err.Error()))
+}
+
+func infoPayload() []byte {
+	payload := []byte{protocolVersion, opcodeInfo, statusOK}
+	payload = appendBytes(payload, []byte(pinnedUpstreamCommit))
+	return appendBytes(payload, []byte(runtime.Version()))
+}
+
+func matchPayload(response matchResponse) []byte {
+	matched := byte(0)
+	if response.matched {
+		matched = 1
+	}
+	positionsPresent := byte(0)
+	if response.positionsPresent {
+		positionsPresent = 1
+	}
+	payload := []byte{protocolVersion, opcodeMatch, statusOK, matched, positionsPresent}
+	payload = appendInt64(payload, response.start)
+	payload = appendInt64(payload, response.end)
+	payload = appendInt64(payload, response.score)
+	payload = appendUint32(payload, uint32(len(response.positions)))
+	for _, position := range response.positions {
+		payload = appendInt64(payload, position)
+	}
+	return payload
+}
+
+func decodeMatchRequest(payload []byte) (matchRequest, error) {
+	if len(payload) < matchHeaderSize {
+		return matchRequest{}, fmt.Errorf("match payload has %d bytes; need at least %d", len(payload), matchHeaderSize)
+	}
+	patternLength := binary.BigEndian.Uint32(payload[5:9])
+	candidateLength := binary.BigEndian.Uint32(payload[9:13])
+	want := uint64(matchHeaderSize) + uint64(patternLength) + uint64(candidateLength)
+	if want != uint64(len(payload)) {
+		return matchRequest{}, fmt.Errorf("match payload has %d bytes; lengths require %d", len(payload), want)
+	}
+	patternEnd := matchHeaderSize + int(patternLength)
+	return matchRequest{
+		algorithm: algorithmID(payload[2]),
+		scheme:    schemeID(payload[3]),
+		flags:     payload[4],
+		pattern:   payload[matchHeaderSize:patternEnd],
+		candidate: payload[patternEnd:],
+	}, nil
+}
+
+func (s *server) handle(payload []byte) []byte {
+	opcode := byte(0xff)
+	if len(payload) >= 2 {
+		opcode = payload[1]
+	}
+	if len(payload) < 2 {
+		return errorPayload(opcode, statusBadRequest, errors.New("request needs a version and opcode"))
+	}
+	if payload[0] != protocolVersion {
+		return errorPayload(opcode, statusBadRequest, fmt.Errorf("unsupported protocol version %d", payload[0]))
+	}
+
+	switch opcode {
+	case opcodeInfo:
+		if len(payload) != 2 {
+			return errorPayload(opcode, statusBadRequest, errors.New("INFO request must contain two bytes"))
+		}
+		return infoPayload()
+	case opcodeMatch:
+		request, err := decodeMatchRequest(payload)
+		if err != nil {
+			return errorPayload(opcode, statusBadRequest, err)
+		}
+		response, err := s.oracle.match(request)
+		if err != nil {
+			return errorPayload(opcode, statusBadRequest, err)
+		}
+		return matchPayload(response)
+	default:
+		return errorPayload(opcode, statusBadRequest, fmt.Errorf("unknown opcode %d", opcode))
+	}
+}
+
+func (s *server) serve(input io.Reader, output io.Writer) error {
+	reader := bufio.NewReader(input)
+	writer := bufio.NewWriter(output)
+	for {
+		payload, err := readFrame(reader)
+		if errors.Is(err, io.EOF) {
+			return writer.Flush()
+		}
+		if err != nil {
+			return err
+		}
+		if err := writeFrame(writer, s.handle(payload)); err != nil {
+			return err
+		}
+		if err := writer.Flush(); err != nil {
+			return err
+		}
+	}
+}

--- a/fuzz/oracle/protocol_test.go
+++ b/fuzz/oracle/protocol_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func requestFrame(payload []byte) []byte {
+	var buffer bytes.Buffer
+	if err := writeFrame(&buffer, payload); err != nil {
+		panic(err)
+	}
+	return buffer.Bytes()
+}
+
+func matchRequestPayload(algorithm algorithmID, scheme schemeID, flags byte, pattern, candidate []byte) []byte {
+	payload := []byte{protocolVersion, opcodeMatch, byte(algorithm), byte(scheme), flags}
+	payload = appendUint32(payload, uint32(len(pattern)))
+	payload = appendUint32(payload, uint32(len(candidate)))
+	payload = append(payload, pattern...)
+	return append(payload, candidate...)
+}
+
+func responseFrames(t *testing.T, data []byte) [][]byte {
+	t.Helper()
+	reader := bytes.NewReader(data)
+	var frames [][]byte
+	for reader.Len() > 0 {
+		payload, err := readFrame(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		frames = append(frames, payload)
+	}
+	return frames
+}
+
+func testServer(t *testing.T, scheme schemeID) *server {
+	t.Helper()
+	oracle, err := newRawOracle(scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &server{oracle: oracle}
+}
+
+func TestPersistentInfoAndMatch(t *testing.T) {
+	server := testServer(t, schemeDefault)
+	input := append(requestFrame([]byte{protocolVersion, opcodeInfo}), requestFrame(
+		matchRequestPayload(algorithmV2, schemeDefault, flagCaseSensitive|flagForward, []byte("fzf"), []byte("src/fzf")))...)
+	var output bytes.Buffer
+	if err := server.serve(bytes.NewReader(input), &output); err != nil {
+		t.Fatal(err)
+	}
+
+	frames := responseFrames(t, output.Bytes())
+	if len(frames) != 2 {
+		t.Fatalf("got %d response frames; want 2", len(frames))
+	}
+	if !bytes.Contains(frames[0], []byte(pinnedUpstreamCommit)) || !bytes.Contains(frames[0], []byte(runtime.Version())) {
+		t.Fatalf("INFO response lacks build identity: %x", frames[0])
+	}
+
+	match := frames[1]
+	if got := hex.EncodeToString(match); got != "010100010100000000000000040000000000000007000000000000005400000003000000000000000400000000000000050000000000000006" {
+		t.Fatalf("unexpected deterministic MATCH response: %s", got)
+	}
+}
+
+func TestV2Alignment(t *testing.T) {
+	oracle := testServer(t, schemeDefault).oracle
+	response, err := oracle.match(matchRequest{
+		algorithm: algorithmV2,
+		scheme:    schemeDefault,
+		flags:     flagForward,
+		pattern:   []byte("/a"),
+		candidate: []byte("a//a"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !response.matched || response.start != 2 || response.end != 4 || response.score != 59 {
+		t.Fatalf("unexpected result: %+v", response)
+	}
+	if len(response.positions) != 2 || response.positions[0] != 2 || response.positions[1] != 3 {
+		t.Fatalf("unexpected positions: %v", response.positions)
+	}
+}
+
+func TestMalformedUTF8UsesGoRuneError(t *testing.T) {
+	oracle := testServer(t, schemeDefault).oracle
+	response, err := oracle.match(matchRequest{
+		algorithm: algorithmV2,
+		scheme:    schemeDefault,
+		flags:     flagCaseSensitive | flagForward,
+		pattern:   []byte{0xff},
+		candidate: []byte{0xfe},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !response.matched || response.start != 0 || response.end != 1 {
+		t.Fatalf("Go replacement-rune behavior changed: %+v", response)
+	}
+}
+
+func TestContiguousMatcherReportsNilPositions(t *testing.T) {
+	oracle := testServer(t, schemeDefault).oracle
+	response, err := oracle.match(matchRequest{
+		algorithm: algorithmExact,
+		scheme:    schemeDefault,
+		flags:     flagCaseSensitive | flagForward,
+		pattern:   []byte("foo"),
+		candidate: []byte("x foo y"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !response.matched || response.start != 2 || response.end != 5 || response.positionsPresent {
+		t.Fatalf("unexpected exact result: %+v", response)
+	}
+}
+
+func TestBadRequestDoesNotStopServer(t *testing.T) {
+	server := testServer(t, schemeDefault)
+	bad := requestFrame([]byte{protocolVersion, opcodeMatch})
+	good := requestFrame([]byte{protocolVersion, opcodeInfo})
+	var output bytes.Buffer
+	if err := server.serve(bytes.NewReader(append(bad, good...)), &output); err != nil {
+		t.Fatal(err)
+	}
+	frames := responseFrames(t, output.Bytes())
+	if len(frames) != 2 || frames[0][2] != statusBadRequest || frames[1][2] != statusOK {
+		t.Fatalf("unexpected statuses: %v", frames)
+	}
+}
+
+func TestSchemeIsFixedPerProcess(t *testing.T) {
+	server := testServer(t, schemeDefault)
+	payload := matchRequestPayload(algorithmV1, schemePath, flagForward, []byte("a"), []byte("a"))
+	response := server.handle(payload)
+	if response[2] != statusBadRequest || !strings.Contains(string(response[7:]), "does not match process scheme") {
+		t.Fatalf("unexpected response: %q", response)
+	}
+}
+
+func TestFrameLimitAndTruncation(t *testing.T) {
+	var oversized [4]byte
+	binary.BigEndian.PutUint32(oversized[:], maxFrameSize+1)
+	if _, err := readFrame(bytes.NewReader(oversized[:])); err == nil {
+		t.Fatal("oversized frame succeeded")
+	}
+
+	truncated := []byte{0, 0, 0, 3, 1, 2}
+	if _, err := readFrame(bytes.NewReader(truncated)); err != io.ErrUnexpectedEOF {
+		t.Fatalf("got %v; want unexpected EOF", err)
+	}
+}

--- a/fuzz/oracle/test.sh
+++ b/fuzz/oracle/test.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eu
+
+pin=1372d04f79bde0daa3bab4b96a068baafa808e67
+go_pin=go1.27.1
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 FZF_SOURCE" >&2
+  exit 2
+fi
+
+source_dir=$(CDPATH= cd -- "$1" && pwd)
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+source_commit=$(git -C "$source_dir" rev-parse HEAD)
+if [ "$source_commit" != "$pin" ]; then
+  echo "fzf source is at $source_commit; expected $pin" >&2
+  exit 2
+fi
+
+go_version=$(go env GOVERSION)
+if [ "$go_version" != "$go_pin" ]; then
+  echo "Go version is $go_version; expected $go_pin" >&2
+  exit 2
+fi
+
+temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/fzf-raw-oracle-test.XXXXXX")
+trap 'rm -rf "$temp_dir"' EXIT HUP INT TERM
+
+build_dir=$temp_dir/build
+"$script_dir/prepare.sh" "$source_dir" "$build_dir"
+
+cd "$build_dir"
+GOWORK=off go test -count=1 -timeout=60s -mod=vendor -trimpath \
+  -buildvcs=false .
+GOWORK=off go vet -mod=vendor .
+
+first=$temp_dir/oracle-first
+second=$temp_dir/oracle-second
+"$script_dir/build.sh" "$source_dir" "$first"
+"$script_dir/build.sh" "$source_dir" "$second"
+if ! cmp -s "$first" "$second"; then
+  echo "two oracle builds from the same source differ" >&2
+  cksum "$first" "$second" >&2
+  exit 1
+fi
+
+if go version -m "$first" | grep -q '=>'; then
+  echo "oracle module data contains a local replacement" >&2
+  go version -m "$first" >&2
+  exit 1
+fi

--- a/fuzz/upstream-parity-handoff.org
+++ b/fuzz/upstream-parity-handoff.org
@@ -1,0 +1,294 @@
+#+title: PR 48 hand-off
+#+author: Codex
+#+date: 2026-09-06
+#+startup: overview
+
+* Purpose
+
+This document transfers [[https://github.com/dangduc/fzf-native/pull/48][PR 48]] to =@dangduc=.
+It records the current state, completed work, review evidence, known debt, and next actions.
+This document is a dated snapshot at commit =13b2365=.
+
+* Current state
+
+| Field | Value |
+|-------+-------|
+| Title | Add an upstream differential fuzz regime |
+| State | Open draft |
+| Base | =dangduc/fzf-native:main= |
+| Head | =fastducduc:codex/fzf-upstream-parity-fuzz= |
+| Reviewed code commit | =13b2365b61f5b1d4375c29d7cdae442125c76acb= |
+| Merge state | Mergeable and clean |
+| Maintainer edits | Enabled |
+| CI for reviewed code | All jobs passed |
+
+The local branch has no changes and matches the fork branch.
+The reviewed code change contains 26 files, 5,215 insertions, and 199 deletions.
+
+Five inline review threads remain open.
+Each thread has a fix and a reply.
+No requested reviewer or formal approval exists.
+
+The author has read access to =dangduc/fzf-native= and write access to the fork.
+Thus, =@dangduc= must mark the PR ready, resolve threads, and merge it.
+
+* Change summary
+
+The PR adds a differential-test system that uses junegunn/fzf as the oracle.
+The oracle uses [[https://github.com/junegunn/fzf/tree/1372d04f79bde0daa3bab4b96a068baafa808e67][fzf commit =1372d04f79bde0daa3bab4b96a068baafa808e67=]] and Go =1.27.1=.
+
+The PR adds these test lanes:
+
+- A raw C and Go algorithm lane with persistent framed peers.
+- A parsed-query lane with stable candidate identities.
+- Native libFuzzer targets with metamorphic relations.
+- Persistent-session state and reader targets.
+- An Emacs ABI lane for scalar, batch, and session calls.
+- ASan, UBSan, TSan, corpus replay, corpus merge, and scheduled CI jobs.
+
+Read [[file:README.org][fuzz/README.org]] for the complete test guide.
+Read [[file:oracle/README.org][fuzz/oracle/README.org]] for the raw protocol and oracle contract.
+Read [[https://github.com/dangduc/fzf-native/pull/46][PR 46]] for the implementation comparison.
+
+* File ownership
+
+| Path | Responsibility |
+|------+----------------|
+| =fzf.c= and =fzf-additions.c= | Production matcher behavior. |
+| =fuzz/oracle/= | The pinned Go oracle and wire protocol. |
+| =fuzz/differential/= | Structured generators and the exception policy. |
+| =fuzz/fzf-native-algo-driver.c= | The test-only native peer. |
+| =fuzz/fzf-native-session-fuzz.c= | Persistent-session libFuzzer targets. |
+| =fuzz/fzf-native-fuzz-test.el= | Deterministic public-ABI properties. |
+| =.github/workflows/fuzz.yaml= | Short PR jobs and longer weekly jobs. |
+
+Learned corpora are temporary.
+Add a permanent seed only after you identify a confirmed defect.
+Add a focused regression test with each permanent seed.
+
+* Commit map
+
+| Commit | Purpose |
+|--------+---------|
+| =f556840= | Add the upstream differential fuzz regime. |
+| =b565b1e= | Correct the CMake format job. |
+| =c614991= | Correct four defects from the code review. |
+| =13b2365= | Make the malformed-input exception fail closed. |
+
+* Code review
+
+Six independent reviewer personas completed three review rounds.
+The roles were John Ousterhout, Dan Luu, Linus Torvalds, Kyle Kingsbury, and two contrarian reviewers.
+
+Each reviewer wrote executable probes before the reviewer reported a finding.
+Actionable probes became permanent tests in this branch.
+
+The review found and corrected these defects:
+
+| Priority | Finding | Fix | Thread |
+|----------+---------+-----+--------|
+| P1 | Filter-only EqualMatch removed required edge spaces. | =c614991= | [[https://github.com/dangduc/fzf-native/pull/48#discussion_r3946625706][review thread]] |
+| P1 | One malformed decoy waived a valid membership loss. | =c614991= | [[https://github.com/dangduc/fzf-native/pull/48#discussion_r3946625948][review thread]] |
+| P2 | Go read stderr while =os/exec= wrote it. | =c614991= | [[https://github.com/dangduc/fzf-native/pull/48#discussion_r3946626344][review thread]] |
+| P2 | The reader fuzzer waited for an unreachable epoch. | =c614991= | [[https://github.com/dangduc/fzf-native/pull/48#discussion_r3946627242][review thread]] |
+| P1 | A malformed query waived a valid-candidate loss. | =13b2365= | [[https://github.com/dangduc/fzf-native/pull/48#discussion_r3946675126][review thread]] |
+
+Two malformed-input threads refer to old lines after =13b2365=.
+The replies in both threads describe the final rule.
+
+Review probes remain under =/private/tmp/pr48-review= on the author machine.
+The committed tests are the durable evidence.
+
+* Validation evidence
+
+The current head passed these local gates:
+
+- The C suite passed with ASan and UBSan.
+- The parser allocation tests passed at all 25 failure sites.
+- The scorer allocation tests passed across 36 injected failures.
+- Both session corpora passed with TSan.
+- The raw oracle passed 20,000 membership comparisons.
+- The parsed common profile passed 5,000 cases.
+- Those 5,000 cases contained 117 candidate-scoped malformed-input exceptions.
+- A separate 20,000-case audit found no valid or unknown identity waivers.
+- The long profile passed candidate lengths 999, 1000, and 1001.
+- The Emacs 30.2 suite passed 168 of 168 tests.
+- The Emacs ABI lane passed 500 generated cases and 100 interactive sessions.
+
+Short libFuzzer runs completed without a finding:
+
+| Target | Executions |
+|--------+------------|
+| Matcher | 68,540 |
+| Session state | 5,756 |
+| Session reader | 125 |
+
+GitHub Actions passed Linux, FreeBSD, Windows, macOS arm64, and macOS x86-64 jobs.
+The Emacs 30.1 and snapshot jobs passed on each configured platform.
+The format, fuzz, and Linux smoke jobs also passed.
+
+* Difference policy
+
+Only malformed UTF-8 decoder behavior is an accepted difference.
+The rule applies only to membership and position differences.
+
+Each differing identity must resolve to a candidate with malformed bytes.
+A malformed query does not waive a difference for a valid candidate.
+Valid UTF-8 differences always fail.
+
+Read [[file:differential/fzf-native-differential-exceptions.el][the exception policy]] before you change an exception.
+Do not broaden an exception to make a generated case pass.
+
+* Known parity debt
+
+This PR adds the parity test system.
+It does not give full result parity with upstream fzf.
+
+The strict full-result audit reports score, range, or position differences in 19,268 of 20,000 cases.
+Membership passes for the same raw matrix.
+
+These areas remain explicit parity debt:
+
+- Score values and ranges.
+- Position lists.
+- Result ranking.
+- Normalization.
+- Backward matching.
+- Path and history scoring schemes.
+- Boundary syntax.
+
+The strict full-result mode is red by design.
+Do not hide this debt with the malformed-input exception.
+
+If you want the expected-red parity audits, run these commands:
+
+#+begin_src sh
+make FUZZ_CC=clang FZF_SOURCE=/path/to/pinned/fzf \
+  FZF_RAW_MATRIX_FULL_RESULTS=1 fuzz-oracle-test-san
+
+make FZF_SOURCE=/path/to/pinned/fzf \
+  FZF_NATIVE_UPSTREAM_PROFILE=parity fuzz-upstream-pinned
+#+end_src
+
+* Coverage limits
+
+The end-to-end session lane compares completed rounds.
+It does not compare each partial result during producer input.
+
+The ABI lane uses deterministic ERT properties.
+It is not coverage-guided ABI fuzzing.
+
+[[file:../abi-fuzzing-plan.org][abi-fuzzing-plan.org]] does not show the completed state of PR 48.
+It does not add the planned ABI sanitizer runner, AFL++, or ABI source-coverage guidance.
+
+The raw oracle covers matcher algorithms.
+It does not cover the upstream parser, ranking system, or interactive state.
+
+* PR structure decision
+
+The current PR is much larger than the preferred 100-line review unit.
+An earlier request asked for a series of stacked PRs.
+
+The fork author cannot create stack branches in =dangduc/fzf-native=.
+GitHub native stacks work best with all stack branches in one repository.
+
+If you require a stack, create the stack branches in =dangduc/fzf-native=.
+Use each preceding branch as the base of the next PR.
+Preserve the oracle pin and exception policy in every buildable unit.
+
+If you keep PR 48 intact, request a maintainer review before you mark it ready.
+
+* Pickup procedure
+
+1. Create a local branch for the PR.
+
+   #+begin_src sh
+   gh pr checkout 48 --repo dangduc/fzf-native
+   #+end_src
+
+2. Make sure that the branch has no unexpected changes.
+
+   #+begin_src sh
+   git status --short --branch
+   #+end_src
+
+3. Make sure that the current-head jobs still pass.
+
+   #+begin_src sh
+   gh pr checks 48 --repo dangduc/fzf-native
+   #+end_src
+
+4. Read the five review threads in the review table.
+
+5. Decide whether to keep one PR or create an upstream stack.
+
+6. If you keep one PR, request review and mark the draft ready.
+
+   #+begin_src sh
+   gh pr ready 48 --repo dangduc/fzf-native
+   #+end_src
+
+7. Resolve each review thread after you accept its fix.
+
+8. Merge the PR with the repository merge method after the required review.
+
+* Minimum local gates
+
+Set a junegunn/fzf checkout to the pinned commit before you run the oracle gates.
+Use Go =1.27.1= for the raw oracle build.
+
+#+begin_src sh
+make FUZZ_CC=clang fuzz-replay
+
+make BUILD_DIR=/tmp/fzf-ctest CC=clang ctest-asan
+
+make BUILD_DIR=/tmp/fzf-tsan FUZZ_CC=clang fuzz-session-tsan
+
+make BUILD_DIR=/tmp/fzf-oracle FUZZ_CC=clang \
+  FZF_SOURCE=/path/to/pinned/fzf fuzz-oracle-test-san
+
+make FZF_SOURCE=/path/to/pinned/fzf \
+  FZF_NATIVE_UPSTREAM_CASES=5000 fuzz-upstream-pinned
+
+make fuzz-elisp
+make test
+#+end_src
+
+If Emacs reports stale bytecode, rebuild the bytecode before you interpret a failure.
+Use a fresh build directory for sanitizer and oracle runs.
+
+* Failure workflow
+
+1. Replay the exact seed and serial number.
+
+2. Reduce the input while you preserve the same failure.
+
+3. Identify a product defect or a documented implementation difference.
+
+4. If the product has a defect, correct it and add a permanent test.
+
+5. If an exception is necessary, give it an owner and a removal condition.
+
+6. Run the related sanitizer and differential gates again.
+
+* Next parity units
+
+The next work can use these independent units:
+
+1. Align raw scores, ranges, and positions.
+
+2. Align ranking and equal-score tie rules.
+
+3. Add path and history scoring schemes.
+
+4. Expose normalization, backward matching, and boundary syntax.
+
+5. Compare partial session results during producer input.
+
+6. Add coverage-guided fuzzing at the Emacs ABI boundary.
+
+* Handoff boundary
+
+The continuous native fuzz automation remains paused.
+No active fuzz campaign owns a corpus directory.
+The branch is clean, pushed, and ready for maintainer action.

--- a/fzf-additions-test.c
+++ b/fzf-additions-test.c
@@ -140,6 +140,50 @@ static void test_equal_no_match_different_string(void) {
                   CaseIgnore, true, false);
 }
 
+static void test_equal_preserves_pattern_edge_whitespace(void) {
+  fzf_string_t ascii_text = {.data = "- ", .size = 2};
+  fzf_string_t ascii_pattern = {.data = "- ", .size = 2};
+  fzf_result_t ascii = fzf_equal_match(
+      false, false, &ascii_text, &ascii_pattern, NULL, NULL);
+  CHECK(ascii.start == 0);
+  CHECK(ascii.end == 2);
+  CHECK(ascii.score > 0);
+
+  fzf_string_t ascii_leading_text = {.data = " -", .size = 2};
+  fzf_string_t ascii_leading_pattern = {.data = " -", .size = 2};
+  fzf_result_t ascii_leading = fzf_equal_match(
+      false, false, &ascii_leading_text, &ascii_leading_pattern, NULL, NULL);
+  CHECK(ascii_leading.start == 0);
+  CHECK(ascii_leading.end == 2);
+  CHECK(ascii_leading.score > 0);
+
+  fzf_string_t space_text = {.data = " ", .size = 1};
+  fzf_string_t space_pattern = {.data = " ", .size = 1};
+  fzf_result_t space = fzf_equal_match(
+      false, false, &space_text, &space_pattern, NULL, NULL);
+  CHECK(space.start == 0);
+  CHECK(space.end == 1);
+  CHECK(space.score > 0);
+
+  fzf_string_t utf8_text = {.data = "你 ", .size = strlen("你 ")};
+  fzf_string_t utf8_pattern = {.data = "你 ", .size = strlen("你 ")};
+  fzf_result_t utf8 = fzf_equal_match_utf8(
+      false, false, &utf8_text, &utf8_pattern, NULL, NULL);
+  CHECK(utf8.start == 0);
+  CHECK(utf8.end == 2);
+  CHECK(utf8.score > 0);
+
+  fzf_string_t utf8_leading_text = {
+      .data = " 你", .size = strlen(" 你")};
+  fzf_string_t utf8_leading_pattern = {
+      .data = " 你", .size = strlen(" 你")};
+  fzf_result_t utf8_leading = fzf_equal_match_utf8(
+      false, false, &utf8_leading_text, &utf8_leading_pattern, NULL, NULL);
+  CHECK(utf8_leading.start == 0);
+  CHECK(utf8_leading.end == 2);
+  CHECK(utf8_leading.score > 0);
+}
+
 static void test_negation_term_excludes(void) {
   /* "foo !bar" — must contain foo AND must NOT contain bar. */
   check_agreement("negation excludes", "src/foobar.c", "foo !bar",
@@ -498,6 +542,7 @@ int main(void) {
   RUN(test_anchored_matches_trim_candidate_whitespace);
   RUN(test_equal_match);
   RUN(test_equal_no_match_different_string);
+  RUN(test_equal_preserves_pattern_edge_whitespace);
   RUN(test_negation_term_excludes);
   RUN(test_and_across_term_sets);
   RUN(test_or_within_term_set);

--- a/fzf-additions-test.c
+++ b/fzf-additions-test.c
@@ -184,6 +184,24 @@ static void test_equal_preserves_pattern_edge_whitespace(void) {
   CHECK(utf8_leading.score > 0);
 }
 
+static void test_parsed_equal_preserves_escaped_edge_whitespace(void) {
+  /* Exercise the public parser and both fuzzy settings.  In either mode the
+     two anchors select EqualMatch; escaped spaces belong to the term and must
+     not be trimmed from the candidate before the cheap membership check. */
+  check_agreement("fuzzy equal escaped leading space", " -", "^\\ -$",
+                  CaseRespect, true, true);
+  check_agreement("fuzzy equal escaped trailing space", "- ", "^-\\ $",
+                  CaseRespect, true, true);
+  check_agreement("fuzzy equal escaped single space", " ", "^\\ $",
+                  CaseRespect, true, true);
+  check_agreement("exact equal escaped leading space", " -", "^\\ -$",
+                  CaseRespect, false, true);
+  check_agreement("exact equal escaped trailing space", "- ", "^-\\ $",
+                  CaseRespect, false, true);
+  check_agreement("exact equal escaped single space", " ", "^\\ $",
+                  CaseRespect, false, true);
+}
+
 static void test_negation_term_excludes(void) {
   /* "foo !bar" — must contain foo AND must NOT contain bar. */
   check_agreement("negation excludes", "src/foobar.c", "foo !bar",
@@ -543,6 +561,7 @@ int main(void) {
   RUN(test_equal_match);
   RUN(test_equal_no_match_different_string);
   RUN(test_equal_preserves_pattern_edge_whitespace);
+  RUN(test_parsed_equal_preserves_escaped_edge_whitespace);
   RUN(test_negation_term_excludes);
   RUN(test_and_across_term_sets);
   RUN(test_or_within_term_set);

--- a/fzf-additions.c
+++ b/fzf-additions.c
@@ -112,10 +112,13 @@ static bool fzf_addn_suffix(bool case_sensitive,
 static bool fzf_addn_equal(bool case_sensitive,
                            const char *text, size_t tn,
                            const char *pat,  size_t pn) {
+  if (pn == 0) return false;
   size_t start = 0;
   size_t end = tn;
-  while (start < end && fzf_addn_space((unsigned char)text[start])) start++;
-  while (end > start && fzf_addn_space((unsigned char)text[end - 1])) end--;
+  if (!fzf_addn_space((unsigned char)pat[0]))
+    while (start < end && fzf_addn_space((unsigned char)text[start])) start++;
+  if (!fzf_addn_space((unsigned char)pat[pn - 1]))
+    while (end > start && fzf_addn_space((unsigned char)text[end - 1])) end--;
   if (end - start != pn) return false;
   if (case_sensitive) return memcmp(text + start, pat, pn) == 0;
   for (size_t i = 0; i < pn; i++)

--- a/fzf.c
+++ b/fzf.c
@@ -1445,8 +1445,14 @@ fzf_result_t fzf_equal_match(bool case_sensitive, bool normalize,
     return (fzf_result_t){-1, -1, 0};
   }
 
-  size_t trimmed_len = leading_whitespaces(text);
-  size_t trimmed_end_len = trailing_whitespaces(text);
+  size_t trimmed_len = 0;
+  if (!fzf_unicode_is_space((uint8_t)pattern->data[0])) {
+    trimmed_len = leading_whitespaces(text);
+  }
+  size_t trimmed_end_len = 0;
+  if (!fzf_unicode_is_space((uint8_t)pattern->data[M - 1])) {
+    trimmed_end_len = trailing_whitespaces(text);
+  }
   size_t content_len = trimmed_len + trimmed_end_len >= text->size
                          ? 0
                          : text->size - trimmed_len - trimmed_end_len;
@@ -1813,8 +1819,27 @@ fzf_result_t fzf_equal_match_utf8(bool case_sensitive, bool normalize,
     return (fzf_result_t){-1, -1, 0};
   }
 
-  size_t trimmed_start = leading_whitespaces(text);
-  size_t trimmed_end_len = trailing_whitespaces(text);
+  utf8proc_int32_t first_pattern_cp = 0;
+  (void)utf8_iterate_lossy(
+      (const utf8proc_uint8_t *)pattern->data, M, &first_pattern_cp);
+  utf8proc_int32_t last_pattern_cp = first_pattern_cp;
+  for (size_t pattern_pos = 0; pattern_pos < M;) {
+    utf8proc_int32_t cp;
+    utf8proc_ssize_t width = utf8_iterate_lossy(
+        (const utf8proc_uint8_t *)pattern->data + pattern_pos,
+        (utf8proc_ssize_t)(M - pattern_pos), &cp);
+    last_pattern_cp = cp;
+    pattern_pos += (size_t)width;
+  }
+
+  size_t trimmed_start = 0;
+  if (!fzf_unicode_is_space(first_pattern_cp)) {
+    trimmed_start = leading_whitespaces(text);
+  }
+  size_t trimmed_end_len = 0;
+  if (!fzf_unicode_is_space(last_pattern_cp)) {
+    trimmed_end_len = trailing_whitespaces(text);
+  }
   /* Leading and trailing whitespace regions overlap when the candidate is
      entirely whitespace.  Clamp that case to an empty content slice instead
      of underflowing size_t and asking utf8_strlen to scan arbitrary memory. */


### PR DESCRIPTION
## Summary

- Pin junegunn/fzf at commit 1372d04f79bde0daa3bab4b96a068baafa808e67 and Go 1.27.1.
- Add persistent raw Go and C matcher peers with a framed binary protocol.
- Add deterministic generators for raw algorithms, parsed queries, Unicode, malformed bytes, duplicate candidates, length boundaries, and interactive query rounds.
- Add native metamorphic checks, persistent-session libFuzzer targets, Emacs ABI properties, sanitizer replay, TSan replay, corpus merging, and scheduled CI coverage.
- Add a narrow executable exception policy. Only malformed UTF-8 decoder differences pass. Valid UTF-8 differences always fail.

## Found defect

The raw differential matrix found that EqualMatch removed candidate edge whitespace even when the pattern contained that whitespace. The patch aligns the ASCII and UTF-8 implementations with upstream fzf and adds focused regressions.

## Validation

- C and ASan/UBSan suites pass, including parser and scorer allocation-failure tests.
- Permanent matcher and session corpora pass under ASan, UBSan, and TSan.
- The raw sanitizer lane passes 20,000 membership comparisons.
- The parsed common profile passes 1,000 cases and two persistent sessions. It records 24 narrowly classified malformed UTF-8 differences.
- The long profile passes the 999, 1000, and 1001 length boundaries without exceptions.
- Emacs ABI fuzz passes 500 public-ABI cases and 100 interactive sessions.
- The complete Emacs 30.2 suite passes 168 of 168 tests.
- Short libFuzzer runs completed 68,540 matcher, 5,756 session-state, and 125 reader executions without findings.

## Known parity debt

The strict full-result audit deliberately remains red. It reports score, range, and position differences in 19,268 of 20,000 generated cases while membership passes. Ranking, normalization, backward matching, path/history schemes, and boundary syntax remain explicit parity work. None of these differences are waived by the accepted exception policy.

The fuzz guide documents replay commands, failure records, exception removal rules, and CI cadence.
