### PR TITLE
Optimize case folding and one-rune session scoring

### DIFF
--- a/benchmarks/2026-09-08T213838Z.md
+++ b/benchmarks/2026-09-08T213838Z.md
@@ -1,0 +1,188 @@
+# Frozen benchmark results
+
+**Decision: GO.** The candidate is correct on every checked output. It is faster on both sealed holdouts in aggregate.
+
+The unweighted holdout geomean is **1.0228x** across 39 one-to-one rows. The candidate also improves each material session total.
+
+Small single-candidate benchmarks have regressions. This report gives all regressions and does not claim a universal 10% improvement.
+
+Speedup is the base time divided by the candidate time. A value of more than 1.0 favors the candidate.
+
+Each time cell gives the median across independent processes and the full process range. Each speedup cell gives paired ratios and their range.
+
+## Summary
+
+| Suite | Rows / pairs | Aggregate | Candidate wins | Correctness |
+|---|---:|---:|---:|---|
+| sealed fuzzy-benches | 16 / 7 | 1.0187x geomean | 4/16 | exact on all 8 workloads |
+| sealed Frizbee | 23 / 7 | 1.0256x geomean | 16/23 | exact on 3 real and 20 generated workloads |
+| core probe | 9 / 7 | 1.1099x geomean | 8/9 | 9/9 fingerprints exact |
+| growth | 6 / 5 | 1.1369x geomean | 6/6 | 41/41 snapshots per run exact |
+| session trace | 4 / 6 | full trace 1.1473x | 4/4 | 14/14 steps per run exact |
+| Skim session totals | 4 / 7 | 1.2058x geomean | 4/4, all 7/7 pairs | 18 query/configuration signatures exact |
+
+## Source and method
+
+- Base commit: `4b9236e8cd1e9f9f3aaf5f2ebf83f1fc5995d38d`.
+- Evaluated candidate commit: `c00f656bbe0d34378c9f43a5b4ddc957ae3dc193`.
+- Published product commit: `2c8b67a`.
+- Both candidate commits have tree `eb7fe383611d9260647b0bf80a933b7328911566`.
+- fuzzy-benches revision: `633c6c359f4a6f859ee7c35abd574dd3eafc4910`.
+- Frizbee revision: `f2ec9684559479a428b29dc81b94f38596565b0e`.
+- Skim revision: `998175ed0af817f541f1108e4f686fc7b554fd6b`.
+
+The fuzzy preflight compared match counts, position counts, score checksums, and position checksums. All eight workloads were exact before each timed process.
+
+The Frizbee preflight compared tuple checksums for three real corpora. A separate program compared all 20 generated workloads before measurement.
+
+Core fingerprints, growth snapshots, session fingerprints, and Skim result checksums were identical. The number of correctness mismatches is zero.
+
+All timing used `/private/tmp/fzf-native-retry10/benchmark.lock/owner-final-holdout` as its sole owner. The evaluator released the lock after the last process.
+
+The host was an Apple M3 MacBook Air with 8 cores and 16 GB. It used macOS 26.5.2 and AC power.
+
+The build used Homebrew clang 22.1.8 and Rust/Cargo 1.98.1. The raw evidence contains the complete environment and binary hashes.
+
+The iteration agents did not read or run fuzzy-benches or Frizbee. A separate agent ran both holdouts after the product candidate was frozen.
+
+## Sealed fuzzy-benches results
+
+| Workload | Base median [range] | Candidate median [range] | Paired speedup [range] | Wins |
+|---|---:|---:|---:|---:|
+| e-macs/fzf-native | 10.407 ms [10.326 ms–10.440 ms] | 7.333 ms [7.279 ms–7.367 ms] | 1.414x [1.410–1.434] | 7/7 |
+| e-macs/fzf-native/with_matches | 22.661 ms [22.457 ms–22.721 ms] | 16.455 ms [16.299 ms–16.828 ms] | 1.376x [1.350–1.385] | 7/7 |
+| emacs/fzf-native | 5.944 ms [5.919 ms–5.959 ms] | 5.811 ms [5.792 ms–5.825 ms] | 1.023x [1.019–1.029] | 7/7 |
+| emacs/fzf-native/with_matches | 7.782 ms [7.764 ms–7.810 ms] | 7.536 ms [7.508 ms–7.565 ms] | 1.032x [1.029–1.034] | 7/7 |
+| long-end/fzf-native | 8.890 µs [8.427 µs–8.973 µs] | 8.996 µs [8.740 µs–9.261 µs] | 0.982x [0.964–0.997] | 0/7 |
+| long-end/fzf-native/with_matches | 17.863 µs [17.254 µs–18.072 µs] | 18.233 µs [17.937 µs–18.363 µs] | 0.973x [0.943–0.996] | 0/7 |
+| long-middle/fzf-native | 2.756 µs [2.715 µs–2.770 µs] | 2.764 µs [2.710 µs–2.817 µs] | 0.991x [0.969–1.020] | 1/7 |
+| long-middle/fzf-native/with_matches | 5.517 µs [5.395 µs–5.570 µs] | 5.600 µs [5.503 µs–5.681 µs] | 0.984x [0.968–0.992] | 0/7 |
+| long-start/fzf-native | 7.931 µs [7.816 µs–8.025 µs] | 8.071 µs [7.923 µs–8.232 µs] | 0.978x [0.956–1.004] | 1/7 |
+| long-start/fzf-native/with_matches | 15.791 µs [15.239 µs–16.100 µs] | 16.265 µs [15.884 µs–16.402 µs] | 0.977x [0.959–0.987] | 0/7 |
+| medium-end/fzf-native | 544 ns [525 ns–545 ns] | 564 ns [556 ns–567 ns] | 0.963x [0.944–0.966] | 0/7 |
+| medium-end/fzf-native/with_matches | 1.149 µs [1.144 µs–1.169 µs] | 1.186 µs [1.182 µs–1.195 µs] | 0.969x [0.964–0.984] | 0/7 |
+| medium-middle/fzf-native | 901 ns [878 ns–915 ns] | 966 ns [946 ns–972 ns] | 0.933x [0.928–0.948] | 0/7 |
+| medium-middle/fzf-native/with_matches | 1.849 µs [1.751 µs–1.866 µs] | 1.981 µs [1.957 µs–1.990 µs] | 0.932x [0.884–0.944] | 0/7 |
+| medium-start/fzf-native | 1.285 µs [1.217 µs–1.310 µs] | 1.349 µs [1.333 µs–1.362 µs] | 0.952x [0.913–0.967] | 0/7 |
+| medium-start/fzf-native/with_matches | 2.619 µs [2.457 µs–2.647 µs] | 2.750 µs [2.690 µs–2.758 µs] | 0.951x [0.909–0.974] | 0/7 |
+
+## Sealed Frizbee results
+
+| Workload | Base median [range] | Candidate median [range] | Paired speedup [range] | Wins |
+|---|---:|---:|---:|---:|
+| All Match/fzf-native/128 | 161.967 ms [157.354 ms–164.840 ms] | 148.065 ms [145.581 ms–148.488 ms] | 1.095x [1.081–1.110] | 7/7 |
+| All Match/fzf-native/16 | 28.955 ms [28.516 ms–28.991 ms] | 27.429 ms [27.376 ms–27.755 ms] | 1.055x [1.042–1.057] | 7/7 |
+| All Match/fzf-native/32 | 47.765 ms [46.699 ms–47.859 ms] | 44.229 ms [43.878 ms–44.599 ms] | 1.080x [1.064–1.081] | 7/7 |
+| All Match/fzf-native/64 | 81.774 ms [79.949 ms–83.430 ms] | 74.674 ms [74.093 ms–74.992 ms] | 1.096x [1.079–1.113] | 7/7 |
+| Arabic/fzf-native/Sequential | 47.985 ms [46.578 ms–48.543 ms] | 45.320 ms [45.097 ms–45.560 ms] | 1.055x [1.033–1.071] | 7/7 |
+| Chromium/fzf-native/Sequential | 141.803 ms [134.695 ms–145.228 ms] | 139.127 ms [138.328 ms–147.330 ms] | 1.017x [0.963–1.042] | 5/7 |
+| Copy/fzf-native/128 | 368.051 µs [367.844 µs–374.283 µs] | 370.008 µs [369.480 µs–370.827 µs] | 0.995x [0.992–1.012] | 2/7 |
+| Copy/fzf-native/16 | 368.079 µs [367.431 µs–373.352 µs] | 370.020 µs [369.832 µs–371.064 µs] | 0.994x [0.991–1.009] | 1/7 |
+| Copy/fzf-native/32 | 367.278 µs [364.889 µs–372.776 µs] | 369.420 µs [367.642 µs–370.753 µs] | 0.994x [0.988–1.014] | 1/7 |
+| Copy/fzf-native/64 | 368.346 µs [367.441 µs–374.529 µs] | 370.438 µs [369.683 µs–370.753 µs] | 0.995x [0.991–1.011] | 2/7 |
+| Korean/fzf-native/Sequential | 35.235 ms [33.582 ms–35.877 ms] | 34.137 ms [33.937 ms–34.182 ms] | 1.032x [0.983–1.052] | 6/7 |
+| No Match with Partial/fzf-native/128 | 4.704 ms [4.620 ms–4.806 ms] | 4.700 ms [4.660 ms–5.179 ms] | 0.997x [0.928–1.018] | 3/7 |
+| No Match with Partial/fzf-native/16 | 3.056 ms [3.031 ms–3.109 ms] | 3.074 ms [3.046 ms–3.581 ms] | 0.994x [0.864–1.005] | 3/7 |
+| No Match with Partial/fzf-native/32 | 3.384 ms [3.371 ms–3.472 ms] | 3.369 ms [3.354 ms–3.838 ms] | 1.004x [0.897–1.034] | 5/7 |
+| No Match with Partial/fzf-native/64 | 3.912 ms [3.902 ms–4.057 ms] | 3.893 ms [3.873 ms–4.367 ms] | 1.008x [0.910–1.042] | 5/7 |
+| No Match/fzf-native/128 | 4.430 ms [4.372 ms–4.568 ms] | 4.358 ms [4.314 ms–4.815 ms] | 1.018x [0.922–1.038] | 6/7 |
+| No Match/fzf-native/16 | 2.813 ms [2.800 ms–2.877 ms] | 2.822 ms [2.794 ms–3.338 ms] | 1.002x [0.859–1.013] | 4/7 |
+| No Match/fzf-native/32 | 3.131 ms [3.103 ms–3.206 ms] | 3.112 ms [3.109 ms–3.577 ms] | 0.999x [0.888–1.027] | 3/7 |
+| No Match/fzf-native/64 | 3.649 ms [3.613 ms–3.810 ms] | 3.634 ms [3.614 ms–4.136 ms] | 1.004x [0.897–1.054] | 5/7 |
+| Partial Match/fzf-native/128 | 12.908 ms [12.531 ms–12.994 ms] | 12.157 ms [12.026 ms–12.689 ms] | 1.061x [1.018–1.066] | 7/7 |
+| Partial Match/fzf-native/16 | 4.537 ms [4.460 ms–4.709 ms] | 4.437 ms [4.425 ms–4.954 ms] | 1.019x [0.917–1.063] | 6/7 |
+| Partial Match/fzf-native/32 | 5.802 ms [5.669 ms–6.050 ms] | 5.618 ms [5.587 ms–6.048 ms] | 1.034x [0.957–1.077] | 6/7 |
+| Partial Match/fzf-native/64 | 8.076 ms [7.973 ms–8.444 ms] | 7.670 ms [7.636 ms–8.136 ms] | 1.052x [0.988–1.096] | 6/7 |
+
+## Core, growth, and session results
+
+| Suite | Metric | Base median [range] | Candidate median [range] | Paired speedup [range] | Wins |
+|---|---|---:|---:|---:|---:|
+| core | Arabic | 5.402 ms [5.068 ms–5.422 ms] | 4.951 ms [4.783 ms–4.963 ms] | 1.091x [1.060–1.094] | 7/7 |
+| core | Chromium | 1.485 ms [1.400 ms–1.495 ms] | 1.402 ms [1.394 ms–1.421 ms] | 1.062x [0.999–1.068] | 6/7 |
+| core | EarlyASCII | 0.529 ms [0.529 ms–0.537 ms] | 0.330 ms [0.330 ms–0.356 ms] | 1.603x [1.486–1.618] | 7/7 |
+| core | Korean | 6.178 ms [5.915 ms–6.193 ms] | 5.603 ms [5.382 ms–5.614 ms] | 1.104x [1.099–1.118] | 7/7 |
+| core | Literal | 0.929 ms [0.912 ms–0.935 ms] | 0.905 ms [0.892 ms–0.926 ms] | 1.026x [0.985–1.042] | 6/7 |
+| core | OneByte | 0.267 ms [0.263 ms–0.271 ms] | 0.239 ms [0.223 ms–0.256 ms] | 1.117x [1.051–1.179] | 7/7 |
+| core | UTF8-hit | 14.355 ms [13.720 ms–14.486 ms] | 13.890 ms [13.537 ms–13.912 ms] | 1.033x [1.014–1.050] | 7/7 |
+| core | V1-early | 30.631 ms [30.571 ms–31.455 ms] | 30.689 ms [30.589 ms–31.248 ms] | 0.998x [0.991–1.007] | 1/7 |
+| core | V1-late | 46.846 ms [45.134 ms–47.320 ms] | 44.380 ms [43.264 ms–44.746 ms] | 1.054x [1.043–1.065] | 7/7 |
+| growth | maximum | 2.734 ms [2.723 ms–2.853 ms] | 2.733 ms [2.656 ms–2.806 ms] | 1.000x [0.980–1.074] | 4/5 |
+| growth | mean | 0.350 ms [0.348 ms–0.355 ms] | 0.308 ms [0.305 ms–0.310 ms] | 1.140x [1.126–1.153] | 5/5 |
+| growth | median | 0.286 ms [0.284 ms–0.289 ms] | 0.230 ms [0.230 ms–0.234 ms] | 1.243x [1.214–1.257] | 5/5 |
+| growth | p95 | 0.310 ms [0.298 ms–0.316 ms] | 0.296 ms [0.294 ms–0.302 ms] | 1.047x [0.987–1.057] | 4/5 |
+| growth | total | 14.009 ms [13.909 ms–14.215 ms] | 12.310 ms [12.195 ms–12.383 ms] | 1.141x [1.127–1.155] | 5/5 |
+| growth | initial scan | 30.715 ms [28.950 ms–31.738 ms] | 24.166 ms [22.712 ms–29.213 ms] | 1.275x [1.051–1.313] | 5/5 |
+| session trace | backspace | 0.003 ms [0.002 ms–0.005 ms] | 0.002 ms [0.002 ms–0.003 ms] | 1.500x [0.667–2.500] | 3/6 |
+| session trace | full trace | 308.721 ms [308.405 ms–309.480 ms] | 268.962 ms [267.592 ms–270.288 ms] | 1.147x [1.145–1.154] | 6/6 |
+| session trace | narrowing | 236.037 ms [235.639 ms–236.694 ms] | 205.113 ms [204.278 ms–206.702 ms] | 1.150x [1.141–1.156] | 6/6 |
+| session trace | unrelated | 72.721 ms [72.459 ms–72.892 ms] | 63.384 ms [63.128 ms–63.622 ms] | 1.146x [1.143–1.152] | 6/6 |
+
+## Skim session results
+
+| Workload | Workers | Metric | Base median [range] | Candidate median [range] | Paired speedup [range] | Wins |
+|---|---:|---|---:|---:|---:|---:|
+| prefix | 1 | session total | 530.257 ms [527.807 ms–539.036 ms] | 427.386 ms [426.357 ms–450.661 ms] | 1.239x [1.174–1.262] | 7/7 |
+| prefix | 1 | step 1 | 102.523 ms [101.818 ms–102.939 ms] | 61.799 ms [61.486 ms–62.881 ms] | 1.656x [1.627–1.669] | 7/7 |
+| prefix | 1 | step 2 | 162.314 ms [161.521 ms–163.703 ms] | 135.404 ms [135.243 ms–151.269 ms] | 1.196x [1.071–1.210] | 7/7 |
+| prefix | 1 | step 3 | 153.254 ms [152.618 ms–160.686 ms] | 132.429 ms [131.793 ms–133.004 ms] | 1.157x [1.151–1.213] | 7/7 |
+| prefix | 1 | step 4 | 111.933 ms [111.666 ms–112.326 ms] | 97.819 ms [97.135 ms–103.508 ms] | 1.144x [1.079–1.156] | 7/7 |
+| prefix | 8 | session total | 127.728 ms [118.626 ms–130.283 ms] | 105.612 ms [101.383 ms–107.472 ms] | 1.201x [1.137–1.263] | 7/7 |
+| prefix | 8 | step 1 | 37.372 ms [31.200 ms–39.547 ms] | 26.141 ms [18.941 ms–26.961 ms] | 1.434x [1.223–1.979] | 7/7 |
+| prefix | 8 | step 2 | 35.331 ms [33.913 ms–35.881 ms] | 30.614 ms [29.987 ms–32.268 ms] | 1.131x [1.064–1.172] | 7/7 |
+| prefix | 8 | step 3 | 31.687 ms [30.736 ms–32.104 ms] | 28.969 ms [28.161 ms–29.430 ms] | 1.091x [1.044–1.124] | 7/7 |
+| prefix | 8 | step 4 | 22.834 ms [22.594 ms–23.557 ms] | 20.622 ms [20.536 ms–21.457 ms] | 1.109x [1.053–1.143] | 7/7 |
+| trace | 1 | session total | 320.503 ms [319.894 ms–322.179 ms] | 243.323 ms [242.816 ms–244.666 ms] | 1.318x [1.315–1.324] | 7/7 |
+| trace | 1 | step 1 | 102.026 ms [101.442 ms–102.687 ms] | 60.831 ms [60.619 ms–61.661 ms] | 1.677x [1.662–1.694] | 7/7 |
+| trace | 1 | step 2 | 142.644 ms [141.993 ms–143.085 ms] | 119.921 ms [119.412 ms–120.879 ms] | 1.192x [1.181–1.194] | 7/7 |
+| trace | 1 | step 3 | 76.181 ms [75.845 ms–76.696 ms] | 62.485 ms [62.098 ms–62.672 ms] | 1.218x [1.212–1.235] | 7/7 |
+| trace | 1 | step 4 | 0.016 ms [0.014 ms–0.022 ms] | 0.016 ms [0.015 ms–0.020 ms] | 1.060x [0.690–1.438] | 5/7 |
+| trace | 1 | step 5 | 0.016 ms [0.015 ms–0.030 ms] | 0.015 ms [0.013 ms–0.019 ms] | 1.045x [0.805–1.911] | 5/7 |
+| trace | 8 | session total | 72.778 ms [72.411 ms–82.744 ms] | 68.553 ms [67.077 ms–70.284 ms] | 1.077x [1.034–1.207] | 7/7 |
+| trace | 8 | step 1 | 26.582 ms [26.339 ms–36.246 ms] | 27.374 ms [26.470 ms–27.642 ms] | 0.992x [0.966–1.311] | 2/7 |
+| trace | 8 | step 2 | 30.298 ms [29.957 ms–30.751 ms] | 27.084 ms [26.474 ms–28.286 ms] | 1.122x [1.067–1.158] | 7/7 |
+| trace | 8 | step 3 | 15.858 ms [15.770 ms–16.071 ms] | 14.047 ms [13.794 ms–14.767 ms] | 1.123x [1.074–1.165] | 7/7 |
+| trace | 8 | step 4 | 0.015 ms [0.014 ms–0.027 ms] | 0.017 ms [0.015 ms–0.018 ms] | 0.883x [0.763–1.866] | 1/7 |
+| trace | 8 | step 5 | 0.014 ms [0.013 ms–0.022 ms] | 0.015 ms [0.013 ms–0.017 ms] | 0.877x [0.816–1.606] | 2/7 |
+
+## Regressions
+
+Twelve fuzzy rows have a median below 1.0. Seven Frizbee rows and one core row have a median below 1.0.
+
+The medium fuzzy workloads are 0.932–0.969x. Their candidate latency is 3.2–7.3% higher.
+
+Several long fuzzy workloads are 0.973–0.983x. Their candidate latency is 1.7–2.7% higher.
+
+These are one-candidate calls with absolute increases from tens to hundreds of nanoseconds. Ten fuzzy regression ranges stay below 1.0.
+
+The seven Frizbee median regressions are 0.994–0.999x. Each range crosses 1.0, and no row loses all seven pairs.
+
+The Copy rows are near the fixed allocation and sort floor. Core V1-early is 0.998x with a 0.991–1.007x range.
+
+Growth has no median regression. The session backspace result is 2–5 µs and is near the timer resolution.
+
+Skim trace/w8 step 1 is 0.992x with a 0.966–1.311x range. Its cached steps are 13–28 µs with wide ranges.
+
+All four Skim session totals improve by 1.077–1.318x. Each total wins all seven pairs.
+
+The strongest holdout gains are on the 95,655-item Emacs corpus. `e-macs` improves 1.414x without positions and 1.376x with positions.
+
+The ordinary `emacs` query improves 1.023x without positions and 1.032x with positions.
+
+## Native Emacs, ABI, and memory
+
+The frozen pre-holdout gate ran GNU Emacs 30.2 directly. All 188 ERT tests passed with the candidate module.
+
+A separate direct Emacs timing used five paired processes and a 50,000-candidate corpus. Its seven-query geomean was 0.999x.
+
+The Lisp result-copy and sort work dominated that direct timing. Candidate counts, order, scores, and SHA-256 fingerprints were exact.
+
+The module exports are unchanged. The module adds 772 bytes of text, which is 0.53%.
+
+The arena adds two bytes for each candidate. The measured peak RSS increase was 1.92 MiB for one million candidates.
+
+## Evidence
+
+The raw workspace is `/private/tmp/fzf-native-retry10/final-bench`. The independent audit is `/private/tmp/fzf-native-retry10/audit-simd`.
+
+The final workspace contains source identities, checksum preflights, process outputs, order files, summary tables, commands, environment data, and binary hashes.

