### PR TITLE
Speed up short queries and persistent sessions

### DIFF
--- a/architecture.org
+++ b/architecture.org
@@ -369,7 +369,12 @@ The decoder still scans discarded bytes.
 It therefore detects a NUL after a retained prefix or inside discarded ANSI data.
 
 Candidate strings live in 4 MiB arena chunks.
+Each ordinary arena record carries a two-byte packed byte-length and ASCII tag.
+Long records use a sentinel and are classified again when a worker scores them.
 The reader appends their pointers to fixed pointer blocks.
+
+The incremental decoder derives the ASCII tag while it validates producer bytes.
+Interactive scoring therefore does not repeat =strlen= and ASCII classification for each edit.
 
 One pointer block holds 262,144 entries.
 The fixed top-level table permits at most 1,073,741,824 candidates.

--- a/architecture.org
+++ b/architecture.org
@@ -370,11 +370,11 @@ It therefore detects a NUL after a retained prefix or inside discarded ANSI data
 
 Candidate strings live in 4 MiB arena chunks.
 Each ordinary arena record carries a two-byte packed byte-length and ASCII tag.
-Long records use a sentinel and are classified again when a worker scores them.
+A worker classifies long records again when it scores them.
 The reader appends their pointers to fixed pointer blocks.
 
 The incremental decoder derives the ASCII tag while it validates producer bytes.
-Interactive scoring therefore does not repeat =strlen= and ASCII classification for each edit.
+Thus, interactive workers do not repeat =strlen= and ASCII classification for each edit.
 
 One pointer block holds 262,144 entries.
 The fixed top-level table permits at most 1,073,741,824 candidates.

