### PR TITLE
benchmarks: publish full SIMD prefilter A/B results

### DIFF
--- a/benchmarks/2026-09-08T111924Z.md
+++ b/benchmarks/2026-09-08T111924Z.md
@@ -1,0 +1,298 @@
+# Full SIMD benchmark follow-up
+
+Date: 2026-09-08T11:19:24Z
+
+This report compares the parent of pull request 51 with the merged result.
+
+- Base: `0fb77593d449d15722847a650c99516b14f81c43`
+- Main: `0c971fd76969cbd66e78183d510c05f77199fdcb`
+- Pull request head: `9384f10ceeac6b3df380a14690a678fb96ff0d5e`
+
+The pull request head and the merge commit have the same Git tree.
+Lower times are better. A speedup value greater than 1 favors main.
+
+## Result
+
+The fuzzy-benches and Frizbee holdouts favor main in most ASCII rows.
+The miss-heavy Chromium workload improves by 1.8%, with ten wins from ten pairs.
+The fuzzy micro-workload geometric means improve by 0.3% and 0.5%.
+The Arabic and Korean controls are flat.
+
+The focused scorer shows the intended fast-path gains.
+The Chromium shape runs 1.139 times as fast.
+The exact-literal shape runs 1.374 times as fast.
+
+The full run also finds hit-heavy regressions.
+The repeated `emacs` hit uses 9.3% to 10.1% more time.
+The long-sparse and extended hits use 4.8% to 6.3% more time.
+Public one-byte misses use 2.8% to 3.7% more time.
+Case-fold hits use about 2.0% more time.
+CJK hits use 0.6% to 1.3% more time.
+
+The interactive one-worker trace is flat.
+The five-pair Emacs macrobenchmark is unresolved.
+The Skim holdout finds a likely regression for short queries with eight workers.
+
+The SIMD prefilter helps long, miss-heavy ASCII workloads.
+It is not a general speedup for hit-heavy or short workloads.
+
+## External holdouts
+
+Each harness used ten alternating process pairs.
+Criterion used a one-second warmup, a two-second measurement, and 20 samples.
+The table contains 380 fresh estimates.
+
+| Harness and case | Base median | Main median | Paired speedup, 95% interval | Main wins |
+|---|---:|---:|---:|---:|
+| fuzzy, medium-start score | 1.277 us | 1.278 us | 1.000x `[0.989, 1.006]` | 5/10 |
+| fuzzy, medium-start score plus positions | 2.594 us | 2.590 us | 1.000x `[0.996, 1.008]` | 4/10 |
+| fuzzy, medium-middle score | 0.904 us | 0.894 us | 1.009x `[1.008, 1.012]` | 9/10 |
+| fuzzy, medium-middle score plus positions | 1.854 us | 1.835 us | 1.011x `[1.001, 1.012]` | 8/10 |
+| fuzzy, medium-end score | 0.541 us | 0.540 us | 1.002x `[0.998, 1.005]` | 7/10 |
+| fuzzy, medium-end score plus positions | 1.150 us | 1.141 us | 1.010x `[1.003, 1.011]` | 8/10 |
+| fuzzy, long-start score | 7.809 us | 7.787 us | 1.002x `[0.999, 1.008]` | 8/10 |
+| fuzzy, long-start score plus positions | 15.658 us | 15.618 us | 1.000x `[0.994, 1.008]` | 5/10 |
+| fuzzy, long-middle score | 2.705 us | 2.697 us | 1.004x `[0.994, 1.013]` | 6/10 |
+| fuzzy, long-middle score plus positions | 5.480 us | 5.435 us | 1.008x `[1.002, 1.015]` | 9/10 |
+| fuzzy, long-end score | 8.774 us | 8.694 us | 1.007x `[0.995, 1.019]` | 7/10 |
+| fuzzy, long-end score plus positions | 17.669 us | 17.502 us | 1.007x `[0.994, 1.022]` | 7/10 |
+| fuzzy, `emacs` score | 5.970 ms | 5.937 ms | 1.006x `[1.004, 1.007]` | 9/10 |
+| fuzzy, `emacs` score plus positions | 7.921 ms | 7.784 ms | 1.017x `[1.015, 1.019]` | 9/10 |
+| fuzzy, `e-macs` score | 10.460 ms | 10.392 ms | 1.007x `[1.004, 1.011]` | 10/10 |
+| fuzzy, `e-macs` score plus positions | 22.773 ms | 22.607 ms | 1.007x `[1.004, 1.009]` | 9/10 |
+| Frizbee, Chromium | 144.793 ms | 142.183 ms | 1.018x `[1.018, 1.021]` | 10/10 |
+| Frizbee, Arabic | 47.981 ms | 48.137 ms | 0.996x `[0.994, 1.003]` | 3/10 |
+| Frizbee, Korean | 35.247 ms | 35.261 ms | 0.999x `[0.998, 1.004]` | 3/10 |
+
+### Six-workload geometric mean
+
+| Mode | Base | Main | Paired speedup, 95% interval | Main wins |
+|---|---:|---:|---:|---:|
+| Score | 2.208 us | 2.198 us | 1.003x `[1.000, 1.006]` | 9/10 |
+| Score plus positions | 4.508 us | 4.477 us | 1.005x `[0.997, 1.009]` | 8/10 |
+
+Every external process ran a semantic preflight.
+All score, position, match-count, and sorted-tuple fingerprints matched.
+
+## Core scorer
+
+Each process reports the median of 11 samples.
+The table uses nine alternating process pairs.
+
+| Case | Base median | Main median | Paired speedup, 95% interval | Main wins |
+|---|---:|---:|---:|---:|
+| Early ASCII hit | 0.537 ms | 0.529 ms | 1.011x `[1.008, 1.023]` | 9/9 |
+| One-byte candidates | 0.253 ms | 0.262 ms | 0.966x `[0.948, 0.985]` | 0/9 |
+| Chromium shape | 1.686 ms | 1.484 ms | 1.139x `[1.125, 1.160]` | 9/9 |
+| ASCII literal | 1.245 ms | 0.917 ms | 1.374x `[1.330, 1.407]` | 9/9 |
+| Arabic shape | 5.429 ms | 5.411 ms | 1.004x `[1.000, 1.014]` | 7/9 |
+| Korean shape | 6.194 ms | 6.188 ms | 1.001x `[0.997, 1.005]` | 5/9 |
+| UTF-8 hit | 14.484 ms | 14.441 ms | 1.005x `[0.998, 1.011]` | 5/9 |
+| UTF-8 v1 early hit | 31.649 ms | 31.405 ms | 1.000x `[0.987, 1.028]` | 5/9 |
+| UTF-8 v1 late hit | 47.585 ms | 47.276 ms | 1.003x `[0.991, 1.013]` | 6/9 |
+
+All result checksums matched.
+
+## One-byte paths
+
+Each process reports the median of 101 samples.
+Each sample makes 20,800 calls.
+The table uses nine alternating process pairs.
+
+| Path and case | Base median | Main median | Paired speedup, 95% interval | Main wins |
+|---|---:|---:|---:|---:|
+| Direct, all hit | 10.05 ns | 9.81 ns | 1.024x `[1.024, 1.024]` | 9/9 |
+| Direct, folded hit | 11.92 ns | 11.92 ns | 1.000x `[1.000, 1.000]` | 1/9 |
+| Direct, all miss | 3.17 ns | 3.17 ns | 1.000x `[1.000, 1.000]` | 0/9 |
+| Direct, one hit in 26 | 3.80 ns | 3.75 ns | 1.000x `[0.987, 1.013]` | 3/9 |
+| Direct, case-sensitive miss | 3.17 ns | 3.17 ns | 1.000x `[1.000, 1.000]` | 0/9 |
+| Public API, all hit | 14.62 ns | 14.57 ns | 1.003x `[1.003, 1.006]` | 8/9 |
+| Public API, folded hit | 16.39 ns | 16.68 ns | 0.983x `[0.983, 0.986]` | 0/9 |
+| Public API, all miss | 7.93 ns | 8.22 ns | 0.965x `[0.965, 0.965]` | 0/9 |
+| Public API, one hit in 26 | 8.46 ns | 8.70 ns | 0.972x `[0.967, 0.972]` | 0/9 |
+
+The direct all-hit path improves by 2.4%.
+The other direct byte paths are mostly flat.
+The public path adds 1.7% to 3.5% for three short cases.
+The probe prints two decimal places, so equal interval endpoints are quantized.
+
+## Symmetric score-and-positions probe
+
+Both revisions contain the combined API.
+This report compares both APIs across nine alternating process pairs.
+Each process uses 50,000 calls per sample and reports the median of 21 samples.
+
+| Case and API | Base median | Main median | Paired speedup, 95% interval | Main wins |
+|---|---:|---:|---:|---:|
+| `emacs`, legacy | 1175.2 ns | 1293.4 ns | 0.911x `[0.907, 0.927]` | 0/9 |
+| `emacs`, combined | 609.5 ns | 666.0 ns | 0.915x `[0.910, 0.924]` | 0/9 |
+| `emacs` miss, legacy | 23.0 ns | 24.1 ns | 0.950x `[0.906, 0.983]` | 1/9 |
+| `emacs` miss, combined | 25.7 ns | 26.7 ns | 0.963x `[0.939, 0.978]` | 1/9 |
+| `e-macs`, legacy | 1028.4 ns | 1048.6 ns | 0.979x `[0.957, 1.013]` | 3/9 |
+| `e-macs`, combined | 588.2 ns | 598.4 ns | 0.982x `[0.970, 1.020]` | 3/9 |
+| Simple miss, legacy | 28.2 ns | 29.8 ns | 0.944x `[0.927, 0.986]` | 0/9 |
+| Simple miss, combined | 31.5 ns | 32.3 ns | 0.969x `[0.954, 0.991]` | 1/9 |
+| Long sparse, legacy | 1533.8 ns | 1630.8 ns | 0.948x `[0.938, 0.968]` | 1/9 |
+| Long sparse, combined | 852.3 ns | 893.4 ns | 0.952x `[0.931, 0.968]` | 1/9 |
+| Extended, legacy | 1202.0 ns | 1263.6 ns | 0.951x `[0.943, 0.977]` | 1/9 |
+| Extended, combined | 1202.5 ns | 1262.4 ns | 0.952x `[0.941, 0.977]` | 0/9 |
+| Late AND miss, legacy | 223.0 ns | 229.0 ns | 0.974x `[0.964, 1.001]` | 2/9 |
+| Late AND miss, combined | 224.5 ns | 230.8 ns | 0.974x `[0.966, 1.000]` | 1/9 |
+| CJK, legacy | 833.7 ns | 843.7 ns | 0.987x `[0.980, 0.996]` | 1/9 |
+| CJK, combined | 433.0 ns | 436.5 ns | 0.994x `[0.982, 0.998]` | 1/9 |
+| Case fold, legacy | 1381.5 ns | 1404.9 ns | 0.980x `[0.957, 0.983]` | 0/9 |
+| Case fold, combined | 708.5 ns | 721.9 ns | 0.980x `[0.969, 0.988]` | 0/9 |
+
+All 18 processes produced the same fixed checksum.
+
+### Prefilter attribution
+
+A second main binary disables the SIMD prefilter through the internal worker switch.
+Five alternating pairs compare this binary with normal main.
+Each process uses 50,000 calls per sample and reports the median of 21 samples.
+
+| Hit case | Main, legacy | Disabled, legacy | Main, combined | Disabled, combined |
+|---|---:|---:|---:|---:|
+| `emacs` | 1294.0 ns | 1178.5 ns | 665.5 ns | 609.9 ns |
+| Long sparse | 1622.3 ns | 1524.7 ns | 894.3 ns | 836.8 ns |
+| Extended | 1265.2 ns | 1213.2 ns | 1266.9 ns | 1211.9 ns |
+
+The prefilter scans a matching candidate before the scorer scans it again.
+Disabling the prefilter removes most of the hit-heavy slowdown.
+
+## Interactive session trace
+
+Each process uses 200,000 candidates, one worker, and a 256-result limit.
+Each process reports the median of seven samples.
+The table uses six alternating process pairs.
+
+| Metric | Base median | Main median | Paired speedup, 95% interval | Main wins |
+|---|---:|---:|---:|---:|
+| Full trace | 307.024 ms | 307.135 ms | 1.000x `[0.992, 1.003]` | 4/6 |
+| Narrowing edits | 235.478 ms | 234.701 ms | 1.002x `[0.994, 1.007]` | 4/6 |
+| Backspace cache hits | 0.004 ms | 0.003 ms | timing floor | 3/6 |
+| Unrelated edits | 72.049 ms | 72.315 ms | 0.997x `[0.990, 1.001]` | 2/6 |
+
+Every result matched an independent full scan and sort.
+The timed region excludes session creation, corpus loading, destruction, and validation.
+
+## Session growth
+
+Each process starts with one million candidates.
+It appends 1,000 candidates in each of 40 rounds.
+The table uses five alternating process pairs.
+
+| Metric | Base median | Main median | Paired speedup, 95% interval | Main wins |
+|---|---:|---:|---:|---:|
+| Initial scan | 35.530 ms | 31.740 ms | 1.119x `[0.467, 1.200]` | 3/5 |
+| 40 growth rounds | 13.906 ms | 14.066 ms | 0.988x `[0.388, 1.003]` | 2/5 |
+| Growth-round median | 0.288 ms | 0.289 ms | 0.997x `[0.484, 1.003]` | 1/5 |
+| Growth-round p95 | 0.301 ms | 0.309 ms | 0.980x `[0.158, 0.997]` | 0/5 |
+| Growth-round maximum | 2.773 ms | 2.751 ms | 1.001x `[0.573, 1.011]` | 3/5 |
+
+The process pairs contain scheduler outliers.
+The typical growth rounds stay close to parity.
+
+## Skim persistent-session holdout
+
+Each session loads one million candidates and emits at most 10,000 results.
+Each configuration uses ten alternating measured pairs after balanced warmups.
+The table sums only query-round elapsed times.
+It excludes corpus loading, process startup, and verification.
+
+| Workload | Workers | Base median | Main median | Paired speedup, 95% interval | Main wins |
+|---|---:|---:|---:|---:|---:|
+| Prefix | 1 | 525.974 ms | 525.357 ms | 1.003x `[1.000, 1.009]` | 8/10 |
+| Edit trace | 1 | 320.602 ms | 321.365 ms | 0.998x `[0.997, 1.000]` | 3/10 |
+| Prefix | 8 | 117.668 ms | 127.338 ms | 0.932x `[0.911, 0.957]` | 0/10 |
+| Edit trace | 8 | 83.788 ms | 82.365 ms | 1.015x `[0.976, 1.081]` | 6/10 |
+
+The eight-worker prefix result did not remain stable in a separate 20-pair repeat.
+
+| Repeat metric | Base median | Main median | Paired speedup, 95% interval | Main wins |
+|---|---:|---:|---:|---:|
+| Prefix total | 121.151 ms | 126.408 ms | 0.959x `[0.933, 1.021]` | 8/20 |
+| First `t` round | 31.136 ms | 36.614 ms | 0.891x `[0.736, 1.008]` | 6/20 |
+
+The repeat interval crosses parity.
+Pooling both batches gives a 0.945x paired ratio with a `[0.929, 0.974]` interval.
+Main wins 8 of these 30 pairs.
+The batch baselines differ, so do not use 0.945x as a stable effect size.
+The combined evidence still indicates a likely short-query, eight-worker regression.
+All 120 measured Skim sessions matched the independent result oracle.
+The Skim queries contain one to four bytes, so they do not enter the SIMD fast path.
+
+## Emacs completion macrobenchmark
+
+The harness uses five alternating process pairs.
+Each process measures five sweeps of four needles after one warmup.
+
+| fzf-native style | Base median | Main median | Paired speedup | Main wins |
+|---|---:|---:|---:|---:|
+| Full score, scoring filter | 0.162293 s | 0.169871 s | 0.990x | 0/5 |
+| Full score, default filter | 0.146280 s | 0.149114 s | 0.994x | 2/5 |
+| Filter only, scoring filter | 0.149636 s | 0.151553 s | 1.023x | 3/5 |
+| Filter only, default filter | 0.134295 s | 0.138052 s | 0.991x | 2/5 |
+
+The nine control styles range from 0.988x to 1.011x.
+The five-pair sample cannot resolve changes of this size.
+All 12 Emacs processes produced the same 16-record fzf digest.
+
+## Source and host identity
+
+| Item | Value |
+|---|---|
+| Base tree | `19079ef9e1dbb78f49bb126a4fc00ec4121d14f9` |
+| Main tree | `68802293e22aba39a6643eaf7557b3b587c717f9` |
+| fuzzy-benches fork | `633c6c359f4a6f859ee7c35abd574dd3eafc4910` |
+| Frizbee fork | `f2ec9684559479a428b29dc81b94f38596565b0e` |
+| Skim fork | `998175ed0af817f541f1108e4f686fc7b554fd6b` |
+| Emacs harness | `05ff2cbbaddc8d7b7bb6d12038e46cd55e482dc9` |
+| Base trace harness | `3703493ca9ff128559d3a3a0807df0500014e2fb` |
+| Core probe overlay | SHA-256 `e6c09d9a739801e40f00626d51157878c4f073abd916c8d27e9991f23ce5a34e` |
+| Growth probe overlay | SHA-256 `01965efe60337563d7d9a41969e6423c4d5ac5e48b352992901ab2aff66005d4` |
+| Combined-API probe overlay | SHA-256 `af8282068d5b822fa8aa4a9f8ba7a24dae1360a88495fc67c116a7c44330cbe1` |
+| One-byte probe | SHA-256 `9d5e660f44644c3f23bdde176ca93670e4597088b2e934f07810c20daf913d15` |
+| Attribution shim | SHA-256 `b228a6ef493328fc370a00b304249dd429fe1990606ab0d9dbb4eaa6a70e185b` |
+| Attribution binary | SHA-256 `05c182c11cb1c236eb728050432852a3ea3be53301e86744d49615e881ad8b50` |
+| SIMD header SHA-256 | `2e61fd4266048f5348cd5a125e48a18132ab19b34d985a38951164ddeda625b8` |
+| Host | Apple M3 MacBook Air, 8 cores, 16 GB RAM |
+| Operating system | macOS 26.5.2, build `25F84` |
+| C compilers | Homebrew clang 22.1.8 and Apple clang 21.0.0 |
+| Rust compiler | rustc 1.98.1, LLVM 22.1.8 |
+| Emacs | GNU Emacs 30.2, revision `636f166cfc86` |
+
+The timed work ran from 2026-09-08T10:30:02Z through 2026-09-08T11:18:41Z.
+All timed suites ran serially.
+The base trace commit adds only the shared benchmark source and its build target.
+The harness applied the current-tree probes to both revisions where listed.
+
+## Correctness gates
+
+- All external semantic preflights matched.
+- All core and one-byte checksums matched.
+- All interactive snapshots matched their independent full scans.
+- All Skim protocol, count, query-hash, and result checks matched.
+- All Emacs completion records matched.
+- All primary A/B binaries retained their recorded SHA-256 values.
+
+## Limits
+
+The benchmark adapters omit `fzf-simd-prefilter.h` from their reported source build IDs.
+Fresh target directories compiled the header through the `fzf.c` include.
+This run records the Git revision, the header hash, and each binary hash separately.
+
+The Frizbee result includes scoring, result collection, copying, and stable score sorting.
+It does not use the complete fzf rank order.
+
+The fuzzy-benches position rows call score before positions.
+They do not use the combined API.
+
+The Emacs sample uses a fixed style order and only five pairs.
+Use it for large end-to-end changes, not small percentage claims.
+
+The prefilter attribution is exploratory.
+It has retained output timestamps, binary hashes, and the shim hash.
+It does not have a saved runner or run-order manifest.
+
+The raw run is in `/private/tmp/fzf-pr51-full-bench` on the measurement host.