--- a/fzf-additions-test.c
+++ b/fzf-additions-test.c
@@ -1229,6 +1229,54 @@ static void test_pinned_fzf_backward_direction(void) {
   fzf_free_positions(positions);
 }
 
+static void test_case_fold_page_filter_is_exhaustive(void) {
+  for (utf8proc_int32_t codepoint = 0; codepoint < 0x110000; codepoint++) {
+    utf8proc_int32_t expected = utf8proc_tolower(codepoint);
+    utf8proc_int32_t actual = utf8proc_case_fold(codepoint);
+    if (actual != expected) {
+      fprintf(stderr,
+              "  FAIL case-fold page filter at U+%04x: %d != %d\n",
+              (unsigned int)codepoint, (int)actual, (int)expected);
+      failed++;
+      break;
+    }
+  }
+  CHECK(utf8proc_case_fold(-1) == utf8proc_tolower(-1));
+  CHECK(utf8proc_case_fold(0x110000) == utf8proc_tolower(0x110000));
+}
+
+static void test_case_fold_page_filter_edge_cases(void) {
+  const utf8proc_int32_t codepoints[] = {
+    'A', 0x00df, 0x0130, 0x01c5, 0x212a, 0xfb00, 0x10400, 0x1d400,
+  };
+  for (size_t i = 0; i < sizeof codepoints / sizeof codepoints[0]; i++)
+    CHECK(utf8proc_case_fold(codepoints[i]) ==
+          utf8proc_tolower(codepoints[i]));
+
+  /* The scorer intentionally implements one-codepoint ToLower, not full
+     Unicode fold expansions: sharp-s and the ff ligature stay unchanged. */
+  CHECK(utf8proc_case_fold(0x00df) == 0x00df);
+  CHECK(utf8proc_case_fold(0xfb00) == 0xfb00);
+  CHECK(utf8proc_case_fold(0x10400) == 0x10428); /* supplementary Deseret */
+  /* Mathematical alphabets case-fold through compatibility mappings, not
+     utf8proc's one-codepoint lowercase table. */
+  CHECK(utf8proc_case_fold(0x1d400) == 0x1d400);
+
+  check_agreement("unicode case-ignore", "\xce\x98\xce\xb5\xcf\x89",
+                  "\xce\xb8\xce\xb5\xcf\x89", CaseIgnore, true, true);
+  check_agreement("unicode case-respect", "\xce\x98\xce\xb5\xcf\x89",
+                  "\xce\xb8\xce\xb5\xcf\x89", CaseRespect, true, false);
+  check_agreement("unicode smart lower", "\xce\x98\xce\xb5\xcf\x89",
+                  "\xce\xb8\xce\xb5\xcf\x89", CaseSmart, true, true);
+  check_agreement("unicode smart upper", "\xce\xb8\xce\xb5\xcf\x89",
+                  "\xce\x98\xce\xb5\xcf\x89", CaseSmart, true, false);
+  check_agreement("supplementary case-ignore",
+                  "\xf0\x90\x90\x80", "\xf0\x90\x90\xa8",
+                  CaseIgnore, true, true);
+  check_agreement("v2 titlecase guard", "\xc7\x85", "\xc7\x86",
+                  CaseIgnore, true, false);
+}
+
 int main(void) {
   printf("--- fzf-additions: fzf_has_match ---\n");
   RUN(test_fuzzy_basic_match);
@@ -1278,6 +1326,8 @@ int main(void) {
   RUN(test_pinned_fzf_latin_normalization);
   RUN(test_normalized_utf8_prefilter);
   RUN(test_pinned_fzf_backward_direction);
+  RUN(test_case_fold_page_filter_is_exhaustive);
+  RUN(test_case_fold_page_filter_edge_cases);
 
   if (failed == 0) {
     printf("\nAll fzf-additions tests passed.\n");

--- a/fzf-additions.c
+++ b/fzf-additions.c
@@ -26,11 +26,10 @@
 #include "fzf-private.h"
 #include "fzf-simd-prefilter.h"
 
-#include <ctype.h>
 #include <string.h>
 
 static inline char fzf_addn_lower(unsigned char c) {
-  return (char)tolower(c);
+  return fzf_ascii_tolower(c);
 }
 
 static inline bool fzf_addn_space(unsigned char c) {

--- a/fzf-native-ctest.c
+++ b/fzf-native-ctest.c
@@ -135,6 +135,96 @@ static void test_candidate_analysis_fuses_nul_and_ascii_checks(void) {
   CHECK(ascii);
 }
 
+static void test_async_candidate_metadata_round_trip(void) {
+  typedef struct {
+    char *str;
+    int score;
+    uint32_t idx;
+    FzfRankKeys rank;
+  } ScoredStrBeforeMetadata;
+  CHECK(sizeof(ScoredStr) == sizeof(ScoredStrBeforeMetadata));
+
+  Arena arena = {0};
+  static const char ascii_text[] = "workspace/src/alpha.c";
+  static const char unicode_text[] = "caf\xc3\xa9";
+  static const char invalid_text[] = {'a', (char)0xff, 'b', '\0'};
+  const struct {
+    const char *text;
+    size_t len;
+    bool ascii;
+  } cases[] = {
+    {ascii_text, sizeof ascii_text - 1, true},
+    {unicode_text, sizeof unicode_text - 1, false},
+    {invalid_text, sizeof invalid_text - 1, false},
+    {"", 0, true},
+  };
+
+  for (size_t i = 0; i < sizeof cases / sizeof cases[0]; i++) {
+    char *stored = arena_strdup(
+        &arena, cases[i].text, cases[i].len, cases[i].ascii);
+    CHECK(stored != NULL);
+    if (!stored) continue;
+    ScoredStr candidate = {
+      .str = stored,
+      .metadata = async_arena_candidate_metadata(stored),
+    };
+    size_t measured_len = SIZE_MAX;
+    bool measured_ascii = !cases[i].ascii;
+    async_candidate_measure(&candidate, &measured_len, &measured_ascii);
+    CHECK(measured_len == cases[i].len);
+    CHECK(measured_ascii == cases[i].ascii);
+  }
+
+  /* Zero metadata remains a safe compatibility path for records assembled
+     outside the session arena. */
+  ScoredStr fallback = {.str = (char *)unicode_text};
+  size_t fallback_len = 0;
+  bool fallback_ascii = true;
+  async_candidate_measure(&fallback, &fallback_len, &fallback_ascii);
+  CHECK(fallback_len == sizeof unicode_text - 1);
+  CHECK(!fallback_ascii);
+
+  /* Exercise both sides of the compact-length sentinel.  Long ASCII lines
+     retain classification while length falls back to strlen; long byte-junk
+     lines safely rederive both values. */
+  const size_t boundary_lengths[] = {
+    ASYNC_CANDIDATE_LENGTH_MASK - 1,
+    ASYNC_CANDIDATE_LENGTH_MASK,
+    ASYNC_CANDIDATE_LENGTH_MASK + 1,
+  };
+  for (size_t i = 0;
+       i < sizeof boundary_lengths / sizeof boundary_lengths[0]; i++) {
+    size_t long_len = boundary_lengths[i];
+    char *long_text = malloc(long_len + 1);
+    CHECK(long_text != NULL);
+    if (!long_text) continue;
+    memset(long_text, 'x', long_len);
+    long_text[long_len] = '\0';
+    for (int ascii_case = 0; ascii_case < 2; ascii_case++) {
+      bool expected_ascii = ascii_case != 0;
+      if (!expected_ascii) long_text[long_len - 1] = (char)0xff;
+      char *stored = arena_strdup(
+          &arena, long_text, long_len, expected_ascii);
+      CHECK(stored != NULL);
+      if (stored) {
+        ScoredStr candidate = {
+          .str = stored,
+          .metadata = async_arena_candidate_metadata(stored),
+        };
+        size_t measured_len = 0;
+        bool measured_ascii = !expected_ascii;
+        async_candidate_measure(
+            &candidate, &measured_len, &measured_ascii);
+        CHECK(measured_len == long_len);
+        CHECK(measured_ascii == expected_ascii);
+      }
+      long_text[long_len - 1] = 'x';
+    }
+    free(long_text);
+  }
+  arena_free(&arena);
+}
+
 static enum emacs_funcall_exit ctest_copy_pending_exit;
 static emacs_value ctest_copy_original;
 static emacs_value ctest_copy_encoded;
@@ -1540,6 +1630,17 @@ static void test_async_line_decoder_matches_one_shot_reference(void) {
         if (actual) {
           CHECK(strlen(actual) == reference_len);
           CHECK(memcmp(actual, reference, reference_len) == 0);
+          ScoredStr candidate = {
+            .str = (char *)actual,
+            .metadata = async_arena_candidate_metadata(actual),
+          };
+          size_t measured_len = SIZE_MAX;
+          bool measured_ascii = false;
+          async_candidate_measure(
+              &candidate, &measured_len, &measured_ascii);
+          CHECK(measured_len == reference_len);
+          CHECK(measured_ascii == is_ascii_utf8proc(
+                                      reference, reference_len));
         }
         expected_count++;
       } else {
@@ -1618,6 +1719,30 @@ static void test_async_line_decoder_truncates_without_splitting_utf8(void) {
   CHECK(async_line_finish(s, &line));
   CHECK(s->count == 1);
   CHECK(strcmp(cands_at(s, 0), "\xe4\xbd\xa0\xe5\xa5\xbd") == 0);
+
+  /* Bytes beyond a negative truncation cap must not make the retained ASCII
+     prefix pessimistically Unicode. */
+  static const unsigned char ascii_then_unicode[] = {
+      'a', 'b', 0xc3, 0xa9,
+  };
+  CHECK(async_line_feed_bytes(
+      s, &line, (const char *)ascii_then_unicode,
+      sizeof ascii_then_unicode));
+  CHECK(async_line_finish(s, &line));
+  CHECK(s->count == 2);
+  const char *truncated = cands_at(s, 1);
+  CHECK(truncated != NULL && strcmp(truncated, "ab") == 0);
+  if (truncated) {
+    ScoredStr candidate = {
+      .str = (char *)truncated,
+      .metadata = async_arena_candidate_metadata(truncated),
+    };
+    size_t measured_len = 0;
+    bool measured_ascii = false;
+    async_candidate_measure(&candidate, &measured_len, &measured_ascii);
+    CHECK(measured_len == 2);
+    CHECK(measured_ascii);
+  }
   free(line.output);
   free_async_session(s);
 }
@@ -4442,6 +4567,7 @@ int main(void) {
   RUN(test_async_snapshot_staleness_covers_pool_growth);
   RUN(test_batch_worker_stops_on_shared_allocation_failure);
   RUN(test_candidate_analysis_fuses_nul_and_ascii_checks);
+  RUN(test_async_candidate_metadata_round_trip);
   RUN(test_copy_emacs_string_fallback_is_bounded);
   RUN(test_score_all_empty_collection_frees_query_bump);
   RUN(test_lossless_string_conversion_preserves_runtime_errors);

--- a/fzf-native-module.c
+++ b/fzf-native-module.c
@@ -2003,15 +2003,41 @@ emacs_value fzf_native_make_slab(emacs_env *env,
 typedef struct ArenaChunk { struct ArenaChunk *next; size_t used; char data[]; } ArenaChunk;
 typedef struct { ArenaChunk *head; } Arena;
 
-static char *arena_strdup(Arena *a, const char *s, size_t len) {
-  size_t need = len + 1;
-  if (!a->head || a->head->used + need > ARENA_CHUNK_SIZE) {
-    size_t chunk_sz = sizeof(ArenaChunk) + (need > ARENA_CHUNK_SIZE ? need : ARENA_CHUNK_SIZE);
+#define ASYNC_CANDIDATE_LENGTH_MASK UINT16_C(0x7fff)
+#define ASYNC_CANDIDATE_ASCII_FLAG UINT16_C(0x8000)
+
+static uint16_t async_candidate_metadata(size_t len, bool ascii) {
+  /* Zero means "measure on demand" for callers that construct ScoredStr
+     values outside the session arena.  Store short lengths plus one. */
+  uint16_t stored_len = len < ASYNC_CANDIDATE_LENGTH_MASK
+                            ? (uint16_t)(len + 1)
+                            : 0;
+  return (uint16_t)(stored_len |
+                    (ascii ? ASYNC_CANDIDATE_ASCII_FLAG : 0));
+}
+
+static uint16_t async_arena_candidate_metadata(const char *str) {
+  uint16_t metadata;
+  memcpy(&metadata, str - sizeof metadata, sizeof metadata);
+  return metadata;
+}
+
+static char *arena_strdup(Arena *a, const char *s, size_t len, bool ascii) {
+  if (len > SIZE_MAX - sizeof(ArenaChunk) - sizeof(uint16_t) - 1)
+    return NULL;
+  size_t need = sizeof(uint16_t) + len + 1;
+  if (!a->head || need > ARENA_CHUNK_SIZE ||
+      a->head->used > ARENA_CHUNK_SIZE - need) {
+    size_t chunk_sz = sizeof(ArenaChunk) +
+                      (need > ARENA_CHUNK_SIZE ? need : ARENA_CHUNK_SIZE);
     ArenaChunk *c = malloc(chunk_sz);
     if (!c) return NULL;
     c->used = 0; c->next = a->head; a->head = c;
   }
-  char *p = a->head->data + a->head->used;
+  char *storage = a->head->data + a->head->used;
+  uint16_t metadata = async_candidate_metadata(len, ascii);
+  memcpy(storage, &metadata, sizeof metadata);
+  char *p = storage + sizeof metadata;
   memcpy(p, s, len + 1);
   a->head->used += need;
   return p;
@@ -2049,7 +2075,25 @@ typedef struct {
   int score;
   uint32_t idx;
   FzfRankKeys rank;
+  /* Session-arena byte length and ASCII state in the tail padding that this
+     record already had on supported ABIs.  Zero remains a safe fallback for
+     test and compatibility records built outside the arena. */
+  uint16_t metadata;
 } ScoredStr;
+
+static void async_candidate_measure(const ScoredStr *candidate, size_t *len,
+                                    bool *ascii) {
+  uint16_t stored_len =
+      candidate->metadata & ASYNC_CANDIDATE_LENGTH_MASK;
+  *len = stored_len ? (size_t)stored_len - 1 : strlen(candidate->str);
+  if (candidate->metadata & ASYNC_CANDIDATE_ASCII_FLAG) {
+    *ascii = true;
+  } else if (stored_len) {
+    *ascii = false;
+  } else {
+    *ascii = is_ascii_utf8proc(candidate->str, *len);
+  }
+}
 
 /* Reference-counted immutable index array.  Allocated once by the scoring
    thread on cache_insert, retained in O(1) (atomic refcount bump under the
@@ -4144,8 +4188,8 @@ static void async_publish_stop(AsyncSession *s) {
    top-level block pointer before taking MU is safe.  Keeping this operation
    separate from getline lets the native interactive fuzzer drive the real
    growth path without an Emacs process or a shell child. */
-static bool async_append_candidate(AsyncSession *s, const char *line,
-                                   size_t len) {
+static bool async_append_candidate_preclassified(
+    AsyncSession *s, const char *line, size_t len, bool ascii) {
   if (atomic_load_explicit(&s->stop, memory_order_acquire)) return false;
   size_t i  = s->count;
   size_t hi = i >> CANDS_BLOCK_SHIFT;
@@ -4160,7 +4204,7 @@ static bool async_append_candidate(AsyncSession *s, const char *line,
     return false;
   }
 
-  char *dup = arena_strdup(&s->arena, line, len);
+  char *dup = arena_strdup(&s->arena, line, len, ascii);
   if (!dup) {
     async_record_producer_failure(
         s, AsyncProducerErrorAllocation, ENOMEM);
@@ -4196,6 +4240,15 @@ static bool async_append_candidate(AsyncSession *s, const char *line,
   atomic_fetch_add_explicit(&s->gen, 1, memory_order_relaxed);
   async_notify_candidate_growth(s);
   return true;
+}
+
+/* Test and embedding callers do not necessarily use the incremental reader,
+   so retain the original self-classifying helper for them. */
+static bool async_append_candidate(AsyncSession *s, const char *line,
+                                   size_t len) {
+  if (atomic_load_explicit(&s->stop, memory_order_acquire)) return false;
+  return async_append_candidate_preclassified(
+      s, line, len, is_ascii_utf8proc(line, len));
 }
 
 enum AsyncAnsiState {
@@ -4234,6 +4287,7 @@ typedef struct {
   enum AsyncAnsiState ansi_state;
   bool                over_limit;
   bool                saw_bytes;
+  bool                output_has_non_ascii;
 } AsyncLineDecoder;
 
 static size_t async_line_limit(ptrdiff_t configured) {
@@ -4307,6 +4361,7 @@ static bool async_line_commit_character(AsyncSession *s,
     }
     line->char_count++;
   }
+  if (bytes[0] & 0x80) line->output_has_non_ascii = true;
   return async_line_append_output(s, line, bytes, width);
 }
 
@@ -4320,8 +4375,10 @@ static unsigned async_utf8_expected_width(unsigned char byte) {
 static bool async_line_emit_visible_byte(AsyncSession *s,
                                          AsyncLineDecoder *line,
                                          unsigned char byte) {
-  if (s->max_line_length == 0)
+  if (s->max_line_length == 0) {
+    if (byte & 0x80) line->output_has_non_ascii = true;
     return async_line_append_output(s, line, &byte, 1);
+  }
 
   size_t cap = async_line_limit(s->max_line_length);
   if ((s->max_line_length > 0 && line->over_limit) ||
@@ -4473,6 +4530,7 @@ static bool async_line_emit_visible_run(AsyncSession *s,
         bytes + offset, (utf8proc_ssize_t)(amount - offset), &codepoint);
     offset += width > 0 ? (size_t)width : 1;
     line->char_count++;
+    line->output_has_non_ascii = true;
     retained_end = offset;
   }
 
@@ -4508,12 +4566,17 @@ static bool async_line_feed_bytes(AsyncSession *s, AsyncLineDecoder *line,
 
     if (line->ansi_state == AsyncAnsiNormal && line->pending_crs == 0) {
       size_t start = offset;
+      bool retain_all = s->max_line_length == 0;
+      unsigned char visible_bits = 0;
       while (offset < amount) {
         unsigned char byte = (unsigned char)bytes[offset];
         if (byte == '\0' || byte == '\r' || byte == 0x1b)
           break;
+        visible_bits |= byte;
         offset++;
       }
+      if (retain_all && (visible_bits & 0x80))
+        line->output_has_non_ascii = true;
       if (offset > start &&
           !async_line_emit_visible_run(
               s, line, (const unsigned char *)bytes + start,
@@ -4555,6 +4618,7 @@ static void async_line_reset(AsyncLineDecoder *line) {
   line->ansi_state = AsyncAnsiNormal;
   line->over_limit = false;
   line->saw_bytes = false;
+  line->output_has_non_ascii = false;
   if (line->output) line->output[0] = '\0';
 }
 
@@ -4574,7 +4638,9 @@ static bool async_line_finish(AsyncSession *s, AsyncLineDecoder *line) {
   if (publish) {
     if (!async_line_reserve(s, line, 0)) return false;
     line->output[line->output_len] = '\0';
-    ok = async_append_candidate(s, line->output, line->output_len);
+    ok = async_append_candidate_preclassified(
+        s, line->output, line->output_len,
+        !line->output_has_non_ascii);
   }
   async_line_reset(line);
   return ok;
@@ -6023,16 +6089,19 @@ static void async_score_batches(struct AsyncScoringShared *shared,
       FzfRankKeys rank = {0};
       if (!pattern) {
         sc = 1;                  /* empty filter: keep everything */
-      } else if (filter_only) {
-        sc = fzf_has_match(batch->xs[i].str, pattern, slab) ? 1 : 0;
       } else {
-        text_len = strlen(batch->xs[i].str);
-        input_is_ascii = is_ascii_utf8proc(
-            batch->xs[i].str, text_len);
-        sc = fzf_score_and_rank(
-            batch->xs[i].str, text_len, input_is_ascii,
-            pattern, slab, shared->score_scheme,
-            can_reuse_public_score, &rank);
+        async_candidate_measure(
+            &batch->xs[i], &text_len, &input_is_ascii);
+        sc = filter_only
+                 ? (fzf_has_match_bytes_preclassified(
+                        batch->xs[i].str, text_len, input_is_ascii,
+                        pattern, slab)
+                        ? 1
+                        : 0)
+                 : fzf_score_and_rank(
+                       batch->xs[i].str, text_len, input_is_ascii,
+                       pattern, slab, shared->score_scheme,
+                       can_reuse_public_score, &rank);
       }
       if (fzf_allocation_failed()) {
         atomic_store_explicit(&shared->allocation_failed, true,
@@ -6716,6 +6785,8 @@ static void *scoring_thread_fn(void *arg) {
           batch->xs[local_i].str =
               s->cands_top[global_i >> CANDS_BLOCK_SHIFT]
                           [global_i & CANDS_BLOCK_MASK];
+          batch->xs[local_i].metadata = async_arena_candidate_metadata(
+              batch->xs[local_i].str);
           batch->xs[local_i].score = 0;
           batch->xs[local_i].idx = (uint32_t)global_i;
         }
@@ -7023,8 +7094,9 @@ static void *scoring_thread_fn(void *arg) {
           rank_aborted = true;
           break;
         }
-        size_t text_len = strlen(flat[i].str);
-        bool input_is_ascii = is_ascii_utf8proc(flat[i].str, text_len);
+        size_t text_len;
+        bool input_is_ascii;
+        async_candidate_measure(&flat[i], &text_len, &input_is_ascii);
         flat[i].score = fzf_score_and_rank(
             flat[i].str, text_len, input_is_ascii, pattern, rank_slab,
             score_scheme, can_reuse_public_score, &flat[i].rank);

--- a/fzf-private.h
+++ b/fzf-private.h
@@ -4,6 +4,13 @@
 
 #include "fzf.h"
 
+/* fzf's byte-oriented algorithms operate on ASCII candidates.  Avoid the
+   locale-aware ctype dispatch in their inner loops: only ASCII uppercase
+   bytes have a distinct folded value in these paths. */
+static inline char fzf_ascii_tolower(unsigned char byte) {
+  return (char)(byte >= 'A' && byte <= 'Z' ? byte + ('a' - 'A') : byte);
+}
+
 #ifdef _MSC_VER
 #define FZF_THREAD_LOCAL __declspec(thread)
 #else

--- a/fzf-scorer-oom-ctest.c
+++ b/fzf-scorer-oom-ctest.c
@@ -138,6 +138,31 @@ static int exercise_score_positions(const char *label, const char *candidate,
   }
 }
 
+static int test_v2_single_byte_observes_prior_failure(void) {
+  static const char candidate_byte = 'a';
+  static const char pattern_byte = 'a';
+  fzf_string_t candidate = {.data = &candidate_byte, .size = 1};
+  fzf_string_t pattern = {.data = &pattern_byte, .size = 1};
+  fzf_position_t positions = {0};
+
+  fail_at = SIZE_MAX;
+  allocation_number = 0;
+  failure_injected = false;
+  fzf_allocation_failure = true;
+  fzf_result_t result = fzf_fuzzy_match_v2(
+      true, false, &candidate, &pattern, &positions, NULL);
+  if (result.start != -1 || result.end != -1 || result.score != 0 ||
+      positions.size != 0 || !fzf_allocation_failed()) {
+    free(positions.data);
+    fzf_clear_allocation_failure();
+    return fail("single-byte prior OOM", 0,
+                "scratch-free v2 path did not preserve failure state");
+  }
+  free(positions.data);
+  fzf_clear_allocation_failure();
+  return 0;
+}
+
 int main(void) {
   size_t tested = 0;
   char ascii_query[] = "abc";
@@ -161,7 +186,8 @@ int main(void) {
       exercise_positions("UTF-8 positions", "a你---界z", utf8_pattern,
                          &tested) ||
       exercise_score_positions("UTF-8 combined", "a你---界z", utf8_pattern,
-                               &tested);
+                               &tested) ||
+      test_v2_single_byte_observes_prior_failure();
 
   fail_at = SIZE_MAX;
   fzf_free_pattern(ascii_pattern);

--- a/fzf.c
+++ b/fzf.c
@@ -5,6 +5,14 @@
 #include <string.h>
 #include <stdlib.h>
 
+#if defined(_MSC_VER)
+#define FZF_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__) || defined(__clang__)
+#define FZF_NOINLINE __attribute__((noinline))
+#else
+#define FZF_NOINLINE
+#endif
+
 // UTF8PROC integration for Unicode support
 #include "utf8proc-2.10.0/utf8proc.h"
 #include "utf8_char_index.h"
@@ -179,12 +187,6 @@ static size_t trailing_whitespaces(fzf_string_t *str) {
     pos += (size_t)width;
   }
   return trailing;
-}
-
-static void copy_runes(fzf_string_t *src, fzf_i32_t *destination) {
-  for (size_t i = 0; i < src->size; i++) {
-    destination->data[i] = (int32_t)src->data[i];
-  }
 }
 
 static void copy_into_i16(i16_slice_t *src, fzf_i16_t *dest) {
@@ -1202,6 +1204,11 @@ fzf_result_t fzf_fuzzy_match_v1(bool case_sensitive, bool normalize,
                                  pattern, pos, slab, NULL);
 }
 
+static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_single(
+    bool case_sensitive, bool normalize, bool forward, fzf_string_t *text,
+    fzf_string_t *pattern, fzf_position_t *pos, size_t start,
+    const score_scheme_config_t *config);
+
 static fzf_result_t fzf_fuzzy_match_v2_impl(
     bool case_sensitive, bool normalize, bool forward, fzf_string_t *text,
     fzf_string_t *pattern, fzf_position_t *pos, fzf_slab_t *slab,
@@ -1244,6 +1251,16 @@ static fzf_result_t fzf_fuzzy_match_v2_impl(
     idx = (size_t)tmp_idx;
   }
 
+  if (M == 1) {
+    /* Direct algorithm callers can intentionally carry an allocation failure
+       into this call.  The former scratch allocation path observed that flag
+       before scoring; keep the same failure result on the scratch-free path. */
+    if (fzf_allocation_failed())
+      return (fzf_result_t){-1, -1, 0};
+    return fzf_fuzzy_match_v2_single(
+        case_sensitive, normalize, forward, text, pattern, pos, idx, config);
+  }
+
   size_t offset16 = 0;
   size_t offset32 = 0;
 
@@ -1263,7 +1280,6 @@ static fzf_result_t fzf_fuzzy_match_v2_impl(
     free_alloc(h0);
     return (fzf_result_t){-1, -1, 0};
   }
-  copy_runes(text, &t); // input.CopyRunes(T)
 
   // Phase 2. Calculate bonus for each point
   int16_t max_score = 0;
@@ -1278,6 +1294,9 @@ static fzf_result_t fzf_fuzzy_match_v2_impl(
   int32_t prev_class = config->initial_class;
   bool in_gap = false;
 
+  /* Initialize the rune suffix while computing its bonus data.  The old
+     whole-array copy wrote every rune immediately before this loop overwrote
+     the matched suffix; positions before IDX are never read by later rows. */
   i32_slice_t t_sub = slice_i32(t.data, idx, t.size); // T[idx:];
   i16_slice_t h0_sub =
       slice_i16_right(slice_i16(h0.data, idx, h0.size).data, t_sub.size);
@@ -1288,7 +1307,7 @@ static fzf_result_t fzf_fuzzy_match_v2_impl(
 
   for (size_t off = 0; off < t_sub.size; off++) {
     char_class class;
-    char c = (char)t_sub.data[off];
+    char c = text->data[idx + off];
     class = char_class_of_ascii(c, config);
     if (!case_sensitive && class == CharUpper) {
       /* TODO(conni2461): unicode support */
@@ -1315,13 +1334,6 @@ static fzf_result_t fzf_fuzzy_match_v2_impl(
       int16_t score = ScoreMatch + bonus * BonusFirstCharMultiplier;
       h0_sub.data[off] = score;
       c0_sub.data[off] = 1;
-      if (M == 1 && (forward ? score > max_score : score >= max_score)) {
-        max_score = score;
-        max_score_pos = idx + off;
-        if (forward && bonus >= BonusBoundary) {
-          break;
-        }
-      }
       in_gap = false;
     } else {
       if (in_gap) {
@@ -1342,18 +1354,6 @@ static fzf_result_t fzf_fuzzy_match_v2_impl(
     free_alloc(h0);
     return (fzf_result_t){-1, -1, 0};
   }
-  if (M == 1) {
-    free_alloc(t);
-    free_alloc(f);
-    free_alloc(bo);
-    free_alloc(c0);
-    free_alloc(h0);
-    fzf_result_t res = {(int32_t)max_score_pos, (int32_t)max_score_pos + 1,
-                        max_score};
-    append_pos(pos, max_score_pos);
-    return res;
-  }
-
   size_t f0 = (size_t)f.data[0];
   size_t width = last_idx - f0 + 1;
   if (M != 0 && width > SIZE_MAX / M) {
@@ -3508,4 +3508,37 @@ void fzf_free_slab(fzf_slab_t *slab) {
     free(slab->UTF8.map.byte_to_char);
     free(slab);
   }
+}
+
+/* Keep the one-rune specialization out of the multi-rune instruction layout:
+   it is common in incremental completion, but cold for longer DP queries. */
+static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_single(
+    bool case_sensitive, bool normalize, bool forward, fzf_string_t *text,
+    fzf_string_t *pattern, fzf_position_t *pos, size_t start,
+    const score_scheme_config_t *config) {
+  char pattern_char = pattern->data[0];
+  int16_t max_score = 0;
+  size_t max_score_pos = 0;
+  char_class prev_class = config->initial_class;
+  for (size_t text_index = start; text_index < text->size; text_index++) {
+    char c = text->data[text_index];
+    char_class class = char_class_of_ascii(c, config);
+    if (!case_sensitive && class == CharUpper)
+      c = fzf_ascii_tolower((uint8_t)c);
+    if (normalize) c = normalize_rune(c);
+    if (c == pattern_char) {
+      int16_t bonus = bonus_for(config, prev_class, class);
+      int16_t score = ScoreMatch + bonus * BonusFirstCharMultiplier;
+      if (forward ? score > max_score : score >= max_score) {
+        max_score = score;
+        max_score_pos = text_index;
+        if (forward && bonus >= BonusBoundary) break;
+      }
+    }
+    prev_class = class;
+  }
+  if (max_score == 0) return (fzf_result_t){-1, -1, 0};
+  append_pos(pos, max_score_pos);
+  return (fzf_result_t){(int32_t)max_score_pos,
+                        (int32_t)max_score_pos + 1, max_score};
 }

--- a/fzf.c
+++ b/fzf.c
@@ -3,7 +3,6 @@
 #include "fzf-simd-prefilter.h"
 
 #include <string.h>
-#include <ctype.h>
 #include <stdlib.h>
 
 // UTF8PROC integration for Unicode support
@@ -302,7 +301,7 @@ static char *str_tolower(const char *str, size_t size) {
     char *lower_str = (char *)malloc(size + 1);
     if (!lower_str) return NULL;
     for (size_t i = 0; i < size; i++) {
-      lower_str[i] = (char)tolower((uint8_t)str[i]);
+      lower_str[i] = fzf_ascii_tolower((uint8_t)str[i]);
     }
     lower_str[size] = '\0';
     return lower_str;
@@ -755,8 +754,26 @@ int32_t char_class_of_utf8proc(utf8proc_int32_t codepoint) {
                                  &score_scheme_configs[FZF_SCORE_SCHEME_DEFAULT]);
 }
 
+/* Only 29 of Unicode's 4352 256-codepoint pages contain a lowercase mapping
+   in the vendored utf8proc data.  Avoid its two-level property-table lookup
+   for the overwhelmingly common caseless scripts.  The bits are generated
+   exhaustively from utf8proc_property_t.lowercase_seqindex. */
+static bool fzf_page_has_lowercase_mapping(utf8proc_int32_t codepoint) {
+  static const uint64_t pages[] = {
+      UINT64_C(0x00001012d009003f), UINT64_C(0x0000000000000000),
+      UINT64_C(0x000000c000000000), UINT64_C(0x8000000000000000),
+      UINT64_C(0x0000000001003030), UINT64_C(0x0000400000000000),
+      UINT64_C(0x0000000000000000), UINT64_C(0x0002020000f00000),
+  };
+  uint32_t page = (uint32_t)codepoint >> 8;
+  return page < 64 * (sizeof pages / sizeof pages[0]) &&
+         (pages[page >> 6] & (UINT64_C(1) << (page & 63))) != 0;
+}
+
 utf8proc_int32_t utf8proc_case_fold(utf8proc_int32_t codepoint) {
-  return utf8proc_tolower(codepoint);
+  return fzf_page_has_lowercase_mapping(codepoint)
+             ? utf8proc_tolower(codepoint)
+             : codepoint;
 }
 
 /* FuzzyMatchV2 follows fzf's unicode.IsUpper guard when it lowercases
@@ -765,8 +782,9 @@ utf8proc_int32_t utf8proc_case_fold(utf8proc_int32_t codepoint) {
    belonging to the Lu category. */
 static utf8proc_int32_t v2_case_fold_candidate(
     utf8proc_int32_t codepoint) {
+  if (!fzf_page_has_lowercase_mapping(codepoint)) return codepoint;
   return utf8proc_category(codepoint) == UTF8PROC_CATEGORY_LU
-             ? utf8proc_case_fold(codepoint)
+             ? utf8proc_tolower(codepoint)
              : codepoint;
 }
 
@@ -957,7 +975,7 @@ static int32_t calculate_score(bool case_sensitive, bool normalize,
     int32_t class = char_class_of(c, config);
     if (!case_sensitive) {
       /* TODO(conni2461): He does some unicode stuff here, investigate */
-      c = (char)tolower((uint8_t)c);
+      c = fzf_ascii_tolower((uint8_t)c);
     }
     if (normalize) {
       c = normalize_rune(c);
@@ -1117,7 +1135,7 @@ static fzf_result_t fzf_fuzzy_match_v1_impl(
     /* TODO(conni2461): Common pattern maybe a macro would be good here */
     if (!case_sensitive) {
       /* TODO(conni2461): He does some unicode stuff here, investigate */
-      c = (char)tolower((uint8_t)c);
+      c = fzf_ascii_tolower((uint8_t)c);
     }
     if (normalize) {
       c = normalize_rune(c);
@@ -1145,7 +1163,7 @@ static fzf_result_t fzf_fuzzy_match_v1_impl(
       char c = text->data[text_index];
       if (!case_sensitive) {
         /* TODO(conni2461): He does some unicode stuff here, investigate */
-        c = (char)tolower((uint8_t)c);
+        c = fzf_ascii_tolower((uint8_t)c);
       }
       if (normalize) {
         c = normalize_rune(c);
@@ -1274,7 +1292,7 @@ static fzf_result_t fzf_fuzzy_match_v2_impl(
     class = char_class_of_ascii(c, config);
     if (!case_sensitive && class == CharUpper) {
       /* TODO(conni2461): unicode support */
-      c = (char)tolower((uint8_t)c);
+      c = fzf_ascii_tolower((uint8_t)c);
     }
     if (normalize) {
       c = normalize_rune(c);
@@ -1583,7 +1601,7 @@ static fzf_result_t fzf_exact_match_impl(
       char c = text->data[idx];
       if (!case_sensitive) {
         /* TODO(conni2461): He does some unicode stuff here, investigate */
-        c = (char)tolower((uint8_t)c);
+        c = fzf_ascii_tolower((uint8_t)c);
       }
       if (normalize) c = normalize_rune(c);
       if (c == pattern->data[pidx]) {
@@ -1693,7 +1711,7 @@ fzf_result_t fzf_prefix_match(bool case_sensitive, bool normalize,
   for (size_t i = 0; i < M; i++) {
     char c = text->data[trimmed_len + i];
     if (!case_sensitive) {
-      c = (char)tolower((uint8_t)c);
+      c = fzf_ascii_tolower((uint8_t)c);
     }
     if (normalize) {
       c = normalize_rune(c);
@@ -1735,7 +1753,7 @@ fzf_result_t fzf_suffix_match(bool case_sensitive, bool normalize,
   for (size_t idx = 0; idx < M; idx++) {
     char c = text->data[idx + diff];
     if (!case_sensitive) {
-      c = (char)tolower((uint8_t)c);
+      c = fzf_ascii_tolower((uint8_t)c);
     }
     if (normalize) {
       c = normalize_rune(c);
@@ -1784,7 +1802,7 @@ fzf_result_t fzf_equal_match(bool case_sensitive, bool normalize,
       char pchar = pattern->data[idx];
       char c = text->data[trimmed_len + idx];
       if (!case_sensitive) {
-        c = (char)tolower((uint8_t)c);
+        c = fzf_ascii_tolower((uint8_t)c);
       }
       if (normalize_rune(c) != normalize_rune(pchar)) {
         match = false;
@@ -1797,7 +1815,7 @@ fzf_result_t fzf_equal_match(bool case_sensitive, bool normalize,
       char pchar = pattern->data[idx];
       char c = text->data[trimmed_len + idx];
       if (!case_sensitive) {
-        c = (char)tolower((uint8_t)c);
+        c = fzf_ascii_tolower((uint8_t)c);
       }
       if (c != pchar) {
         match = false;


### PR DESCRIPTION
## Summary

- Replace locale-aware byte folding with fixed ASCII folding.
- Skip Unicode property lookups on pages that have no lowercase mapping.
- Store the byte length and ASCII state in two bytes for each session candidate.
- Remove one redundant V2 copy pass and use a scratch-free one-rune scorer.

## Results

The product candidate was frozen before the holdout evaluation.

| Suite | Speedup |
|---|---:|
| core geomean | 1.110x |
| producer growth geomean | 1.137x |
| interactive session trace | 1.147x |
| Skim session-total geomean | 1.206x |
| sealed fuzzy-benches geomean | 1.019x |
| sealed Frizbee geomean | 1.026x |
| combined sealed holdouts | 1.023x |

The strongest holdout result is `e-macs`: 1.414x without positions and 1.376x with positions.

This change does not give a universal 10% improvement. Twelve tiny fuzzy-benches rows regress by 1.7% to 7.3%.

The full paired tables and ranges are in `benchmarks/2026-09-08T213838Z.md`.

## Correctness

- An independent differential program compared 1,954,455 semantic records with the base. All records matched.
- C, ASan, UBSan, TSan, OOM, Unicode, session, cancellation, and reader checks passed.
- GNU Emacs 30.2 passed 188 of 188 ERT checks.
- All holdout checksums, session snapshots, scores, bounds, positions, and result orders matched.
- The ABI exports and public headers are unchanged.

## Costs

- The module adds 772 bytes of text, which is 0.53%.
- The session arena adds two bytes for each candidate.
- Peak RSS increased by 1.92 MiB for one million candidates.
- A direct Emacs timing was flat at 0.999x because Lisp copy and sort work dominated it.