--- a/benchmarks/2026-09-08T134029Z.md
+++ b/benchmarks/2026-09-08T134029Z.md
@@ -1,0 +1,361 @@
+# Final scorer and session benchmark
+
+Date: 2026-09-08T13:40:29Z
+
+This report compares the current main branch with the frozen optimization candidate.
+
+- Base: `4b9236e8cd1e9f9f3aaf5f2ebf83f1fc5995d38d`
+- Candidate: `684742ce6ac92198c5ffbd802efb446a6cb7e0b0`
+
+Lower times are better. A speedup value greater than 1 favors the candidate.
+
+## Result
+
+The candidate exceeds the 10% target for persistent interactive use.
+The four Skim session totals have a 1.229x geometric-mean speedup.
+Their paired speedups range from 1.123x to 1.329x.
+
+The independent session trace improves by 1.113x.
+The session-growth total improves by 1.160x.
+The median growth round improves by 1.252x.
+
+The focused scorer shows large gains for short ASCII queries.
+The early-ASCII case improves by 2.108x.
+The one-byte basket improves by 1.258x.
+
+The Emacs macrobenchmark improves by 1.020x to 1.058x.
+The four fzf-native styles have a 1.034x geometric-mean speedup.
+This sample has five process pairs, so small effects remain descriptive.
+
+The holdouts also find a cost.
+All six small fuzzy-benches workloads regress.
+Their score geometric mean regresses by 4.7%.
+Their score-plus-positions geometric mean regresses by 4.5%.
+Individual paired ratios range from 0.917x to 0.975x.
+
+The larger repeated-corpus workloads improve.
+The `emacs` workload improves by 1.033x to 1.036x.
+The `e-macs` workload improves by 1.258x to 1.305x.
+The three Frizbee workloads improve by 1.006x to 1.013x.
+
+The combined probe finds small Unicode costs.
+The CJK and case-fold rows regress by 0.5% to 0.9%.
+The core Unicode controls stay near parity.
+
+## Method
+
+The candidate was frozen before the holdout run.
+No product source changed after the holdout results became available.
+
+All timed suites ran serially.
+Each A/B suite alternated the first revision in each pair.
+The analyzers used the paired process or session ratio.
+Each analyzer used 100,000 deterministic bootstrap samples where listed.
+
+The timed work ran from 2026-09-08T13:04:07Z through 2026-09-08T13:40:14Z.
+
+## External holdouts
+
+Each harness used ten alternating process pairs.
+Criterion used a one-second warmup, a two-second measurement, and 20 samples.
+
+| Case | Base median | Candidate median | Paired speedup, 95% interval | Candidate wins |
+|---|---:|---:|---:|---:|
+| fuzzy, medium-start score | 1.266 us | 1.347 us | 0.940x `[0.935, 0.945]` | 0/10 |
+| fuzzy, medium-start score plus positions | 2.557 us | 2.726 us | 0.938x `[0.932, 0.940]` | 0/10 |
+| fuzzy, medium-middle score | 0.889 us | 0.969 us | 0.919x `[0.914, 0.920]` | 0/10 |
+| fuzzy, medium-middle score plus positions | 1.820 us | 1.984 us | 0.917x `[0.916, 0.921]` | 0/10 |
+| fuzzy, medium-end score | 0.537 us | 0.568 us | 0.945x `[0.943, 0.945]` | 0/10 |
+| fuzzy, medium-end score plus positions | 1.132 us | 1.189 us | 0.952x `[0.948, 0.955]` | 0/10 |
+| fuzzy, long-start score | 7.642 us | 7.883 us | 0.969x `[0.967, 0.971]` | 0/10 |
+| fuzzy, long-start score plus positions | 15.416 us | 15.823 us | 0.973x `[0.969, 0.978]` | 0/10 |
+| fuzzy, long-middle score | 2.658 us | 2.739 us | 0.970x `[0.967, 0.977]` | 0/10 |
+| fuzzy, long-middle score plus positions | 5.379 us | 5.526 us | 0.972x `[0.968, 0.977]` | 0/10 |
+| fuzzy, long-end score | 8.560 us | 8.818 us | 0.970x `[0.968, 0.977]` | 0/10 |
+| fuzzy, long-end score plus positions | 17.226 us | 17.658 us | 0.975x `[0.974, 0.978]` | 0/10 |
+| fuzzy, `emacs` score | 5.908 ms | 5.701 ms | 1.036x `[1.034, 1.040]` | 10/10 |
+| fuzzy, `emacs` score plus positions | 7.745 ms | 7.501 ms | 1.033x `[1.032, 1.034]` | 10/10 |
+| fuzzy, `e-macs` score | 10.323 ms | 7.914 ms | 1.305x `[1.304, 1.306]` | 10/10 |
+| fuzzy, `e-macs` score plus positions | 22.476 ms | 17.858 ms | 1.258x `[1.255, 1.262]` | 10/10 |
+| Frizbee, Chromium | 141.058 ms | 139.443 ms | 1.012x `[1.011, 1.013]` | 10/10 |
+| Frizbee, Arabic | 47.715 ms | 47.419 ms | 1.006x `[1.004, 1.010]` | 10/10 |
+| Frizbee, Korean | 35.066 ms | 34.588 ms | 1.013x `[1.010, 1.017]` | 10/10 |
+
+### Six-workload geometric mean
+
+| Mode | Base | Candidate | Paired speedup, 95% interval | Candidate wins |
+|---|---:|---:|---:|---:|
+| Score | 2.172 us | 2.282 us | 0.953x `[0.950, 0.954]` | 0/10 |
+| Score plus positions | 4.427 us | 4.636 us | 0.955x `[0.953, 0.956]` | 0/10 |
+
+All external processes ran a semantic preflight.
+All score, position, match-count, and sorted-tuple fingerprints matched.
+
+## Core scorer
+
+Each process reports the median of 11 samples.
+The table uses nine alternating process pairs.
+
+| Case | Base median | Candidate median | Paired speedup, 95% interval | Candidate wins |
+|---|---:|---:|---:|---:|
+| Early ASCII hit | 0.529 ms | 0.251 ms | 2.108x `[2.075, 2.143]` | 9/9 |
+| One-byte candidates | 0.264 ms | 0.210 ms | 1.258x `[1.248, 1.281]` | 9/9 |
+| Chromium shape | 1.494 ms | 1.385 ms | 1.078x `[1.048, 1.091]` | 8/9 |
+| ASCII literal | 0.931 ms | 0.896 ms | 1.040x `[1.009, 1.074]` | 8/9 |
+| Arabic shape | 5.387 ms | 5.380 ms | 1.000x `[0.991, 1.003]` | 4/9 |
+| Korean shape | 6.163 ms | 6.092 ms | 1.011x `[0.995, 1.018]` | 7/9 |
+| UTF-8 hit | 14.201 ms | 14.089 ms | 1.008x `[0.996, 1.018]` | 6/9 |
+| UTF-8 v1 early hit | 30.609 ms | 30.586 ms | 1.001x `[1.000, 1.002]` | 7/9 |
+| UTF-8 v1 late hit | 46.471 ms | 46.485 ms | 0.997x `[0.985, 1.003]` | 2/9 |
+
+All result checksums matched.
+
+## One-byte paths
+
+Each process reports the median of 101 samples.
+Each sample makes 20,800 calls.
+The table uses nine alternating process pairs.
+
+| Path and case | Base median | Candidate median | Paired speedup, 95% interval | Candidate wins |
+|---|---:|---:|---:|---:|
+| Direct, all hit | 9.81 ns | 7.60 ns | 1.291x `[1.284, 1.299]` | 9/9 |
+| Direct, folded hit | 11.92 ns | 5.87 ns | 2.031x `[2.031, 2.048]` | 9/9 |
+| Direct, all miss | 3.17 ns | 2.98 ns | 1.064x `[1.064, 1.064]` | 9/9 |
+| Direct, one hit in 26 | 3.75 ns | 3.27 ns | 1.147x `[1.147, 1.147]` | 9/9 |
+| Direct, case-sensitive miss | 3.17 ns | 2.98 ns | 1.064x `[1.064, 1.064]` | 9/9 |
+| Public API, all hit | 14.66 ns | 8.75 ns | 1.671x `[1.671, 1.675]` | 9/9 |
+| Public API, folded hit | 16.68 ns | 9.81 ns | 1.700x `[1.685, 1.700]` | 9/9 |
+| Public API, all miss | 8.22 ns | 6.63 ns | 1.240x `[1.240, 1.240]` | 9/9 |
+| Public API, one hit in 26 | 8.70 ns | 6.92 ns | 1.257x `[1.257, 1.257]` | 9/9 |
+
+All processes produced the fixed semantic checksum for every case.
+The probe prints two decimal places, so some interval endpoints are quantized.
+
+## Symmetric score-and-positions probe
+
+Each process uses 50,000 calls per sample.
+Each process reports the median of 21 samples.
+The table uses nine alternating process pairs.
+
+| Case and API | Base median | Candidate median | Paired speedup, 95% interval | Candidate wins |
+|---|---:|---:|---:|---:|
+| `emacs`, legacy | 1269.3 ns | 1168.4 ns | 1.087x `[1.084, 1.091]` | 9/9 |
+| `emacs`, combined | 654.0 ns | 604.3 ns | 1.082x `[1.078, 1.088]` | 9/9 |
+| `emacs` miss, legacy | 23.8 ns | 22.3 ns | 1.072x `[1.062, 1.077]` | 9/9 |
+| `emacs` miss, combined | 26.5 ns | 25.7 ns | 1.027x `[1.019, 1.039]` | 8/9 |
+| `e-macs`, legacy | 1035.3 ns | 1018.5 ns | 1.016x `[1.007, 1.021]` | 9/9 |
+| `e-macs`, combined | 591.7 ns | 576.4 ns | 1.027x `[1.012, 1.035]` | 9/9 |
+| Simple miss, legacy | 29.6 ns | 28.4 ns | 1.046x `[1.031, 1.046]` | 9/9 |
+| Simple miss, combined | 32.2 ns | 32.2 ns | 1.000x `[0.988, 1.009]` | 4/9 |
+| Long sparse, legacy | 1600.5 ns | 1541.9 ns | 1.038x `[1.035, 1.042]` | 9/9 |
+| Long sparse, combined | 881.6 ns | 842.9 ns | 1.046x `[1.039, 1.053]` | 9/9 |
+| Extended, legacy | 1256.3 ns | 1173.8 ns | 1.067x `[1.051, 1.075]` | 9/9 |
+| Extended, combined | 1257.4 ns | 1174.8 ns | 1.067x `[1.053, 1.074]` | 9/9 |
+| Late AND miss, legacy | 226.8 ns | 219.0 ns | 1.032x `[1.014, 1.038]` | 9/9 |
+| Late AND miss, combined | 229.0 ns | 221.2 ns | 1.035x `[1.013, 1.039]` | 9/9 |
+| CJK, legacy | 837.3 ns | 845.4 ns | 0.993x `[0.984, 0.996]` | 0/9 |
+| CJK, combined | 433.4 ns | 437.6 ns | 0.991x `[0.983, 0.998]` | 1/9 |
+| Case fold, legacy | 1387.5 ns | 1394.9 ns | 0.995x `[0.988, 0.999]` | 1/9 |
+| Case fold, combined | 714.2 ns | 718.0 ns | 0.995x `[0.990, 0.997]` | 1/9 |
+
+All 18 processes produced the same fixed checksum.
+
+## Interactive session trace
+
+Each process uses 200,000 candidates, one worker, and a 256-result limit.
+Each process reports the median of seven samples.
+The table uses six alternating process pairs.
+
+| Metric | Base median | Candidate median | Paired speedup, 95% interval | Candidate wins |
+|---|---:|---:|---:|---:|
+| Full trace | 306.811 ms | 274.935 ms | 1.113x `[1.102, 1.122]` | 6/6 |
+| Narrowing edits | 234.470 ms | 210.359 ms | 1.113x `[1.102, 1.124]` | 6/6 |
+| Backspace cache hits | 0.002 ms | 0.003 ms | timing floor | 0/6 |
+| Unrelated edits | 71.889 ms | 64.777 ms | 1.109x `[1.099, 1.115]` | 6/6 |
+
+Every result matched an independent full scan and sort.
+The timed region excludes session creation, corpus loading, destruction, and validation.
+
+## Session growth
+
+Each process starts with one million candidates.
+It appends 1,000 candidates in each of 40 rounds.
+The table uses five alternating process pairs.
+
+| Metric | Base median | Candidate median | Paired speedup, 95% interval | Candidate wins |
+|---|---:|---:|---:|---:|
+| Initial scan | 30.829 ms | 20.028 ms | 1.484x `[1.116, 2.040]` | 5/5 |
+| 40 growth rounds | 13.817 ms | 11.885 ms | 1.160x `[1.140, 1.191]` | 5/5 |
+| Growth-round median | 0.287 ms | 0.230 ms | 1.252x `[1.242, 1.268]` | 5/5 |
+| Growth-round p95 | 0.301 ms | 0.293 ms | 1.027x `[1.007, 1.047]` | 5/5 |
+| Growth-round maximum | 2.644 ms | 2.590 ms | 1.021x `[0.966, 1.042]` | 3/5 |
+
+## Skim persistent-session holdout
+
+Each session loads one million candidates and emits at most 10,000 results.
+Each configuration uses ten alternating measured pairs after balanced warmups.
+The table sums only query-round elapsed times.
+It excludes corpus loading, process startup, and result validation.
+
+| Workload | Workers | Base median | Candidate median | Paired speedup, 95% interval | Candidate wins |
+|---|---:|---:|---:|---:|---:|
+| Prefix | 1 | 524.837 ms | 437.968 ms | 1.197x `[1.196, 1.200]` | 10/10 |
+| Edit trace | 1 | 320.139 ms | 250.358 ms | 1.278x `[1.276, 1.284]` | 10/10 |
+| Prefix | 8 | 119.944 ms | 108.216 ms | 1.123x `[1.081, 1.147]` | 10/10 |
+| Edit trace | 8 | 81.747 ms | 61.246 ms | 1.329x `[1.225, 1.342]` | 10/10 |
+
+### Skim round medians
+
+| Workload | Workers | Query | Base | Candidate | Paired speedup, 95% interval | Candidate wins |
+|---|---:|---|---:|---:|---:|---:|
+| Prefix | 1 | `t` | 102.226 ms | 60.961 ms | 1.675x `[1.672, 1.682]` | 10/10 |
+| Prefix | 1 | `te` | 162.595 ms | 143.428 ms | 1.136x `[1.133, 1.136]` | 10/10 |
+| Prefix | 1 | `tes` | 149.930 ms | 134.949 ms | 1.112x `[1.109, 1.113]` | 10/10 |
+| Prefix | 1 | `test` | 109.521 ms | 98.638 ms | 1.111x `[1.104, 1.117]` | 10/10 |
+| Edit trace | 1 | `m` | 101.483 ms | 60.611 ms | 1.675x `[1.672, 1.679]` | 10/10 |
+| Edit trace | 1 | `ma` | 143.188 ms | 126.673 ms | 1.130x `[1.127, 1.133]` | 10/10 |
+| Edit trace | 1 | `mal` | 75.354 ms | 63.094 ms | 1.194x `[1.193, 1.200]` | 10/10 |
+| Prefix | 8 | `t` | 29.516 ms | 25.722 ms | 1.185x `[1.120, 1.225]` | 9/10 |
+| Prefix | 8 | `te` | 35.765 ms | 32.739 ms | 1.097x `[1.057, 1.171]` | 10/10 |
+| Prefix | 8 | `tes` | 31.348 ms | 28.611 ms | 1.113x `[1.054, 1.139]` | 10/10 |
+| Prefix | 8 | `test` | 22.635 ms | 20.836 ms | 1.097x `[1.069, 1.117]` | 10/10 |
+| Edit trace | 8 | `m` | 34.718 ms | 19.184 ms | 1.782x `[1.368, 1.844]` | 10/10 |
+| Edit trace | 8 | `ma` | 31.165 ms | 28.060 ms | 1.096x `[1.061, 1.118]` | 10/10 |
+| Edit trace | 8 | `mal` | 16.202 ms | 13.851 ms | 1.171x `[1.129, 1.178]` | 10/10 |
+
+The backspace rounds operate near the polling floor.
+This report does not use their ratios as speed evidence.
+All 80 measured Skim sessions matched the independent result oracle.
+
+## Emacs completion macrobenchmark
+
+The harness uses five alternating process pairs.
+Each process measures five sweeps of four needles after one warmup.
+
+| fzf-native style | Base median | Candidate median | Paired speedup | Candidate wins |
+|---|---:|---:|---:|---:|
+| Full score, scoring filter | 0.170532 s | 0.164723 s | 1.035x | 4/5 |
+| Full score, default filter | 0.149905 s | 0.147316 s | 1.023x | 5/5 |
+| Filter only, scoring filter | 0.156984 s | 0.148433 s | 1.058x | 4/5 |
+| Filter only, default filter | 0.140619 s | 0.136653 s | 1.020x | 5/5 |
+
+The nine control styles range from 0.996x to 1.010x.
+All 12 Emacs processes produced the same 16-record fzf digest.
+
+## Commands
+
+The following commands ran from `/private/tmp/fzf-next10-full-bench`.
+
+```sh
+sh ./build-external.sh
+sh ./build-internal.sh
+sh ./build-onebyte-ab.sh
+
+FZF_BENCH_CONFIRM_IDLE=1 sh ./run-internal-ab.sh
+python3 ./analyze-internal.py
+
+sh ./run-onebyte-ab.sh
+
+sh ./run-combined-ab.sh
+python3 ./analyze-combined-ab.py
+
+sh ./run-session-trace-ab.sh
+python3 ./analyze-session-trace.py
+
+FZF_BENCH_CONFIRM_IDLE=1 sh ./run-external-ab.sh
+python3 ./analyze-external.py
+
+FZF_BENCH_CONFIRM_IDLE=1 sh ./run-skim-ab.sh
+python3 ./analyze-skim-ab.py
+
+FZF_BENCH_CONFIRM_IDLE=1 sh ./run-emacs-ab.sh
+```
+
+The external runner used this Criterion command shape:
+
+```sh
+env CRITERION_HOME="$criterion_home" "$binary" "$filter" \
+  --bench --warm-up-time 1 --measurement-time 2 \
+  --sample-size 20 --noplot --color never
+```
+
+The Skim runner used these command shapes for one and eight workers:
+
+```sh
+"$cli" native-session --driver "$driver" --file "$corpus" \
+  --query test --workers "$workers" --limit 10000 \
+  --timeout-ms 120000 --warmup 0 --runs 1
+
+"$cli" native-session --driver "$driver" --file "$corpus" \
+  --queries "$trace" --workers "$workers" --limit 10000 \
+  --timeout-ms 120000 --warmup 0 --runs 1
+```
+
+The direct session probes used these arguments:
+
+```sh
+./telemetry/session/session-VARIANT 1000000 1000 40 8 10000
+./session-trace-bin/VARIANT 200000 1 256 7
+./combined-ab-bin/VARIANT 50000 21
+```
+
+The Emacs runner used this command shape:
+
+```sh
+env FZF_NATIVE_BENCH_SOURCE="$source_file" \
+  FZF_NATIVE_BENCH_MODULE="$module" \
+  /Users/duc/emacs/nextstep/Emacs.app/Contents/MacOS/Emacs \
+  -Q --batch -l bench.el
+```
+
+## Source and host identity
+
+| Item | Value |
+|---|---|
+| Base tree | `addf72bc226e4df1840ccf02f56b0903c6f1ba7a` |
+| Candidate tree | `f36958a06232857432669e45c59a8ce632b4df35` |
+| fuzzy-benches fork | `633c6c359f4a6f859ee7c35abd574dd3eafc4910` |
+| Frizbee fork | `f2ec9684559479a428b29dc81b94f38596565b0e` |
+| Skim fork | `998175ed0af817f541f1108e4f686fc7b554fd6b` |
+| Emacs harness | `05ff2cbbaddc8d7b7bb6d12038e46cd55e482dc9` |
+| Core probe | SHA-256 `e6c09d9a739801e40f00626d51157878c4f073abd916c8d27e9991f23ce5a34e` |
+| Growth probe | SHA-256 `01965efe60337563d7d9a41969e6423c4d5ac5e48b352992901ab2aff66005d4` |
+| Combined-API probe | SHA-256 `af8282068d5b822fa8aa4a9f8ba7a24dae1360a88495fc67c116a7c44330cbe1` |
+| One-byte probe | SHA-256 `9d5e660f44644c3f23bdde176ca93670e4597088b2e934f07810c20daf913d15` |
+| Session-trace probe | SHA-256 `4c35aa2213ff1dd252573c7c3dd78a964520dbb9e3028599f247b4be046e7195` |
+| Corpus | SHA-256 `86e55d83e1d30c9bfb2748b6173c0d1b0955cd37ffef4cedc7e10a31c51fdb06` |
+| Edit trace | SHA-256 `0d3660f23bd190dbaed7f4dce7903bc2233b43b15b4d7e4d618a7b1f97a48def` |
+| Host | Apple M3 MacBook Air, 8 cores, 16 GB RAM |
+| Operating system | macOS 26.5.2, build `25F84` |
+| C compilers | Homebrew clang 22.1.8 and Apple clang 21.0.0 |
+| Rust compiler | rustc 1.98.1, LLVM 22.1.8 |
+| Emacs | GNU Emacs 30.2, revision `636f166cfc86` |
+
+## Correctness gates
+
+- All external semantic preflights matched.
+- All core, one-byte, and combined-probe checksums matched.
+- All interactive snapshots matched independent full scans and sorts.
+- All Skim protocol, count, query-hash, and result checks matched.
+- All Emacs completion records matched.
+- All A/B binaries retained their recorded SHA-256 values.
+
+## Limits
+
+The fuzzy-benches micro-workloads contain one candidate.
+They expose call overhead, but they do not represent a complete completion session.
+
+The Frizbee result includes scoring, result collection, copying, and stable score sorting.
+It does not use the complete fzf rank order.
+
+The fuzzy-benches position rows call score before positions.
+They do not use the combined API.
+
+The Skim timed region excludes corpus ingestion.
+The session-growth probe measures ingestion and repeated growth separately.
+
+The Emacs sample uses a fixed style order and only five pairs.
+Use it for large end-to-end changes, not small percentage claims.
+
+The raw run is in `/private/tmp/fzf-next10-full-bench` on the measurement host.
+The directory contains all logs, run orders, provenance files, hashes, and analyzer outputs.