### PR DESCRIPTION
## Summary

This PR publishes a full A/B benchmark of merged PR #51 against its first parent.

The report compares `0fb77593d449d15722847a650c99516b14f81c43` with `0c971fd76969cbd66e78183d510c05f77199fdcb`. It covers fuzzy-benches, Frizbee, Skim, Emacs, the core scorer, byte paths, interactive sessions, and growth.

## Results

- Miss-heavy ASCII improves. Frizbee Chromium is 1.8% faster. The fuzzy micro-workload geometric means improve 0.3% and 0.5%.
- Focused Chromium and literal shapes run 1.139x and 1.374x as fast.
- Hit-heavy probes regress. The repeated `emacs` hit uses 9.3% to 10.1% more time.
- Long-sparse and extended hits use 4.8% to 6.3% more time. Public one-byte misses use 2.8% to 3.7% more time.
- The single-worker interactive trace is flat. The five-pair Emacs macrobenchmark cannot resolve a change.
- Skim indicates a likely short-query, eight-worker regression. The pooled paired ratio is 0.945x, but batch baselines differ.
- Arabic and Korean controls are flat.

The SIMD prefilter helps long, miss-heavy ASCII workloads. It adds work for matching candidates and short workloads.

## Correctness

All correctness comparisons passed:

- External score, position, count, and fingerprint comparisons matched.
- Core and one-byte checksums matched.
- Interactive results matched independent full scans.
- All 120 measured Skim sessions matched the independent result oracle.
- All Emacs completion records matched.
- All primary A/B binary hashes matched their recorded values.

## Reproducibility

All timed suites ran serially on an Apple M3 MacBook Air. The report records source revisions, probe hashes, host details, intervals, and limits.

See [`benchmarks/2026-09-08T111924Z.md`](https://github.com/fastducduc/fzf-native/blob/codex/publish-full-simd-bench/benchmarks/2026-09-08T111924Z.md) for the full results.