--- a/fzf-additions-test.c
+++ b/fzf-additions-test.c
@@ -19,6 +19,7 @@
 #include "fzf-additions.h"
 #include "fzf-private.h"
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -167,6 +168,161 @@ static void test_ascii_v2_single_byte_path(void) {
                        true, false, -1, -1, 0, -1);
   check_single_byte_v2("xxxx", 4, 'b', false, true, false,
                        -1, -1, 0, -1);
+}
+
+static uint32_t score_row_oracle_state = UINT32_C(0x7a61c4e9);
+
+static uint32_t score_row_oracle_random(void) {
+  uint32_t x = score_row_oracle_state;
+  x ^= x << 13;
+  x ^= x >> 17;
+  x ^= x << 5;
+  score_row_oracle_state = x;
+  return x;
+}
+
+/* Treat the unchanged direct v2 matrix path as the differential oracle for
+   the public score-only path.  Bounds also remain on that matrix path, so
+   compare the complete score-and-bounds tuple, not only membership. */
+static void test_ascii_v2_score_only_matches_position_oracle(void) {
+  static const char alphabet[] =
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/_-.";
+  enum { Trials = 2000, MaxText = 96, MaxPattern = 10 };
+  char text_data[MaxText + 1];
+  char pattern_data[MaxPattern + 1];
+
+  for (int scheme = FZF_SCORE_SCHEME_DEFAULT;
+       scheme <= FZF_SCORE_SCHEME_HISTORY; scheme++) {
+    for (int case_sensitive = 0; case_sensitive < 2; case_sensitive++) {
+      for (int normalize = 0; normalize < 2; normalize++) {
+        for (int forward = 0; forward < 2; forward++) {
+          fzf_slab_t *score_slab = fzf_make_default_slab();
+          fzf_slab_t *oracle_slab = fzf_make_default_slab();
+          CHECK(score_slab != NULL);
+          CHECK(oracle_slab != NULL);
+          if (!score_slab || !oracle_slab) {
+            fzf_free_slab(score_slab);
+            fzf_free_slab(oracle_slab);
+            continue;
+          }
+          CHECK(fzf_slab_set_score_scheme(
+              score_slab, (fzf_score_scheme_t)scheme));
+          CHECK(fzf_slab_set_score_scheme(
+              oracle_slab, (fzf_score_scheme_t)scheme));
+
+          for (size_t trial = 0; trial < Trials; trial++) {
+            size_t text_size = 2 + score_row_oracle_random() % (MaxText - 1);
+            size_t pattern_size =
+                2 + score_row_oracle_random() % (MaxPattern - 1);
+            for (size_t i = 0; i < text_size; i++)
+              text_data[i] = alphabet[score_row_oracle_random() %
+                                      (sizeof alphabet - 1)];
+
+            if ((trial & 1) == 0 && pattern_size <= text_size) {
+              size_t next = 0;
+              for (size_t i = 0; i < pattern_size; i++) {
+                size_t max_index = text_size - (pattern_size - i);
+                size_t index = next + score_row_oracle_random() %
+                                        (max_index - next + 1);
+                pattern_data[i] = text_data[index];
+                next = index + 1;
+              }
+            } else {
+              for (size_t i = 0; i < pattern_size; i++)
+                pattern_data[i] = alphabet[score_row_oracle_random() %
+                                           (sizeof alphabet - 1)];
+            }
+            if (!case_sensitive) {
+              for (size_t i = 0; i < pattern_size; i++)
+                pattern_data[i] =
+                    (char)tolower((unsigned char)pattern_data[i]);
+            }
+            text_data[text_size] = '\0';
+            pattern_data[pattern_size] = '\0';
+
+            char *query = strdup(pattern_data);
+            fzf_pattern_t *parsed = fzf_parse_pattern_with_direction(
+                case_sensitive ? CaseRespect : CaseIgnore, normalize, query,
+                true, forward);
+            CHECK(query != NULL);
+            CHECK(parsed != NULL);
+            if (!query || !parsed) {
+              free(query);
+              fzf_free_pattern(parsed);
+              continue;
+            }
+
+            fzf_string_t text = {.data = text_data, .size = text_size};
+            fzf_term_t *term = &parsed->ptr[0]->ptr[0];
+            fzf_string_t *pattern = (fzf_string_t *)term->text;
+
+            fzf_clear_allocation_failure();
+            fzf_result_t oracle_result = fzf_fuzzy_match_v2_with_direction(
+                term->case_sensitive, term->normalize, forward, &text,
+                pattern, NULL, oracle_slab);
+            bool oracle_failed = fzf_allocation_failed();
+            int32_t expected_score = oracle_result.start < 0
+                                         ? 0
+                                         : (oracle_result.score > 0
+                                                ? oracle_result.score
+                                                : 1);
+
+            int32_t score = fzf_get_score(text_data, parsed, score_slab);
+            bool score_failed = fzf_allocation_failed();
+            int32_t byte_score = fzf_get_score_bytes(
+                text_data, text_size, parsed, score_slab);
+            bool byte_score_failed = fzf_allocation_failed();
+            fzf_score_bounds_t bounds = {0};
+            int32_t bounds_score = fzf_get_score_with_bounds(
+                text_data, parsed, score_slab, &bounds);
+            bool bounds_failed = fzf_allocation_failed();
+
+            fzf_score_bounds_t expected_bounds = {0};
+            expected_bounds.raw_score = oracle_result.score;
+            if (oracle_result.start >= 0 &&
+                oracle_result.end > oracle_result.start) {
+              expected_bounds.min_begin = oracle_result.start;
+              expected_bounds.min_end = oracle_result.end;
+              expected_bounds.max_end = oracle_result.end;
+              expected_bounds.valid = true;
+            }
+
+            if (score_failed != oracle_failed ||
+                byte_score_failed != oracle_failed ||
+                bounds_failed != oracle_failed || score != expected_score ||
+                byte_score != expected_score || bounds_score != expected_score ||
+                bounds.raw_score != expected_bounds.raw_score ||
+                bounds.valid != expected_bounds.valid ||
+                (bounds.valid &&
+                 (bounds.min_begin != expected_bounds.min_begin ||
+                  bounds.min_end != expected_bounds.min_end ||
+                  bounds.max_end != expected_bounds.max_end))) {
+              fprintf(stderr,
+                      "  FAIL score-row oracle: trial=%zu scheme=%d case=%d "
+                      "normalize=%d forward=%d text_size=%zu pattern_size=%zu "
+                      "score=%d byte=%d bounds_score=%d "
+                      "bounds=(%d,%d,%d,%lld,%d) oracle=(%d,%d,%d)\n",
+                      trial, scheme, case_sensitive, normalize, forward,
+                      text_size, pattern_size, score, byte_score, bounds_score,
+                      bounds.min_begin, bounds.min_end, bounds.max_end,
+                      (long long)bounds.raw_score, bounds.valid,
+                      oracle_result.start, oracle_result.end,
+                      oracle_result.score);
+              failed++;
+              fzf_free_pattern(parsed);
+              free(query);
+              break;
+            }
+            fzf_free_pattern(parsed);
+            free(query);
+          }
+
+          fzf_free_slab(score_slab);
+          fzf_free_slab(oracle_slab);
+        }
+      }
+    }
+  }
 }
 
 static void test_exact_match(void) {
@@ -1251,6 +1407,7 @@ int main(void) {
   RUN(test_fuzzy_empty_pattern);
   RUN(test_fuzzy_pattern_longer_than_text);
   RUN(test_ascii_v2_single_byte_path);
+  RUN(test_ascii_v2_score_only_matches_position_oracle);
   RUN(test_exact_match);
   RUN(test_exact_no_match);
   RUN(test_pinned_fzf_exact_boundary);

--- a/fzf-additions-test.c
+++ b/fzf-additions-test.c
@@ -125,12 +125,20 @@ static void check_single_byte_v2(const char *text, size_t text_size,
 static void test_ascii_v2_single_byte_path(void) {
   static const char embedded_nul[] = {'x', '\0', 'b', 'x'};
   static const char malformed[] = {'x', (char)0xe9, 'x'};
+  static const char normalizable[] = {(char)0xe9};
 
   check_single_byte_v2("a", 1, 'a', true, false, true,
                        0, 1, 36, 0);
   check_single_byte_v2("A", 1, 'a', false, false, true,
                        0, 1, 36, 0);
   check_single_byte_v2("A", 1, 'a', true, false, true,
+                       -1, -1, 0, -1);
+  /* The byte prefilter can accept an exact raw byte that the scorer then
+     folds away.  A failed post-fold comparison must not emit a result or a
+     highlight position. */
+  check_single_byte_v2("A", 1, 'A', false, false, true,
+                       -1, -1, 0, -1);
+  check_single_byte_v2("A", 1, 'A', false, false, false,
                        -1, -1, 0, -1);
   check_single_byte_v2("b", 1, 'a', false, false, true,
                        -1, -1, 0, -1);
@@ -150,6 +158,13 @@ static void test_ascii_v2_single_byte_path(void) {
                        true, 2, 3, 32, 2);
   check_single_byte_v2(malformed, sizeof malformed, (char)0xe9, true, false,
                        true, 1, 2, 32, 1);
+  /* Likewise, the raw high byte matches the prefilter but normalizes to a
+     different byte before comparison.  Exercise both tie directions and the
+     no-position miss contract. */
+  check_single_byte_v2(normalizable, sizeof normalizable, (char)0xe9, true,
+                       true, true, -1, -1, 0, -1);
+  check_single_byte_v2(normalizable, sizeof normalizable, (char)0xe9, true,
+                       true, false, -1, -1, 0, -1);
   check_single_byte_v2("xxxx", 4, 'b', false, true, false,
                        -1, -1, 0, -1);
 }

--- a/fzf-native-ctest.c
+++ b/fzf-native-ctest.c
@@ -1659,6 +1659,33 @@ static void test_async_line_decoder_truncates_without_splitting_utf8(void) {
   free_async_session(s);
 }
 
+static void test_async_line_decoder_truncated_ascii_metadata(void) {
+  AsyncSession *s = make_async_session(NULL, 0);
+  CHECK(s != NULL);
+  if (!s) return;
+  s->max_line_length = -3;
+  AsyncLineDecoder line = {0};
+  static const unsigned char input[] = {
+      'a', 'b', 'c', 0xc3, 0xa9, 0xff,
+  };
+  CHECK(async_line_feed_bytes(
+      s, &line, (const char *)input, sizeof input));
+  CHECK(async_line_finish(s, &line));
+  CHECK(s->count == 1);
+
+  const char *candidate = cands_at(s, 0);
+  size_t length = SIZE_MAX;
+  bool ascii = false;
+  CHECK(candidate != NULL);
+  async_arena_string_metadata(candidate, &length, &ascii);
+  CHECK(length == 3);
+  CHECK(ascii);
+  CHECK(strcmp(candidate, "abc") == 0);
+
+  free(line.output);
+  free_async_session(s);
+}
+
 /* =====================================================================
  * Chunked candidate storage — index split formula and accessor
  * ===================================================================== */
@@ -4415,6 +4442,7 @@ int main(void) {
   RUN(test_async_line_decoder_matches_one_shot_reference);
   RUN(test_async_line_decoder_bounds_overlong_records);
   RUN(test_async_line_decoder_truncates_without_splitting_utf8);
+  RUN(test_async_line_decoder_truncated_ascii_metadata);
 
   printf("--- chunked cands_top ---\n");
   RUN(test_cands_top_index_split);

--- a/fzf-native-ctest.c
+++ b/fzf-native-ctest.c
@@ -1459,6 +1459,43 @@ static void test_async_reader_rejects_embedded_nul(void) {
   free_async_session(s);
 }
 
+static void test_async_candidate_arena_metadata(void) {
+  AsyncSession *s = make_async_session(NULL, 0);
+  CHECK(s != NULL);
+  const char invalid_utf8[] = {'x', (char)0xff, '\0'};
+  CHECK(async_append_candidate(s, "plain-ascii", strlen("plain-ascii")));
+  CHECK(async_append_candidate(s, invalid_utf8, 2));
+  CHECK(async_append_candidate(s, "", 0));
+
+  const size_t expected_lengths[] = {11, 2, 0};
+  const bool expected_ascii[] = {true, false, true};
+  for (size_t i = 0; i < 3; i++) {
+    const char *candidate = cands_at(s, i);
+    size_t length = SIZE_MAX;
+    bool ascii = false;
+    CHECK(candidate != NULL);
+    async_arena_string_metadata(candidate, &length, &ascii);
+    CHECK(length == expected_lengths[i]);
+    CHECK(ascii == expected_ascii[i]);
+    CHECK(strlen(candidate) == length);
+  }
+
+  size_t fallback_length = ASYNC_ARENA_STRING_LENGTH_MASK;
+  char *long_candidate = malloc(fallback_length + 1);
+  CHECK(long_candidate != NULL);
+  memset(long_candidate, 'z', fallback_length);
+  long_candidate[fallback_length] = '\0';
+  CHECK(async_append_candidate(s, long_candidate, fallback_length));
+  size_t decoded_length = 0;
+  bool decoded_ascii = false;
+  async_arena_string_metadata(
+      cands_at(s, 3), &decoded_length, &decoded_ascii);
+  CHECK(decoded_length == fallback_length);
+  CHECK(decoded_ascii);
+  free(long_candidate);
+  free_async_session(s);
+}
+
 static bool async_line_reference(const unsigned char *raw, size_t raw_len,
                                  ptrdiff_t max_line_length, char **output,
                                  size_t *output_len) {
@@ -4374,6 +4411,7 @@ int main(void) {
   RUN(test_async_reader_long_line);
   RUN(test_async_reader_final_unterminated_line);
   RUN(test_async_reader_rejects_embedded_nul);
+  RUN(test_async_candidate_arena_metadata);
   RUN(test_async_line_decoder_matches_one_shot_reference);
   RUN(test_async_line_decoder_bounds_overlong_records);
   RUN(test_async_line_decoder_truncates_without_splitting_utf8);

--- a/fzf-native-module.c
+++ b/fzf-native-module.c
@@ -4359,6 +4359,11 @@ static bool async_line_commit_character(AsyncSession *s,
     }
     line->char_count++;
   }
+  for (size_t i = 0; i < width; i++)
+    if (bytes[i] & 0x80) {
+      line->output_has_non_ascii = true;
+      break;
+    }
   return async_line_append_output(s, line, bytes, width);
 }
 
@@ -4372,9 +4377,10 @@ static unsigned async_utf8_expected_width(unsigned char byte) {
 static bool async_line_emit_visible_byte(AsyncSession *s,
                                          AsyncLineDecoder *line,
                                          unsigned char byte) {
-  if (byte & 0x80) line->output_has_non_ascii = true;
-  if (s->max_line_length == 0)
+  if (s->max_line_length == 0) {
+    if (byte & 0x80) line->output_has_non_ascii = true;
     return async_line_append_output(s, line, &byte, 1);
+  }
 
   size_t cap = async_line_limit(s->max_line_length);
   if ((s->max_line_length > 0 && line->over_limit) ||
@@ -4525,6 +4531,7 @@ static bool async_line_emit_visible_run(AsyncSession *s,
     utf8proc_ssize_t width = utf8proc_iterate(
         bytes + offset, (utf8proc_ssize_t)(amount - offset), &codepoint);
     offset += width > 0 ? (size_t)width : 1;
+    line->output_has_non_ascii = true;
     line->char_count++;
     retained_end = offset;
   }
@@ -4569,7 +4576,11 @@ static bool async_line_feed_bytes(AsyncSession *s, AsyncLineDecoder *line,
         visible_or |= byte;
         offset++;
       }
-      if (visible_or & 0x80) line->output_has_non_ascii = true;
+      /* In unbounded mode every byte in the run is retained.  Capped mode
+         classifies only the prefix committed by async_line_emit_visible_run,
+         so a discarded high-bit suffix cannot pessimize an ASCII candidate. */
+      if (s->max_line_length == 0 && (visible_or & 0x80))
+        line->output_has_non_ascii = true;
       if (offset > start &&
           !async_line_emit_visible_run(
               s, line, (const unsigned char *)bytes + start,

--- a/fzf-native-module.c
+++ b/fzf-native-module.c
@@ -1999,22 +1999,63 @@ emacs_value fzf_native_make_slab(emacs_env *env,
 #define CANDS_TOP_CAP     4096
 
 /* Arena allocator: strings are packed into large chunks so freeing the
-   entire candidate set is O(chunks) instead of O(candidates). */
+   entire candidate set is O(chunks) instead of O(candidates).
+
+   Session candidates are immutable and are normally scored across many
+   interactive query edits.  Keep their byte length and ASCII classification
+   immediately before the public char pointer so workers do not repeat
+   strlen plus a complete ASCII pre-pass on every edit.  The metadata is read
+   through memcpy, so densely packed records need no per-record alignment. */
 typedef struct ArenaChunk { struct ArenaChunk *next; size_t used; char data[]; } ArenaChunk;
 typedef struct { ArenaChunk *head; } Arena;
 
-static char *arena_strdup(Arena *a, const char *s, size_t len) {
-  size_t need = len + 1;
-  if (!a->head || a->head->used + need > ARENA_CHUNK_SIZE) {
-    size_t chunk_sz = sizeof(ArenaChunk) + (need > ARENA_CHUNK_SIZE ? need : ARENA_CHUNK_SIZE);
+#define ASYNC_ARENA_STRING_METADATA_SIZE sizeof(uint16_t)
+#define ASYNC_ARENA_STRING_ASCII_BIT UINT16_C(0x8000)
+#define ASYNC_ARENA_STRING_LENGTH_MASK UINT16_C(0x7fff)
+/* Unusually long records retain exact semantics through the safe rescan
+   sentinel instead of growing every ordinary arena record. */
+#define ASYNC_ARENA_STRING_FALLBACK UINT16_MAX
+
+static char *arena_strdup_classified(Arena *a, const char *s, size_t len,
+                                     bool ascii) {
+  if (len > SIZE_MAX - ASYNC_ARENA_STRING_METADATA_SIZE - 1) return NULL;
+  size_t need = ASYNC_ARENA_STRING_METADATA_SIZE + len + 1;
+  if (!a->head || a->head->used > ARENA_CHUNK_SIZE ||
+      need > ARENA_CHUNK_SIZE - a->head->used) {
+    size_t payload = need > ARENA_CHUNK_SIZE ? need : ARENA_CHUNK_SIZE;
+    if (payload > SIZE_MAX - sizeof(ArenaChunk)) return NULL;
+    size_t chunk_sz = sizeof(ArenaChunk) + payload;
     ArenaChunk *c = malloc(chunk_sz);
     if (!c) return NULL;
     c->used = 0; c->next = a->head; a->head = c;
   }
-  char *p = a->head->data + a->head->used;
+  unsigned char *metadata =
+      (unsigned char *)a->head->data + a->head->used;
+  uint16_t packed = ASYNC_ARENA_STRING_FALLBACK;
+  if (len < ASYNC_ARENA_STRING_LENGTH_MASK) {
+    packed = (uint16_t)len;
+    if (ascii) packed |= ASYNC_ARENA_STRING_ASCII_BIT;
+  }
+  memcpy(metadata, &packed, sizeof packed);
+  char *p = (char *)metadata + ASYNC_ARENA_STRING_METADATA_SIZE;
   memcpy(p, s, len + 1);
   a->head->used += need;
   return p;
+}
+
+static void async_arena_string_metadata(const char *s, size_t *length,
+                                        bool *ascii) {
+  const unsigned char *metadata =
+      (const unsigned char *)s - ASYNC_ARENA_STRING_METADATA_SIZE;
+  uint16_t packed;
+  memcpy(&packed, metadata, sizeof packed);
+  if (packed == ASYNC_ARENA_STRING_FALLBACK) {
+    *length = strlen(s);
+    *ascii = is_ascii_utf8proc(s, *length);
+  } else {
+    *length = packed & ASYNC_ARENA_STRING_LENGTH_MASK;
+    *ascii = (packed & ASYNC_ARENA_STRING_ASCII_BIT) != 0;
+  }
 }
 
 static void arena_free(Arena *a) {
@@ -4144,8 +4185,9 @@ static void async_publish_stop(AsyncSession *s) {
    top-level block pointer before taking MU is safe.  Keeping this operation
    separate from getline lets the native interactive fuzzer drive the real
    growth path without an Emacs process or a shell child. */
-static bool async_append_candidate(AsyncSession *s, const char *line,
-                                   size_t len) {
+static bool async_append_candidate_classified(AsyncSession *s,
+                                              const char *line, size_t len,
+                                              bool ascii) {
   if (atomic_load_explicit(&s->stop, memory_order_acquire)) return false;
   size_t i  = s->count;
   size_t hi = i >> CANDS_BLOCK_SHIFT;
@@ -4160,7 +4202,7 @@ static bool async_append_candidate(AsyncSession *s, const char *line,
     return false;
   }
 
-  char *dup = arena_strdup(&s->arena, line, len);
+  char *dup = arena_strdup_classified(&s->arena, line, len, ascii);
   if (!dup) {
     async_record_producer_failure(
         s, AsyncProducerErrorAllocation, ENOMEM);
@@ -4196,6 +4238,15 @@ static bool async_append_candidate(AsyncSession *s, const char *line,
   atomic_fetch_add_explicit(&s->gen, 1, memory_order_relaxed);
   async_notify_candidate_growth(s);
   return true;
+}
+
+/* Tests, fuzzers, and internal synthetic benchmarks append complete records
+   directly.  The production decoder calls the classified variant below and
+   fuses this pass with its mandatory byte validation. */
+static bool async_append_candidate(AsyncSession *s, const char *line,
+                                   size_t len) {
+  return async_append_candidate_classified(
+      s, line, len, is_ascii_utf8proc(line, len));
 }
 
 enum AsyncAnsiState {
@@ -4234,6 +4285,7 @@ typedef struct {
   enum AsyncAnsiState ansi_state;
   bool                over_limit;
   bool                saw_bytes;
+  bool                output_has_non_ascii;
 } AsyncLineDecoder;
 
 static size_t async_line_limit(ptrdiff_t configured) {
@@ -4320,6 +4372,7 @@ static unsigned async_utf8_expected_width(unsigned char byte) {
 static bool async_line_emit_visible_byte(AsyncSession *s,
                                          AsyncLineDecoder *line,
                                          unsigned char byte) {
+  if (byte & 0x80) line->output_has_non_ascii = true;
   if (s->max_line_length == 0)
     return async_line_append_output(s, line, &byte, 1);
 
@@ -4508,12 +4561,15 @@ static bool async_line_feed_bytes(AsyncSession *s, AsyncLineDecoder *line,
 
     if (line->ansi_state == AsyncAnsiNormal && line->pending_crs == 0) {
       size_t start = offset;
+      unsigned char visible_or = 0;
       while (offset < amount) {
         unsigned char byte = (unsigned char)bytes[offset];
         if (byte == '\0' || byte == '\r' || byte == 0x1b)
           break;
+        visible_or |= byte;
         offset++;
       }
+      if (visible_or & 0x80) line->output_has_non_ascii = true;
       if (offset > start &&
           !async_line_emit_visible_run(
               s, line, (const unsigned char *)bytes + start,
@@ -4555,6 +4611,7 @@ static void async_line_reset(AsyncLineDecoder *line) {
   line->ansi_state = AsyncAnsiNormal;
   line->over_limit = false;
   line->saw_bytes = false;
+  line->output_has_non_ascii = false;
   if (line->output) line->output[0] = '\0';
 }
 
@@ -4574,7 +4631,8 @@ static bool async_line_finish(AsyncSession *s, AsyncLineDecoder *line) {
   if (publish) {
     if (!async_line_reserve(s, line, 0)) return false;
     line->output[line->output_len] = '\0';
-    ok = async_append_candidate(s, line->output, line->output_len);
+    ok = async_append_candidate_classified(
+        s, line->output, line->output_len, !line->output_has_non_ascii);
   }
   async_line_reset(line);
   return ok;
@@ -5918,6 +5976,9 @@ struct AsyncScoringShared {
      identical; the score field is just set to 0 (unscored) and the
      calling thread skips counting_sort_scored. */
   bool                      filter_only;
+  /* Production session strings carry immutable arena metadata.  Keep this
+     explicit because internal unit jobs can score ordinary C strings. */
+  bool                      arena_metadata;
   _Atomic bool              allocation_failed;
 };
 
@@ -5991,6 +6052,7 @@ static void async_score_batches(struct AsyncScoringShared *shared,
   }
   fzf_pattern_t *pattern      = shared->pattern;
   bool           filter_only  = shared->filter_only;
+  bool           arena_metadata = shared->arena_metadata;
   bool can_reuse_public_score =
       fzf_rank_can_reuse_public_score(pattern, shared->score_scheme);
 
@@ -6024,11 +6086,26 @@ static void async_score_batches(struct AsyncScoringShared *shared,
       if (!pattern) {
         sc = 1;                  /* empty filter: keep everything */
       } else if (filter_only) {
-        sc = fzf_has_match(batch->xs[i].str, pattern, slab) ? 1 : 0;
+        if (arena_metadata)
+          async_arena_string_metadata(
+              batch->xs[i].str, &text_len, &input_is_ascii);
+        else {
+          text_len = strlen(batch->xs[i].str);
+          input_is_ascii = is_ascii_utf8proc(
+              batch->xs[i].str, text_len);
+        }
+        sc = fzf_has_match_bytes_preclassified(
+                 batch->xs[i].str, text_len, input_is_ascii,
+                 pattern, slab) ? 1 : 0;
       } else {
-        text_len = strlen(batch->xs[i].str);
-        input_is_ascii = is_ascii_utf8proc(
-            batch->xs[i].str, text_len);
+        if (arena_metadata)
+          async_arena_string_metadata(
+              batch->xs[i].str, &text_len, &input_is_ascii);
+        else {
+          text_len = strlen(batch->xs[i].str);
+          input_is_ascii = is_ascii_utf8proc(
+              batch->xs[i].str, text_len);
+        }
         sc = fzf_score_and_rank(
             batch->xs[i].str, text_len, input_is_ascii,
             pattern, slab, shared->score_scheme,
@@ -6744,6 +6821,7 @@ static void *scoring_thread_fn(void *arg) {
         .batch_cache = &s->batch_cache,
         .target_query = target_query,
         .filter_only = filter_only_mode,
+        .arena_metadata = true,
         .allocation_failed = false,
       };
       if (worker_pool) {
@@ -7023,8 +7101,10 @@ static void *scoring_thread_fn(void *arg) {
           rank_aborted = true;
           break;
         }
-        size_t text_len = strlen(flat[i].str);
-        bool input_is_ascii = is_ascii_utf8proc(flat[i].str, text_len);
+        size_t text_len;
+        bool input_is_ascii;
+        async_arena_string_metadata(
+            flat[i].str, &text_len, &input_is_ascii);
         flat[i].score = fzf_score_and_rank(
             flat[i].str, text_len, input_is_ascii, pattern, rank_slab,
             score_scheme, can_reuse_public_score, &flat[i].rank);

--- a/fzf-score-input.inc
+++ b/fzf-score-input.inc
@@ -14,6 +14,21 @@
 #define FZF_SCORE_COMMIT_BOUNDS_WAS_DEFAULTED 1
 #endif
 
+/* Parsed interactive queries most often contain one positive term.  Answer
+   that shape directly instead of entering two generic set loops and testing
+   inverse/alternative state that the parser has already ruled out. */
+if (!pattern->only_inv && pattern->size == 1 &&
+    pattern->ptr[0]->size == 1 && !pattern->ptr[0]->ptr[0].inv) {
+  fzf_term_t *term = &pattern->ptr[0]->ptr[0];
+  fzf_result_t res = CALL_ALG(
+      term, false, input, input_is_ascii, pattern->forward, NULL, slab);
+  if (fzf_allocation_failed()) return 0;
+  if (res.start < 0) return 0;
+  FZF_SCORE_RECORD_BOUNDS(res);
+  FZF_SCORE_COMMIT_BOUNDS();
+  return res.score > 0 ? res.score : 1;
+}
+
 if (pattern->only_inv) {
   for (size_t i = 0; i < pattern->size; i++) {
     fzf_term_set_t *term_set = pattern->ptr[i];

--- a/fzf.c
+++ b/fzf.c
@@ -1184,6 +1184,42 @@ fzf_result_t fzf_fuzzy_match_v1(bool case_sensitive, bool normalize,
                                  pattern, pos, slab, NULL);
 }
 
+/* A one-byte pattern has no DP rows and its score cannot contain a gap or
+   consecutive bonus.  Keep the v2 character-class and tie-breaking rules,
+   but do not allocate five scratch slices or copy the complete candidate. */
+static fzf_result_t fzf_fuzzy_match_v2_one_byte(
+    bool case_sensitive, bool normalize, bool forward, fzf_string_t *text,
+    fzf_string_t *pattern, fzf_position_t *pos, size_t scan_start,
+    const score_scheme_config_t *config) {
+  int16_t max_score = 0;
+  size_t max_score_pos = 0;
+  int32_t prev_class = config->initial_class;
+  char pattern_byte = pattern->data[0];
+
+  for (size_t idx = scan_start; idx < text->size; idx++) {
+    char c = text->data[idx];
+    char_class class = char_class_of_ascii(c, config);
+    if (!case_sensitive && class == CharUpper)
+      c = (char)tolower((uint8_t)c);
+    if (normalize) c = normalize_rune(c);
+
+    if (c == pattern_byte) {
+      int16_t bonus = bonus_for(config, prev_class, class);
+      int16_t score = ScoreMatch + bonus * BonusFirstCharMultiplier;
+      if (forward ? score > max_score : score >= max_score) {
+        max_score = score;
+        max_score_pos = idx;
+        if (forward && bonus >= BonusBoundary) break;
+      }
+    }
+    prev_class = class;
+  }
+
+  append_pos(pos, max_score_pos);
+  return (fzf_result_t){(int32_t)max_score_pos,
+                        (int32_t)max_score_pos + 1, max_score};
+}
+
 static fzf_result_t fzf_fuzzy_match_v2_impl(
     bool case_sensitive, bool normalize, bool forward, fzf_string_t *text,
     fzf_string_t *pattern, fzf_position_t *pos, fzf_slab_t *slab,
@@ -1225,6 +1261,10 @@ static fzf_result_t fzf_fuzzy_match_v2_impl(
     }
     idx = (size_t)tmp_idx;
   }
+
+  if (M == 1)
+    return fzf_fuzzy_match_v2_one_byte(
+        case_sensitive, normalize, forward, text, pattern, pos, idx, config);
 
   size_t offset16 = 0;
   size_t offset32 = 0;
@@ -1297,13 +1337,6 @@ static fzf_result_t fzf_fuzzy_match_v2_impl(
       int16_t score = ScoreMatch + bonus * BonusFirstCharMultiplier;
       h0_sub.data[off] = score;
       c0_sub.data[off] = 1;
-      if (M == 1 && (forward ? score > max_score : score >= max_score)) {
-        max_score = score;
-        max_score_pos = idx + off;
-        if (forward && bonus >= BonusBoundary) {
-          break;
-        }
-      }
       in_gap = false;
     } else {
       if (in_gap) {
@@ -1324,18 +1357,6 @@ static fzf_result_t fzf_fuzzy_match_v2_impl(
     free_alloc(h0);
     return (fzf_result_t){-1, -1, 0};
   }
-  if (M == 1) {
-    free_alloc(t);
-    free_alloc(f);
-    free_alloc(bo);
-    free_alloc(c0);
-    free_alloc(h0);
-    fzf_result_t res = {(int32_t)max_score_pos, (int32_t)max_score_pos + 1,
-                        max_score};
-    append_pos(pos, max_score_pos);
-    return res;
-  }
-
   size_t f0 = (size_t)f.data[0];
   size_t width = last_idx - f0 + 1;
   if (M != 0 && width > SIZE_MAX / M) {

--- a/fzf.c
+++ b/fzf.c
@@ -2997,17 +2997,17 @@ static inline fzf_result_t call_alg_for_input(
     algo = get_utf8_algo(algo);
   }
   fzf_string_t *pattern = (fzf_string_t *)term->text;
-  if (algo == fzf_fuzzy_match_v1) {
-    const fzf_ascii_query_plan_t *plan =
-        fzf_fuzzy_query_plan(input, pattern);
-    return fzf_fuzzy_match_v1_impl(
-        term->case_sensitive, term->normalize, forward, input, pattern, pos,
-        slab, plan);
-  }
   if (algo == fzf_fuzzy_match_v2) {
     const fzf_ascii_query_plan_t *plan =
         fzf_fuzzy_query_plan(input, pattern);
     return fzf_fuzzy_match_v2_impl(
+        term->case_sensitive, term->normalize, forward, input, pattern, pos,
+        slab, plan);
+  }
+  if (algo == fzf_fuzzy_match_v1) {
+    const fzf_ascii_query_plan_t *plan =
+        fzf_fuzzy_query_plan(input, pattern);
+    return fzf_fuzzy_match_v1_impl(
         term->case_sensitive, term->normalize, forward, input, pattern, pos,
         slab, plan);
   }

--- a/fzf.c
+++ b/fzf.c
@@ -1193,6 +1193,7 @@ static fzf_result_t fzf_fuzzy_match_v2_one_byte(
     const score_scheme_config_t *config) {
   int16_t max_score = 0;
   size_t max_score_pos = 0;
+  bool matched = false;
   int32_t prev_class = config->initial_class;
   char pattern_byte = pattern->data[0];
 
@@ -1204,6 +1205,7 @@ static fzf_result_t fzf_fuzzy_match_v2_one_byte(
     if (normalize) c = normalize_rune(c);
 
     if (c == pattern_byte) {
+      matched = true;
       int16_t bonus = bonus_for(config, prev_class, class);
       int16_t score = ScoreMatch + bonus * BonusFirstCharMultiplier;
       if (forward ? score > max_score : score >= max_score) {
@@ -1215,6 +1217,7 @@ static fzf_result_t fzf_fuzzy_match_v2_one_byte(
     prev_class = class;
   }
 
+  if (!matched) return (fzf_result_t){-1, -1, 0};
   append_pos(pos, max_score_pos);
   return (fzf_result_t){(int32_t)max_score_pos,
                         (int32_t)max_score_pos + 1, max_score};


### PR DESCRIPTION
## Summary

- Avoid dynamic-programming scratch allocation for one-byte v2 scoring.
- Bypass generic term-set loops for a single positive query term.
- Cache candidate byte length and ASCII classification in the session arena.
- Preserve exact results with new differential and truncation tests.

## Benchmark result

The candidate exceeds the 10% target for persistent interactive work:

- Skim session totals: 1.123x to 1.329x; 1.229x geometric mean.
- Direct interactive trace: 1.113x.
- Session-growth total: 1.160x.
- Emacs completion styles: 1.020x to 1.058x.
- One-byte public API cases: 1.240x to 1.700x.

The sealed holdout also found a cost. Six one-candidate fuzzy-benches workloads regress by 2.5% to 8.3%. CJK and case-fold combined rows regress by 0.5% to 0.9%. The larger repeated-corpus and Frizbee workloads improve.

Full report: `benchmarks/2026-09-08T134029Z.md`

## Validation

- Full C test suite.
- ASan and UBSan suites.
- Session TSan replay.
- Fresh Emacs 30.2 module: 188 of 188 ERT tests.
- Independent old-base versus candidate scorer and session differentials with no mismatch.
- All benchmark semantic fingerprints, snapshots, result orders, and Emacs records matched.

The product candidate was frozen before the holdout run. No product source changed after the holdout results became available.