### PR TITLE
Speed up matching and add matched fzf benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,6 +355,27 @@ benchmark-session-trace: benchmark-session-trace-build
 		$(SESSION_TRACE_CANDIDATES) $(SESSION_TRACE_WORKERS) \
 		$(SESSION_TRACE_LIMIT) $(SESSION_TRACE_SAMPLES)
 
+# Cold first-query probe.  Invoke the executable once per sample so every run
+# starts with a fresh process-wide worker pool.  Corpus construction and an
+# independent full-scan/qsort oracle are outside the measured interval.
+FIRST_QUERY_CANDIDATES ?= 300000
+FIRST_QUERY_LIMIT ?= 256
+FIRST_QUERY_QUERY ?= omega
+FIRST_QUERY_BENCH := $(BUILD_DIR)/first-query-probe
+
+.PHONY: benchmark-first-query-build benchmark-first-query
+benchmark-first-query-build:
+	mkdir -p $(BUILD_DIR)
+	$(CC) -std=gnu11 -Wall -Wextra -O3 -DNDEBUG \
+		-I. -I$(UTF8PROC_DIR) -pthread \
+		-o $(FIRST_QUERY_BENCH) benchmarks/first-query-probe.c \
+		fzf.c fzf-additions.c $(UTF8PROC_SRC)
+
+benchmark-first-query: benchmark-first-query-build
+	$(FIRST_QUERY_BENCH) \
+		$(FIRST_QUERY_CANDIDATES) $(FIRST_QUERY_LIMIT) \
+		$(FIRST_QUERY_QUERY)
+
 # Coverage-guided and differential test targets live in a separate include so
 # they do not alter the release build or the public module ABI.
 include fuzz/fuzz.mk

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,56 @@ emacs-asan:
 .PHONY: ctest
 ctest: ctest-module ctest-additions ctest-parser-oom ctest-scorer-oom \
 	ctest-session-growth-benchmark ctest-session-trace-benchmark \
-	ctest-core-hotpath-oracle ctest-simd-prefilter
+	ctest-core-hotpath-oracle ctest-simd-prefilter ctest-fzf-bench-driver
+
+# Verify the standalone fzf --bench-equivalent driver with multiple workers.
+# A small chunk size gives the fixture independently scheduled chunks; the
+# production benchmark keeps fzf's 1024-item chunk size.
+.PHONY: ctest-fzf-bench-driver
+ctest-fzf-bench-driver:
+	mkdir -p $(BUILD_DIR)
+	$(CC) -std=gnu11 -Wall -Wextra -O2 -DFZF_BENCH_CHUNK_SIZE=3 \
+		-I. -I$(UTF8PROC_DIR) -pthread \
+		-o $(BUILD_DIR)/fzf-bench-driver-ctest \
+		benchmarks/fzf-bench-driver.c fzf.c $(UTF8PROC_SRC)
+	$(BUILD_DIR)/fzf-bench-driver-ctest --filter=abc --literal \
+		--algo=v2 --tiebreak=index --threads=1 --check \
+		< benchmarks/fzf-bench-fixture.txt \
+		> $(BUILD_DIR)/fzf-bench-driver-w1.txt
+	$(BUILD_DIR)/fzf-bench-driver-ctest --filter=abc --literal \
+		--algo=v2 --tiebreak=index --threads=3 --check \
+		< benchmarks/fzf-bench-fixture.txt \
+		> $(BUILD_DIR)/fzf-bench-driver-w3.txt
+	cmp $(BUILD_DIR)/fzf-bench-driver-w1.txt \
+		$(BUILD_DIR)/fzf-bench-driver-w3.txt
+	grep -Fx 'semantic items=12 matches=9 input_checksum=18c3f63929c5b7fa result_checksum=59c7cb863237a38b' \
+		$(BUILD_DIR)/fzf-bench-driver-w1.txt
+	$(BUILD_DIR)/fzf-bench-driver-ctest --filter=abc --literal \
+		--algo=v2 --tiebreak=index --threads=1 --no-sort --check \
+		< benchmarks/fzf-bench-fixture.txt \
+		> $(BUILD_DIR)/fzf-bench-driver-nosort-w1.txt
+	$(BUILD_DIR)/fzf-bench-driver-ctest --filter=abc --literal \
+		--algo=v2 --tiebreak=index --threads=3 --no-sort --check \
+		< benchmarks/fzf-bench-fixture.txt \
+		> $(BUILD_DIR)/fzf-bench-driver-nosort-w3.txt
+	cmp $(BUILD_DIR)/fzf-bench-driver-nosort-w1.txt \
+		$(BUILD_DIR)/fzf-bench-driver-nosort-w3.txt
+	grep -Fx 'semantic items=12 matches=9 input_checksum=18c3f63929c5b7fa result_checksum=57088aed5d299e8b' \
+		$(BUILD_DIR)/fzf-bench-driver-nosort-w1.txt
+	$(BUILD_DIR)/fzf-bench-driver-ctest --filter=abc --literal \
+		--algo=v2 --tiebreak=index --threads=1 --dump-results \
+		< benchmarks/fzf-bench-fixture.txt \
+		> $(BUILD_DIR)/fzf-bench-driver-dump-w1.txt
+	$(BUILD_DIR)/fzf-bench-driver-ctest --filter=abc --literal \
+		--algo=v2 --tiebreak=index --threads=3 --dump-results \
+		< benchmarks/fzf-bench-fixture.txt \
+		> $(BUILD_DIR)/fzf-bench-driver-dump-w3.txt
+	cmp $(BUILD_DIR)/fzf-bench-driver-dump-w1.txt \
+		$(BUILD_DIR)/fzf-bench-driver-dump-w3.txt
+	test "$$(wc -l < $(BUILD_DIR)/fzf-bench-driver-dump-w1.txt)" -eq 9
+	! $(BUILD_DIR)/fzf-bench-driver-ctest --filter=abc --literal \
+		--algo=v2 --tiebreak=index --threads=1 \
+		--bench=18446744073709551616ns < /dev/null
 
 # Prove that the core-hotpath benchmark validates exact per-item scores before
 # it starts timing.  The injected scorer fault must be rejected by the pinned
@@ -318,6 +367,34 @@ benchmark-rejection-hotpath-probe:
 		-o $(BUILD_DIR)/rejection-hotpath-probe \
 		benchmarks/rejection-hotpath-probe.c fzf.c $(UTF8PROC_SRC)
 	$(BUILD_DIR)/rejection-hotpath-probe
+
+# Native counterpart of junegunn/fzf's filter-mode --bench loop.  Ingestion,
+# pattern parsing, and the final semantic checksum are outside the timer.  Each
+# timed scan includes full scoring, worker-local result collection and sorting,
+# and only match-count materialization, matching fzf's lazy-merger boundary.
+# FZF_BENCH_SORT=--no-sort selects a native-only diagnostic.  fzf filter mode
+# forces sorting for sortable patterns, even with its --no-sort option.
+FZF_BENCH_INPUT ?= /dev/stdin
+FZF_BENCH_QUERY ?= linux
+FZF_BENCH_DURATION ?= 1s
+FZF_BENCH_THREADS ?= 1
+FZF_BENCH_SORT ?= --sort
+FZF_BENCH_DRIVER := $(BUILD_DIR)/fzf-bench-driver
+
+.PHONY: benchmark-fzf-bench-build benchmark-fzf-bench
+benchmark-fzf-bench-build:
+	mkdir -p $(BUILD_DIR)
+	$(CC) -std=gnu11 -Wall -Wextra -O3 -DNDEBUG \
+		-I. -I$(UTF8PROC_DIR) -pthread \
+		-o $(FZF_BENCH_DRIVER) benchmarks/fzf-bench-driver.c \
+		fzf.c $(UTF8PROC_SRC)
+
+benchmark-fzf-bench: benchmark-fzf-bench-build
+	$(FZF_BENCH_DRIVER) --filter='$(FZF_BENCH_QUERY)' \
+		--tiebreak=index --bench='$(FZF_BENCH_DURATION)' \
+		--threads='$(FZF_BENCH_THREADS)' $(FZF_BENCH_SORT) \
+		--algo=v2 --literal \
+		< '$(FZF_BENCH_INPUT)'
 
 # Real persistent-session growth probe.  Timings include producer appends,
 # growth notification, coordinator work, shared workers, cache update, and

--- a/Makefile
+++ b/Makefile
@@ -191,8 +191,9 @@ ctest-fzf-bench-driver:
 		--bench=18446744073709551616ns < /dev/null
 
 # Compare the adapter's ordered identities and rank inputs with the exact
-# upstream implementation.  The caller must supply a local, pinned fzf tree;
-# the checker disables module and toolchain downloads.
+# upstream implementation for default score/length and literal score/index
+# profiles, using one and eight native workers.  The caller must supply a
+# local, pinned fzf tree; the checker disables module and toolchain downloads.
 .PHONY: ctest-fzf-upstream-semantic
 ctest-fzf-upstream-semantic:
 	test -n "$(FZF_SOURCE)"

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ endif
 # variants (via utf8_char_index.h -> utf8proc.h) depend on it.
 UTF8PROC_DIR ?= utf8proc-2.10.0
 UTF8PROC_SRC := $(UTF8PROC_DIR)/utf8proc.c
+PYTHON ?= python3
 
 PACKAGE := fzf-native
 AUTOLOADS := $(PACKAGE)-autoloads.el
@@ -167,6 +168,21 @@ ctest-fzf-bench-driver:
 	! $(BUILD_DIR)/fzf-bench-driver-ctest --filter=abc --literal \
 		--algo=v2 --tiebreak=index --threads=1 \
 		--bench=18446744073709551616ns < /dev/null
+
+# Compare the adapter's ordered identities and rank inputs with the exact
+# upstream implementation.  The caller must supply a local, pinned fzf tree;
+# the checker disables module and toolchain downloads.
+.PHONY: ctest-fzf-upstream-semantic
+ctest-fzf-upstream-semantic:
+	test -n "$(FZF_SOURCE)"
+	mkdir -p $(BUILD_DIR)
+	$(CC) -std=gnu11 -Wall -Wextra -O2 \
+		-I. -I$(UTF8PROC_DIR) -pthread \
+		-o $(BUILD_DIR)/fzf-bench-driver-semantic \
+		benchmarks/fzf-bench-driver.c fzf.c $(UTF8PROC_SRC)
+	$(PYTHON) benchmarks/check-fzf-semantic-parity.py \
+		--fzf-source "$(FZF_SOURCE)" \
+		--native-driver $(BUILD_DIR)/fzf-bench-driver-semantic
 
 # Prove that the core-hotpath benchmark validates exact per-item scores before
 # it starts timing.  The injected scorer fault must be rejected by the pinned

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,27 @@ ctest-fzf-bench-driver:
 		$(BUILD_DIR)/fzf-bench-driver-w3.txt
 	grep -Fx 'semantic items=12 matches=9 input_checksum=18c3f63929c5b7fa result_checksum=59c7cb863237a38b' \
 		$(BUILD_DIR)/fzf-bench-driver-w1.txt
+	$(BUILD_DIR)/fzf-bench-driver-ctest --filter=abc \
+		--algo=v2 --tiebreak=length --threads=1 --check \
+		< benchmarks/fzf-bench-fixture.txt \
+		> $(BUILD_DIR)/fzf-bench-driver-length-w1.txt
+	$(BUILD_DIR)/fzf-bench-driver-ctest --filter=abc \
+		--algo=v2 --tiebreak=length --threads=3 --check \
+		< benchmarks/fzf-bench-fixture.txt \
+		> $(BUILD_DIR)/fzf-bench-driver-length-w3.txt
+	cmp $(BUILD_DIR)/fzf-bench-driver-length-w1.txt \
+		$(BUILD_DIR)/fzf-bench-driver-length-w3.txt
+	grep -Fx 'semantic items=12 matches=9 input_checksum=18c3f63929c5b7fa result_checksum=eaad98c78963fb4b' \
+		$(BUILD_DIR)/fzf-bench-driver-length-w1.txt
+	FZF_BENCH_JSON=1 $(BUILD_DIR)/fzf-bench-driver-ctest \
+		--filter=abc --algo=v2 --tiebreak=length --threads=1 \
+		--bench=1ms < benchmarks/fzf-bench-fixture.txt \
+		> $(BUILD_DIR)/fzf-bench-driver-json.txt
+	test "$$(wc -l < $(BUILD_DIR)/fzf-bench-driver-json.txt)" -eq 2
+	grep -Eq '^benchmark-json \{"schema":1,"iterations":[1-9][0-9]*,"total_ns":[1-9][0-9]*,"min_ns":[0-9]+,"max_ns":[0-9]+,"items":12,"matches":9,"ingestion_ns":[0-9]+\}$$' \
+		$(BUILD_DIR)/fzf-bench-driver-json.txt
+	grep -Fx 'semantic items=12 matches=9 input_checksum=18c3f63929c5b7fa result_checksum=eaad98c78963fb4b' \
+		$(BUILD_DIR)/fzf-bench-driver-json.txt
 	$(BUILD_DIR)/fzf-bench-driver-ctest --filter=abc --literal \
 		--algo=v2 --tiebreak=index --threads=1 --no-sort --check \
 		< benchmarks/fzf-bench-fixture.txt \
@@ -405,6 +426,8 @@ FZF_BENCH_QUERY ?= linux
 FZF_BENCH_DURATION ?= 1s
 FZF_BENCH_THREADS ?= 1
 FZF_BENCH_SORT ?= --sort
+FZF_BENCH_TIEBREAK ?= length
+FZF_BENCH_LITERAL ?=
 FZF_BENCH_DRIVER := $(BUILD_DIR)/fzf-bench-driver
 
 .PHONY: benchmark-fzf-bench-build benchmark-fzf-bench
@@ -417,9 +440,9 @@ benchmark-fzf-bench-build:
 
 benchmark-fzf-bench: benchmark-fzf-bench-build
 	$(FZF_BENCH_DRIVER) --filter='$(FZF_BENCH_QUERY)' \
-		--tiebreak=index --bench='$(FZF_BENCH_DURATION)' \
+		--tiebreak='$(FZF_BENCH_TIEBREAK)' --bench='$(FZF_BENCH_DURATION)' \
 		--threads='$(FZF_BENCH_THREADS)' $(FZF_BENCH_SORT) \
-		--algo=v2 --literal \
+		--algo=v2 $(FZF_BENCH_LITERAL) \
 		< '$(FZF_BENCH_INPUT)'
 
 # Real persistent-session growth probe.  Timings include producer appends,

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,11 @@ ctest: ctest-module ctest-additions ctest-parser-oom ctest-scorer-oom \
 .PHONY: ctest-fzf-bench-driver
 ctest-fzf-bench-driver:
 	mkdir -p $(BUILD_DIR)
+	$(CC) -std=gnu11 -Wall -Wextra -O2 -DFZF_BENCH_CHUNK_SIZE=1 \
+		-I. -I$(UTF8PROC_DIR) -pthread \
+		-o $(BUILD_DIR)/fzf-bench-driver-unit-test \
+		benchmarks/fzf-bench-driver-test.c fzf.c $(UTF8PROC_SRC)
+	$(BUILD_DIR)/fzf-bench-driver-unit-test
 	$(CC) -std=gnu11 -Wall -Wextra -O2 -DFZF_BENCH_CHUNK_SIZE=3 \
 		-I. -I$(UTF8PROC_DIR) -pthread \
 		-o $(BUILD_DIR)/fzf-bench-driver-ctest \
@@ -273,6 +278,11 @@ ctest-session-trace-benchmark:
 ctest-asan: export UBSAN_OPTIONS = halt_on_error=1:print_stacktrace=1
 ctest-asan:
 	mkdir -p $(BUILD_DIR)
+	$(CC) -std=gnu11 -Wall -Wextra -fsanitize=address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g \
+		-DFZF_BENCH_CHUNK_SIZE=1 -I. -I$(UTF8PROC_DIR) -pthread \
+		-o $(BUILD_DIR)/fzf-bench-driver-unit-test-asan \
+		benchmarks/fzf-bench-driver-test.c fzf.c $(UTF8PROC_SRC)
+	$(BUILD_DIR)/fzf-bench-driver-unit-test-asan
 	$(CC) -std=gnu11 -Wall -Wextra -fsanitize=address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g \
 		-I. -I$(UTF8PROC_DIR) -pthread \
 		-o $(BUILD_DIR)/fzf-native-ctest-asan fzf-native-ctest.c fzf.c fzf-additions.c $(UTF8PROC_SRC)

--- a/Makefile
+++ b/Makefile
@@ -308,6 +308,17 @@ benchmark-api-overhead-probe:
 		benchmarks/api-overhead-probe.c fzf.c $(UTF8PROC_SRC)
 	$(BUILD_DIR)/api-overhead-probe
 
+# Rejection-focused ASCII scorer probe. It reports preclassified, bounded,
+# and public C-string API lanes separately and includes dense-match, short,
+# case-sensitive, and repeated-byte counterweights.
+.PHONY: benchmark-rejection-hotpath-probe
+benchmark-rejection-hotpath-probe:
+	mkdir -p $(BUILD_DIR)
+	$(CC) -std=gnu11 -O3 -DNDEBUG -I. -I$(UTF8PROC_DIR) \
+		-o $(BUILD_DIR)/rejection-hotpath-probe \
+		benchmarks/rejection-hotpath-probe.c fzf.c $(UTF8PROC_SRC)
+	$(BUILD_DIR)/rejection-hotpath-probe
+
 # Real persistent-session growth probe.  Timings include producer appends,
 # growth notification, coordinator work, shared workers, cache update, and
 # result publication.  Full-scan validation runs after all timed rounds.

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,12 @@ emacs-asan:
 .PHONY: ctest
 ctest: ctest-module ctest-additions ctest-parser-oom ctest-scorer-oom \
 	ctest-session-growth-benchmark ctest-session-trace-benchmark \
-	ctest-core-hotpath-oracle ctest-simd-prefilter ctest-fzf-bench-driver
+	ctest-core-hotpath-oracle ctest-simd-prefilter ctest-fzf-bench-driver \
+	ctest-fzf-envelope-analysis
+
+.PHONY: ctest-fzf-envelope-analysis
+ctest-fzf-envelope-analysis:
+	$(PYTHON) benchmarks/test_analyze_fzf_envelope.py
 
 # Verify the standalone fzf --bench-equivalent driver with multiple workers.
 # A small chunk size gives the fixture independently scheduled chunks; the

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ ctest-fzf-bench-driver:
 		benchmarks/fzf-bench-driver-test.c fzf.c $(UTF8PROC_SRC)
 	$(BUILD_DIR)/fzf-bench-driver-unit-test
 	$(CC) -std=gnu11 -Wall -Wextra -O2 -DFZF_BENCH_CHUNK_SIZE=3 \
+		-DFZF_BENCH_TEST_HOOKS \
 		-I. -I$(UTF8PROC_DIR) -pthread \
 		-o $(BUILD_DIR)/fzf-bench-driver-ctest \
 		benchmarks/fzf-bench-driver.c fzf.c $(UTF8PROC_SRC)
@@ -163,6 +164,12 @@ ctest-fzf-bench-driver:
 		$(BUILD_DIR)/fzf-bench-driver-json.txt
 	grep -Fx 'semantic items=12 matches=9 input_checksum=18c3f63929c5b7fa result_checksum=eaad98c78963fb4b' \
 		$(BUILD_DIR)/fzf-bench-driver-json.txt
+	$(BUILD_DIR)/fzf-bench-driver-ctest --filter=abc \
+		--algo=v2 --tiebreak=length --threads=3 --check-trim-cache \
+		< benchmarks/fzf-bench-fixture.txt \
+		> $(BUILD_DIR)/fzf-bench-driver-trim-cache.txt
+	grep -Fx 'trim-cache items=12 before_known=0 before_computed=0 first_matches=9 first_known=9 first_computed=9 second_matches=9 second_known=9 second_computed=9' \
+		$(BUILD_DIR)/fzf-bench-driver-trim-cache.txt
 	$(BUILD_DIR)/fzf-bench-driver-ctest --filter=abc --literal \
 		--algo=v2 --tiebreak=index --threads=1 --no-sort --check \
 		< benchmarks/fzf-bench-fixture.txt \

--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,18 @@ benchmark-core-hotpath-probe:
 		benchmarks/core-hotpath-probe.c fzf.c $(UTF8PROC_SRC)
 	$(BUILD_DIR)/core-hotpath-probe
 
+# Synthetic scorer-entry probe.  It keeps the candidate bytes and expected
+# scores fixed, then separates C-string length discovery, bounded ASCII
+# classification, and the already-classified matcher path.  Use it to keep
+# adapter/setup work distinct from scorer changes.
+.PHONY: benchmark-api-overhead-probe
+benchmark-api-overhead-probe:
+	mkdir -p $(BUILD_DIR)
+	$(CC) -std=gnu11 -O3 -DNDEBUG -I. -I$(UTF8PROC_DIR) \
+		-o $(BUILD_DIR)/api-overhead-probe \
+		benchmarks/api-overhead-probe.c fzf.c $(UTF8PROC_SRC)
+	$(BUILD_DIR)/api-overhead-probe
+
 # Real persistent-session growth probe.  Timings include producer appends,
 # growth notification, coordinator work, shared workers, cache update, and
 # result publication.  Full-scan validation runs after all timed rounds.

--- a/Makefile
+++ b/Makefile
@@ -203,9 +203,10 @@ ctest-fzf-bench-driver:
 		--bench=18446744073709551616ns < /dev/null
 
 # Compare the adapter's ordered identities and rank inputs with the exact
-# upstream implementation for default score/length and literal score/index
-# profiles, using one and eight native workers.  The caller must supply a
-# local, pinned fzf tree; the checker disables module and toolchain downloads.
+# upstream implementation for default score/length, literal score/index, and
+# path score/pathname/length profiles, using one and eight native workers.  The
+# caller must supply a local, pinned fzf tree; the checker disables module and
+# toolchain downloads.
 .PHONY: ctest-fzf-upstream-semantic
 ctest-fzf-upstream-semantic:
 	test -n "$(FZF_SOURCE)"

--- a/architecture.org
+++ b/architecture.org
@@ -369,6 +369,10 @@ The decoder still scans discarded bytes.
 It therefore detects a NUL after a retained prefix or inside discarded ANSI data.
 
 Candidate strings live in 4 MiB arena chunks.
+Each string has a four-byte private header with its byte length and ASCII flag.
+Strings longer than the header range use an additional =size_t= field.
+The decoder derives the flag while it already scans visible producer bytes.
+Scoring workers reuse both values and do not run =strlen= or a separate ASCII scan for each query.
 The reader appends their pointers to fixed pointer blocks.
 
 One pointer block holds 262,144 entries.

--- a/benchmarks/2026-09-09T12-22-04Z.md
+++ b/benchmarks/2026-09-09T12-22-04Z.md
@@ -4,7 +4,7 @@ Date: 2026-09-09T12:22:04Z
 
 > Correction: The fzf ratios in this report use different benchmark harnesses.
 > They are not direct comparisons.
-> [The matched-envelope report](2026-09-09T18:56:18Z.md) replaces those ratios.
+> [The matched-envelope report](2026-09-09T18-56-18Z.md) replaces those ratios.
 > The native base comparisons and the holdout results remain valid.
 
 Raw artifacts: `/private/tmp/fzf-final-frozen.gXHD88`

--- a/benchmarks/2026-09-09T12:22:04Z.md
+++ b/benchmarks/2026-09-09T12:22:04Z.md
@@ -1,0 +1,288 @@
+# fzf-native parity benchmark
+
+Date: 2026-09-09T12:22:04Z
+
+Raw artifacts: `/private/tmp/fzf-final-frozen.gXHD88`
+
+Candidate: `fb0af7305592677d7e65bee7e79cdc43a1df782c`
+
+Base: `4b9236e8cd1e9f9f3aaf5f2ebf83f1fc5995d38d`
+
+fzf: `63e82a9e3dd52cc67a46db842b8a29e0c1f83229`
+
+Ratios are medians of within-round paired ratios. Values greater than 1 favor the denominator. Geometric means weight cells equally.
+
+## Result
+
+The candidate improves the historical 19-cell adapter by 1.066x against main. It wins 15 of 19 base comparisons.
+
+The candidate reduces the equal-cell fzf lead from 1.31x to 1.23x. It wins 8 of 19 cells, including all real corpora.
+
+The six precreated-pool cells improve by 1.280x against main. fzf remains 1.117x faster and the candidate wins one cell.
+
+Prepared metadata improves the candidate by 1.328x against its C-string adapter. The prepared path wins all 19 attribution cells.
+
+A descriptive comparison of medians puts the prepared candidate 1.079x ahead of fzf. The prepared candidate wins 12 of 19 cells.
+
+This descriptive comparison is not paired. Therefore, it does not replace the historical C-string comparison.
+
+The descriptive prepared aggregate reaches parity. The historical paired C-string aggregate does not reach parity.
+
+In the descriptive prepared comparison, fzf remains 1.06x to 1.28x faster in seven rejection-heavy cells.
+
+These seven cells define the next optimization target.
+
+## Changes
+
+- Async sessions cache the byte length and ASCII status for each candidate. This adds four bytes per candidate.
+- The scorer uses SIMD for two-case rejection scans. The implementation includes safe short tails and an ARM64 MSVC include.
+- The scorer has direct paths for one-byte and two-byte ASCII queries.
+- The ASCII classifier processes four 64-bit words before it checks the next 32-byte block.
+- Score-only Unicode queries use rolling rows for one to 16 uncased `Other_Letter` codepoints.
+- The cold first-query probe now keeps worker-pool construction inside its timed interval.
+
+## Validation
+
+The functional comparison ran 150,302 case executions and produced 601,208 records. Every base and candidate record matches.
+
+The native suite, ASan, UBSan, TSan, and allocation-failure suites pass. The Emacs 30.2 suite passes all 188 tests.
+
+The ARM64 and x86_64 module builds pass. Public headers, structure layouts, and the two module exports do not change.
+
+The Windows branches pass syntax checks. A native Windows build was not available on this host.
+
+The candidate adds four bytes per candidate. The measured cost is approximately 3.9 MiB for one million candidates.
+
+Scorer instructions increase by 12.2%. Linked-module instructions increase by 4.4%.
+
+Four historical cells regress by 0.1% to 0.4% against main. The internal late-v1 case regresses by 3.0%.
+
+The fuzzy long-end score-plus-positions cell regresses by approximately 0.1%. The other 15 fuzzy cells improve.
+
+## Steady match-list
+
+| Cell | Base ms | Candidate ms | fzf ms | Base/candidate | fzf/candidate |
+|---|---:|---:|---:|---:|---:|
+| chromium | 142.163133 | 138.626079 | 160.430000 | 1.026 | 1.158 |
+| arabic | 48.079304 | 32.755452 | 35.560000 | 1.471 | 1.086 |
+| korean | 35.317046 | 26.095366 | 27.940000 | 1.354 | 1.074 |
+| partial-16 | 4.491804 | 4.497577 | 4.020000 | 0.999 | 0.896 |
+| partial-32 | 5.792686 | 5.666546 | 5.050000 | 1.022 | 0.891 |
+| partial-64 | 8.080803 | 7.871375 | 7.520000 | 1.027 | 0.955 |
+| partial-128 | 12.903650 | 12.447774 | 13.390000 | 1.036 | 1.076 |
+| all-16 | 29.014342 | 29.034117 | 37.160000 | 0.999 | 1.281 |
+| all-32 | 47.863271 | 47.507455 | 57.520000 | 1.007 | 1.211 |
+| all-64 | 81.992031 | 81.486867 | 102.150000 | 1.006 | 1.253 |
+| all-128 | 162.236423 | 161.652396 | 211.790000 | 1.004 | 1.310 |
+| partial-miss-16 | 3.034555 | 3.038398 | 1.820000 | 0.999 | 0.599 |
+| partial-miss-32 | 3.379430 | 3.258164 | 1.840000 | 1.042 | 0.565 |
+| partial-miss-64 | 3.914629 | 3.700787 | 2.100000 | 1.061 | 0.567 |
+| partial-miss-128 | 4.681333 | 4.207612 | 2.460000 | 1.115 | 0.587 |
+| none-16 | 2.790678 | 2.807994 | 1.450000 | 0.996 | 0.519 |
+| none-32 | 3.117272 | 3.016952 | 1.450000 | 1.036 | 0.481 |
+| none-64 | 3.645214 | 3.454862 | 1.660000 | 1.056 | 0.480 |
+| none-128 | 4.354521 | 3.883368 | 1.990000 | 1.123 | 0.513 |
+
+base/candidate: geometric mean 1.066. Denominator wins: 15/19.
+
+fzf/candidate: geometric mean 0.813. Denominator wins: 8/19.
+
+fzf/base: geometric mean 0.762. Denominator wins: 6/19.
+
+## Cold first query
+
+| Cell | Base ms | Candidate ms | fzf ms | Base/candidate | fzf/candidate |
+|---|---:|---:|---:|---:|---:|
+| chromium w1 | 165.281000 | 131.038000 | 161.910000 | 1.261 | 1.236 |
+| chromium w8 | 39.308000 | 37.508000 | 29.340000 | 1.044 | 0.783 |
+| arabic w1 | 56.604000 | 37.334000 | 36.420000 | 1.517 | 0.975 |
+| arabic w8 | 11.707000 | 8.985000 | 6.560000 | 1.314 | 0.721 |
+| korean w1 | 41.750000 | 29.577000 | 28.680000 | 1.413 | 0.972 |
+| korean w8 | 8.896000 | 7.517000 | 5.840000 | 1.183 | 0.779 |
+
+base/candidate: geometric mean 1.280. Denominator wins: 6/6.
+
+fzf/candidate: geometric mean 0.895. Denominator wins: 1/6.
+
+fzf/base: geometric mean 0.691. Denominator wins: 0/6.
+
+## Fuzzy-benches holdout
+
+| Cell | Base ms | Candidate ms | fzf ms | Base/candidate | fzf/candidate |
+|---|---:|---:|---:|---:|---:|
+| medium-start score | 0.001284 | 0.001280 | — | 1.003 | — |
+| medium-start score_positions | 0.002612 | 0.002602 | — | 1.004 | — |
+| medium-middle score | 0.000902 | 0.000895 | — | 1.007 | — |
+| medium-middle score_positions | 0.001854 | 0.001836 | — | 1.006 | — |
+| medium-end score | 0.000543 | 0.000539 | — | 1.009 | — |
+| medium-end score_positions | 0.001145 | 0.001140 | — | 1.004 | — |
+| long-start score | 0.007875 | 0.007852 | — | 1.003 | — |
+| long-start score_positions | 0.015789 | 0.015717 | — | 1.005 | — |
+| long-middle score | 0.002718 | 0.002698 | — | 1.005 | — |
+| long-middle score_positions | 0.005494 | 0.005466 | — | 1.006 | — |
+| long-end score | 0.008781 | 0.008747 | — | 1.004 | — |
+| long-end score_positions | 0.017608 | 0.017630 | — | 0.999 | — |
+| emacs score | 5.943805 | 5.852125 | — | 1.015 | — |
+| emacs score_positions | 7.786532 | 7.698443 | — | 1.012 | — |
+| e-macs score | 10.408041 | 5.851902 | — | 1.779 | — |
+| e-macs score_positions | 22.642724 | 12.929490 | — | 1.752 | — |
+
+base/candidate: geometric mean 1.079. Denominator wins: 15/16.
+
+## Protocol and limits
+
+The primary Frizbee lane uses the unchanged legacy public C-string adapter. No prepared input replaces it.
+
+Each steady cell uses five fresh process rounds, 20 Criterion samples, 200 ms warmup, and a one-second measurement target. fzf uses one-second benchmark scans.
+
+The cold lane uses seven fresh process rounds. fzf runs exactly one scan per process. The native timer includes session submission, publication, and polling. It excludes corpus ingestion.
+
+The fuzzy holdout uses three alternating process rounds. Each process uses 100 samples, three-second warmup, and five-second measurement. It uses the existing score and score-plus-positions calls.
+
+The filter also selects telescope-fzf-native. These extra cells remain in the raw logs but do not enter the native aggregates.
+
+All candidate, base, and upstream ordered outputs match in the 19 index-ranked cells and six default-ranked cold configurations. Fuzzy score and position fingerprints match.
+
+The commands and their order are in commands.jsonl. The results directory retains all subprocess outputs and per-process estimates.
+
+All paired native builds use clang and identical flags within each measurement. Scorer builds use -O3 -DNDEBUG. The Emacs module uses RelWithDebInfo.
+
+The upstream Go binary uses its ordinary optimized build. This is one Apple M3 macOS host. Cross-language harnesses have different allocation and scheduling costs.
+
+The fuzzy C adapter cannot call a direct Go score API. A nonfatal rust-objcopy warning reports missing libLLVM.dylib.
+
+The results directory retains the separate setup errors for the rustdoc PATH and hardware sysctl call. No measured cells ran during failed setup attempts.
+
+The candidate source and tracked worktree are unchanged.
+
+## Internal diagnostics
+
+Each diagnostic uses three fresh, alternating base/candidate process rounds. Existing per-process sample counts remain unchanged. All shared score, membership, position, trace, and growth fingerprints agree.
+
+| Probe | Cell | Base ms | Candidate ms | Paired base/candidate |
+|---|---|---:|---:|---:|---:|
+| core-hotpath-probe | EarlyASCII | 0.549000 | 0.288000 | 1.906 |
+| core-hotpath-probe | OneByte | 0.262000 | 0.252000 | 1.040 |
+| core-hotpath-probe | Chromium | 1.459000 | 1.395000 | 1.044 |
+| core-hotpath-probe | Literal | 0.943000 | 0.933000 | 1.011 |
+| core-hotpath-probe | Arabic | 5.433000 | 3.574000 | 1.518 |
+| core-hotpath-probe | Korean | 6.181000 | 4.225000 | 1.463 |
+| core-hotpath-probe | UTF8-hit | 14.585000 | 4.325000 | 3.372 |
+| core-hotpath-probe | V1-early | 32.675000 | 32.414000 | 1.008 |
+| core-hotpath-probe | V1-late | 47.893000 | 49.354000 | 0.970 |
+| score-positions-benchmark | emacs/legacy | 0.000992 | 0.000990 | 1.002 |
+| score-positions-benchmark | emacs/one-pass | 0.000516 | 0.000514 | 1.004 |
+| score-positions-benchmark | emacs miss/legacy | 0.000024 | 0.000022 | 1.099 |
+| score-positions-benchmark | emacs miss/one-pass | 0.000027 | 0.000025 | 1.097 |
+| score-positions-benchmark | e-macs/legacy | 0.000860 | 0.000868 | 0.991 |
+| score-positions-benchmark | e-macs/one-pass | 0.000493 | 0.000500 | 0.989 |
+| score-positions-benchmark | simple miss/legacy | 0.000030 | 0.000028 | 1.067 |
+| score-positions-benchmark | simple miss/one-pass | 0.000033 | 0.000031 | 1.055 |
+| score-positions-benchmark | long sparse/legacy | 0.001231 | 0.001233 | 0.997 |
+| score-positions-benchmark | long sparse/one-pass | 0.000689 | 0.000689 | 1.000 |
+| score-positions-benchmark | extended/legacy | 0.001062 | 0.001059 | 1.002 |
+| score-positions-benchmark | extended/one-pass | 0.001064 | 0.001062 | 1.002 |
+| score-positions-benchmark | late AND miss/legacy | 0.000210 | 0.000209 | 1.001 |
+| score-positions-benchmark | late AND miss/one-pass | 0.000212 | 0.000212 | 1.004 |
+| score-positions-benchmark | CJK/legacy | 0.000858 | 0.000601 | 1.427 |
+| score-positions-benchmark | CJK/one-pass | 0.000440 | 0.000440 | 1.000 |
+| score-positions-benchmark | case-fold/legacy | 0.001406 | 0.001410 | 0.999 |
+| score-positions-benchmark | case-fold/one-pass | 0.000721 | 0.000723 | 0.998 |
+| api-overhead-probe | early-32/c-string | 1.785000 | 1.471000 | 1.186 |
+| api-overhead-probe | early-32/bounded | 1.574000 | 1.247000 | 1.252 |
+| api-overhead-probe | early-32/preclassified | 1.275000 | 1.142000 | 1.115 |
+| api-overhead-probe | late-32/c-string | 2.820000 | 2.323000 | 1.222 |
+| api-overhead-probe | late-32/bounded | 2.582000 | 2.116000 | 1.220 |
+| api-overhead-probe | late-32/preclassified | 2.296000 | 2.005000 | 1.145 |
+| api-overhead-probe | early-128/c-string | 2.810000 | 1.989000 | 1.414 |
+| api-overhead-probe | early-128/bounded | 2.352000 | 1.620000 | 1.450 |
+| api-overhead-probe | early-128/preclassified | 1.754000 | 1.307000 | 1.343 |
+| api-overhead-probe | late-128/c-string | 3.620000 | 2.810000 | 1.281 |
+| api-overhead-probe | late-128/bounded | 3.238000 | 2.442000 | 1.343 |
+| api-overhead-probe | late-128/preclassified | 2.675000 | 2.132000 | 1.262 |
+| session-trace-probe-w1 | trace_median_ms | 303.274000 | 249.621000 | 1.216 |
+| session-trace-probe-w1 | narrow_median_ms | 230.591000 | 193.528000 | 1.194 |
+| session-trace-probe-w1 | backspace_median_ms | 0.002000 | 0.002000 | 1.000 |
+| session-trace-probe-w1 | unrelated_median_ms | 72.718000 | 56.282000 | 1.296 |
+| session-trace-probe-w8 | trace_median_ms | 81.526000 | 61.553000 | 1.285 |
+| session-trace-probe-w8 | narrow_median_ms | 63.401000 | 47.130000 | 1.288 |
+| session-trace-probe-w8 | backspace_median_ms | 0.002000 | 0.003000 | 0.400 |
+| session-trace-probe-w8 | unrelated_median_ms | 18.212000 | 14.411000 | 1.262 |
+| session-growth-benchmark | initial_ms | 28.658000 | 19.575000 | 1.440 |
+| session-growth-benchmark | growth_total_ms | 13.886000 | 11.851000 | 1.164 |
+| session-growth-benchmark | growth_mean_ms | 0.347000 | 0.296000 | 1.166 |
+| session-growth-benchmark | growth_median_ms | 0.285000 | 0.231000 | 1.245 |
+| session-growth-benchmark | growth_p95_ms | 0.302000 | 0.288000 | 1.041 |
+| session-growth-benchmark | growth_max_ms | 2.725000 | 2.789000 | 0.981 |
+| batch-cache | 0..100/mean | 0.140042 | 0.139160 | 1.007 |
+| batch-cache | 0..100/median | 0.138044 | 0.137091 | 1.007 |
+| batch-cache | 0..100/max | 0.293016 | 0.289917 | 1.017 |
+| batch-cache | 4950..5050/mean | 0.268497 | 0.138977 | 1.920 |
+| batch-cache | 4950..5050/median | 0.268936 | 0.138044 | 1.950 |
+| batch-cache | 4950..5050/max | 0.276089 | 0.271797 | 1.036 |
+| batch-cache | 9900..10000/mean | 0.266328 | 0.137885 | 1.930 |
+| batch-cache | 9900..10000/median | 0.268936 | 0.138044 | 1.941 |
+| batch-cache | 9900..10000/max | 0.281096 | 0.143051 | 1.992 |
+
+The rejection probe has separate preclassified, bounded, and C-string cells in diagnostics-summary.json. These cells isolate costs. They do not replace the primary holdout adapter.
+
+## Construction-inclusive first query
+
+This separate internal audit preceded the external holdouts. It used the same frozen candidate and base sources.
+
+Each cell has nine adjacent fresh-process pairs. The timed query includes the first worker-pool construction.
+
+The unchanged wrapper selects one or eight workers. Corpus construction and the full-scan oracle remain outside the query interval.
+
+| Corpus | Workers | Base ms | Candidate ms | Paired base/candidate |
+|---|---:|---:|---:|---:|
+| arabic | 1 | 69.195 | 33.559 | 2.063 |
+| arabic | 8 | 13.383 | 8.437 | 1.603 |
+| ascii | 1 | 18.007 | 15.427 | 1.160 |
+| ascii | 8 | 4.496 | 3.988 | 1.158 |
+| korean | 1 | 63.903 | 32.640 | 1.958 |
+| korean | 8 | 12.449 | 7.800 | 1.652 |
+
+The six-cell comparison against fzf uses the established session driver. That driver creates its private worker pool before the timed request.
+
+These two first-query measurements have different timing boundaries. Their absolute times are not interchangeable.
+
+## Prepared-input attribution
+
+This separate measurement uses an isolated copy of the Frizbee adapter. It does not replace the primary C-string results.
+
+The adapter prepares each C-string, byte length, and ASCII flag before timing. It calls `fzf_get_score_bytes_preclassified` inside timing.
+
+All 19 ordered outputs match the primary results. An untimed proof also compares the two API scores for every candidate in these corpora.
+
+Three adjacent process pairs compare the two adapters with the same frozen candidate. This measurement attributes adapter costs.
+
+It is not a historical base comparison or an additional fzf comparison.
+
+Two inherited adapter tests contain stale expected scores. Both the unchanged C-string adapter and the prepared adapter return 88/78/62 instead of 80/74/56.
+
+The run stopped for this control. It resumed after the control reproduced the same values. The results directory retains both failed-test logs.
+
+| Cell | C-string ms | Prepared ms | Paired C-string/prepared |
+|---|---:|---:|---:|
+| chromium | 138.394010 | 116.728331 | 1.185 |
+| arabic | 32.773768 | 30.770974 | 1.065 |
+| korean | 26.003673 | 24.326563 | 1.069 |
+| partial-16 | 4.503896 | 3.190273 | 1.412 |
+| partial-32 | 5.670019 | 4.389763 | 1.290 |
+| partial-64 | 7.886064 | 6.494256 | 1.214 |
+| partial-128 | 12.449130 | 10.778123 | 1.156 |
+| all-16 | 28.997319 | 27.663545 | 1.049 |
+| all-32 | 47.482709 | 46.274771 | 1.026 |
+| all-64 | 81.473679 | 79.768229 | 1.021 |
+| all-128 | 161.564035 | 159.541227 | 1.013 |
+| partial-miss-16 | 3.058668 | 1.789194 | 1.710 |
+| partial-miss-32 | 3.267858 | 2.035035 | 1.602 |
+| partial-miss-64 | 3.710588 | 2.380306 | 1.551 |
+| partial-miss-128 | 4.202022 | 2.621952 | 1.603 |
+| none-16 | 2.801808 | 1.536814 | 1.833 |
+| none-32 | 3.037371 | 1.767233 | 1.718 |
+| none-64 | 3.451192 | 2.119896 | 1.631 |
+| none-128 | 3.872931 | 2.354046 | 1.643 |
+
+Attribution-only geometric mean: 1.328. The prepared adapter wins 19/19 paired cells.

--- a/benchmarks/2026-09-09T12:22:04Z.md
+++ b/benchmarks/2026-09-09T12:22:04Z.md
@@ -2,6 +2,11 @@
 
 Date: 2026-09-09T12:22:04Z
 
+> Correction: The fzf ratios in this report use different benchmark harnesses.
+> They are not direct comparisons.
+> [The matched-envelope report](2026-09-09T18:56:18Z.md) replaces those ratios.
+> The native base comparisons and the holdout results remain valid.
+
 Raw artifacts: `/private/tmp/fzf-final-frozen.gXHD88`
 
 Candidate: `fb0af7305592677d7e65bee7e79cdc43a1df782c`

--- a/benchmarks/2026-09-09T18-56-18Z.md
+++ b/benchmarks/2026-09-09T18-56-18Z.md
@@ -1,6 +1,6 @@
 # fzf matched-envelope benchmark
 
-Date: 2026-09-09T18:56:18Z
+Run date: 2026-09-09T18:56:18Z
 
 Raw artifacts: `/private/tmp/fzf-envelope.h5jUhf`
 
@@ -131,8 +131,7 @@ Therefore, a ratio does not always equal the ratio of the displayed times.
 
 ## Native no-sort diagnostic
 
-fzf filter mode forces sorting for sortable queries.
-It does this even when the command contains `--no-sort`.
+The old campaign did not run fzf in its no-sort lane.
 Thus, this diagnostic compares only the native candidate and base.
 
 The candidate/base geometric mean is 1.011x.

--- a/benchmarks/2026-09-09T18:56:18Z.md
+++ b/benchmarks/2026-09-09T18:56:18Z.md
@@ -1,0 +1,283 @@
+# fzf matched-envelope benchmark
+
+Date: 2026-09-09T18:56:18Z
+
+Raw artifacts: `/private/tmp/fzf-envelope.h5jUhf`
+
+Candidate product source: `fb0af7305592677d7e65bee7e79cdc43a1df782c`
+
+Benchmark driver commit: `09dc41a73abb33c40186f57fe502fce3e0254bc4`
+
+Base: `4b9236e8cd1e9f9f3aaf5f2ebf83f1fc5995d38d`
+
+fzf: `63e82a9e3dd52cc67a46db842b8a29e0c1f83229`
+
+## Correction
+
+The prior report compared the Rust Frizbee adapter with the internal benchmark of fzf.
+Those harnesses measured different work.
+
+This report replaces only the cross-fzf ratios from that report.
+The native base comparisons and the sealed holdout results remain valid.
+
+This report uses a C driver with the same scan boundary as `fzf --bench`.
+The driver uses the native scorer without a Rust or Emacs call boundary.
+
+## Result
+
+With one worker, the candidate is 1.041x faster than fzf across 19 equally weighted cells.
+The bootstrap interval is [1.011x, 1.054x].
+The candidate wins 11 of 19 cells.
+
+The candidate is 1.219x faster than fzf across the three real corpora.
+It is 1.291x faster across the four all-match cells.
+
+fzf is 1.119x faster across the partial-miss cells.
+It is 1.276x faster across the no-match cells.
+
+The base is also 1.037x faster than fzf in the one-worker aggregate.
+Thus, the corrected parity result does not come only from the candidate changes.
+
+The candidate is 1.011x faster than the base in this aggregate.
+Its interval is [0.997x, 1.018x], which includes 1.
+This aggregate does not show a clear candidate gain.
+
+The candidate gains are not uniform.
+It is 1.277x faster than the base across the real corpora.
+It regresses on most rejection-only cells.
+
+With eight workers, fzf/candidate is 0.750x across the 19 cells.
+Thus, fzf is 1.333x faster in that aggregate.
+The eight-worker lane includes runtime and synchronization costs.
+
+## Aggregate summary
+
+Ratios greater than 1 favor the denominator.
+The confidence intervals describe process noise for these fixed cells.
+
+| Lane | Ratio | Geometric mean | 95% interval | Denominator wins |
+|---|---|---:|---:|---:|
+| Sorted, 1 worker | base/candidate | 1.011 | [0.997, 1.018] | 7/19 |
+| Sorted, 1 worker | fzf/candidate | 1.041 | [1.011, 1.054] | 11/19 |
+| Sorted, 1 worker | fzf/base | 1.037 | [1.013, 1.047] | 9/19 |
+| Sorted, 8 workers | base/candidate | 1.002 | [0.946, 1.069] | 10/19 |
+| Sorted, 8 workers | fzf/candidate | 0.750 | [0.727, 0.805] | 7/19 |
+| Sorted, 8 workers | fzf/base | 0.763 | [0.739, 0.799] | 6/19 |
+| Native no-sort, 1 worker | base/candidate | 1.011 | [1.003, 1.023] | 8/19 |
+
+## Category summary
+
+Ratios greater than 1 favor the candidate.
+
+| Category | Cells | fzf/candidate, 1 worker | base/candidate, 1 worker | fzf/candidate, 8 workers |
+|---|---:|---:|---:|---:|
+| Real corpora | 3 | 1.219 | 1.277 | 0.922 |
+| Partial match | 4 | 1.154 | 0.984 | 1.011 |
+| All match | 4 | 1.291 | 1.016 | 1.367 |
+| Partial miss | 4 | 0.894 | 0.944 | 0.474 |
+| No match | 4 | 0.784 | 0.931 | 0.415 |
+
+## Sorted scan, one worker
+
+The time columns contain medians from five processes.
+The ratio columns contain medians of five paired ratios.
+Therefore, a ratio does not always equal the ratio of the displayed times.
+
+| Cell | Base ms | Candidate ms | fzf ms | Base/candidate | fzf/candidate |
+|---|---:|---:|---:|---:|---:|
+| chromium | 122.89 | 119.43 | 164.77 | 1.035 | 1.366 |
+| arabic | 46.00 | 30.63 | 35.82 | 1.497 | 1.164 |
+| korean | 33.07 | 24.62 | 28.08 | 1.343 | 1.139 |
+| partial-16 | 3.53 | 3.54 | 4.01 | 0.994 | 1.121 |
+| partial-32 | 4.43 | 4.55 | 5.06 | 0.974 | 1.112 |
+| partial-64 | 6.35 | 6.57 | 7.58 | 0.967 | 1.149 |
+| partial-128 | 10.87 | 10.87 | 13.45 | 1.002 | 1.239 |
+| all-16 | 30.83 | 29.86 | 39.36 | 0.999 | 1.321 |
+| all-32 | 49.43 | 47.97 | 61.58 | 1.018 | 1.237 |
+| all-64 | 88.73 | 86.83 | 108.89 | 1.022 | 1.278 |
+| all-128 | 164.13 | 159.64 | 217.64 | 1.027 | 1.331 |
+| partial-miss-16 | 1.94 | 1.92 | 1.82 | 0.989 | 0.971 |
+| partial-miss-32 | 1.99 | 2.17 | 1.85 | 0.943 | 0.853 |
+| partial-miss-64 | 2.19 | 2.54 | 2.11 | 0.898 | 0.852 |
+| partial-miss-128 | 2.60 | 2.74 | 2.48 | 0.949 | 0.903 |
+| none-16 | 1.48 | 1.54 | 1.43 | 0.964 | 0.934 |
+| none-32 | 1.91 | 2.00 | 1.46 | 0.955 | 0.731 |
+| none-64 | 1.99 | 2.31 | 1.78 | 0.866 | 0.719 |
+| none-128 | 2.43 | 2.59 | 2.02 | 0.942 | 0.767 |
+
+## Sorted scan, eight workers
+
+| Cell | Base ms | Candidate ms | fzf ms | Base/candidate | fzf/candidate |
+|---|---:|---:|---:|---:|---:|
+| chromium | 30.53 | 31.98 | 40.82 | 1.076 | 1.265 |
+| arabic | 10.70 | 9.07 | 7.52 | 1.185 | 0.802 |
+| korean | 8.96 | 8.26 | 5.96 | 1.244 | 0.772 |
+| partial-16 | 1.21 | 1.06 | 1.10 | 1.226 | 1.037 |
+| partial-32 | 1.23 | 1.29 | 1.14 | 0.957 | 0.884 |
+| partial-64 | 1.69 | 1.55 | 1.51 | 1.045 | 0.992 |
+| partial-128 | 2.25 | 2.46 | 2.35 | 1.005 | 1.146 |
+| all-16 | 6.50 | 6.87 | 10.91 | 0.946 | 1.496 |
+| all-32 | 11.63 | 10.27 | 14.60 | 1.081 | 1.380 |
+| all-64 | 21.82 | 21.37 | 25.72 | 1.008 | 1.221 |
+| all-128 | 29.74 | 28.68 | 41.82 | 1.037 | 1.386 |
+| partial-miss-16 | 1.02 | 0.95 | 0.43 | 0.867 | 0.478 |
+| partial-miss-32 | 0.92 | 0.99 | 0.45 | 0.821 | 0.455 |
+| partial-miss-64 | 1.07 | 1.15 | 0.56 | 0.912 | 0.448 |
+| partial-miss-128 | 1.34 | 1.24 | 0.70 | 1.129 | 0.518 |
+| none-16 | 0.77 | 0.83 | 0.35 | 0.975 | 0.443 |
+| none-32 | 0.90 | 1.00 | 0.43 | 0.843 | 0.386 |
+| none-64 | 1.24 | 1.01 | 0.47 | 0.911 | 0.406 |
+| none-128 | 0.89 | 1.11 | 0.50 | 0.908 | 0.429 |
+
+## Native no-sort diagnostic
+
+fzf filter mode forces sorting for sortable queries.
+It does this even when the command contains `--no-sort`.
+Thus, this diagnostic compares only the native candidate and base.
+
+The candidate/base geometric mean is 1.011x.
+The interval is [1.003x, 1.023x].
+
+The sorted/no-sort geometric mean is 1.0005x for the candidate.
+It is 1.0047x for the base.
+Sorting is not the main cost in these cells.
+
+| Cell | Base ms | Candidate ms | Base/candidate |
+|---|---:|---:|---:|
+| chromium | 121.22 | 119.57 | 1.017 |
+| arabic | 47.53 | 31.67 | 1.480 |
+| korean | 34.02 | 25.40 | 1.326 |
+| partial-16 | 3.54 | 3.51 | 0.992 |
+| partial-32 | 4.44 | 4.70 | 0.978 |
+| partial-64 | 6.34 | 6.66 | 0.968 |
+| partial-128 | 11.16 | 10.85 | 1.004 |
+| all-16 | 29.41 | 30.17 | 1.005 |
+| all-32 | 48.89 | 47.63 | 1.000 |
+| all-64 | 84.48 | 81.50 | 1.028 |
+| all-128 | 163.41 | 159.20 | 1.027 |
+| partial-miss-16 | 1.99 | 1.95 | 1.033 |
+| partial-miss-32 | 1.99 | 2.19 | 0.943 |
+| partial-miss-64 | 2.22 | 2.62 | 0.884 |
+| partial-miss-128 | 2.68 | 2.75 | 0.956 |
+| none-16 | 1.59 | 1.65 | 0.967 |
+| none-32 | 1.86 | 1.98 | 0.929 |
+| none-64 | 1.96 | 2.22 | 0.877 |
+| none-128 | 2.46 | 2.57 | 0.957 |
+
+## Benchmark boundary
+
+The driver ingests the candidates before timing.
+This step records each byte length and ASCII status.
+
+The driver parses the query and starts the worker pool before timing.
+fzf also ingests the input and parses the query before timing.
+
+Each timed scan includes these operations:
+
+- Match all candidates.
+- Create one 16-byte result record for each match.
+- Sort each worker-local result list when sorting is active.
+- Create the pass merger and the result merger.
+- Create the merger list descriptors and cursors.
+- Count the matches during merger construction.
+
+The driver stops the timer before it reads the merger length.
+fzf uses the same boundary.
+Neither benchmark materializes the global sorted result inside timing.
+
+The next scan releases the prior C result before its timer starts.
+The prior Go result becomes unreachable outside its measured scan.
+Go garbage collection can still occur during a later scan.
+
+## Protocol
+
+Each subject uses `--filter`, `--literal`, `--algo=v2`, and `--tiebreak=index`.
+Each sorted process repeats scans for one second.
+
+The run uses five fresh process rounds.
+Each round shuffles the cells, lanes, and subject order with a fixed seed.
+Adjacent subjects use the same cell and lane.
+
+The campaign contains 760 timed processes.
+It retains all results and deletes no outliers.
+
+Each cell ratio is the median of five paired process ratios.
+Each aggregate is the geometric mean of the 19 cell ratios.
+
+The interval uses 10,000 bootstrap samples.
+Each sample resamples the five ratios inside each fixed cell.
+It then computes each cell median and the equal-cell geometric mean.
+
+The printed averages have 0.01 ms precision.
+Use caution with sub-millisecond cells, especially in the eight-worker lane.
+
+## Checks
+
+The run checks all 19 corpus hashes before timing.
+The candidate, base, and fzf produce identical ordered output for every corpus.
+
+The ordered output contains 646,229 matched lines for each subject.
+All corpora contain valid UTF-8.
+
+Native result checksums match across the candidate and base.
+They also match with one and eight workers, with sorting active or inactive.
+
+All 760 timed processes report the expected item count and match count.
+Every native process also reports its expected semantic checksum.
+
+The complete native C suite passes.
+The driver passes 9,097 ASan and UBSan iterations.
+It also passes 9,378 TSan iterations.
+
+Mixed-score and uniform-score radix cases each compare 4,096 results with fzf.
+Both comparisons pass.
+
+The duration parser rejects `18446744073709551616ns` without an undefined cast.
+This case has a permanent Makefile check.
+
+The source and build record is `build-provenance.json` in the raw directory.
+It records clean commits, source hashes, compiler flags, and binary hashes.
+
+Apple ld changes the Mach-O UUID and signature on each build.
+Rebuilt native binaries match after those two regions are removed.
+
+## Scope and limits
+
+This is a matched scan-boundary comparison.
+It does not force both implementations to do identical internal work.
+
+fzf stores decoded runes during ingestion.
+The native driver stores raw UTF-8, byte lengths, and ASCII status.
+Native Unicode matching decodes the candidate during each scan.
+
+fzf performs chunk-cache bookkeeping, cancellation checks, progress checks, and channel operations.
+The native driver has no equivalent chunk cache.
+It uses persistent pthread workers instead of Go goroutines and channels.
+
+These differences belong to the measured implementations.
+They can explain part of the result.
+
+The output check establishes equal ordered matches.
+It does not establish equal raw score values between C and Go.
+
+The dump mode preserves malformed bytes.
+fzf replaces malformed bytes with the Unicode replacement character.
+The benchmark does not contain malformed input.
+
+This benchmark does not measure the Emacs boundary or an interactive session.
+It measures full repeated scans after input ingestion.
+
+The intervals apply only to process noise on these fixed 19 cells.
+They do not establish performance on other hosts or workload sets.
+
+The run used one Apple M3 host with macOS 26.5.2.
+
+## Artifact index
+
+- `campaign.json` contains all 760 parsed timing records.
+- `commands.jsonl` contains every timed command and output hash.
+- `semantic-summary.json` contains the semantic checks and output hashes.
+- `analysis.json` contains the paired ratios, intervals, and aggregates.
+- `build-provenance.json` contains source and build identities.
+- `timings/` contains every process output.
+- `semantics/` contains all 57 ordered-output dumps.

--- a/benchmarks/2026-09-10T00-32-37Z.md
+++ b/benchmarks/2026-09-10T00-32-37Z.md
@@ -1,6 +1,6 @@
 # fzf matched-envelope parity benchmark
 
-Date: 2026-09-10T00:32:37Z
+Run date: 2026-09-10T00:32:37Z
 
 Raw artifacts: `/private/tmp/fzf-parity-final-20260909T234656Z/full-2`
 
@@ -15,7 +15,7 @@ fzf: `63e82a9e3dd52cc67a46db842b8a29e0c1f83229`
 ## Correction
 
 This report replaces the cross-fzf ratios in
-[`2026-09-09T18:56:18Z.md`](2026-09-09T18:56:18Z.md).
+[`2026-09-09T18-56-18Z.md`](2026-09-09T18-56-18Z.md).
 Do not use the earlier fzf/candidate or fzf/base ratios as the parity result.
 
 The earlier driver ranked native matches with the public membership value.

--- a/benchmarks/2026-09-10T00:32:37Z.md
+++ b/benchmarks/2026-09-10T00:32:37Z.md
@@ -1,0 +1,481 @@
+# fzf matched-envelope parity benchmark
+
+Date: 2026-09-10T00:32:37Z
+
+Raw artifacts: `/private/tmp/fzf-parity-final-20260909T234656Z/full-2`
+
+Candidate product source: `2a1920356695b4f5403258cfc031a04378e0add9`
+
+Benchmark driver commit: `2a1920356695b4f5403258cfc031a04378e0add9`
+
+Base: `4b9236e8cd1e9f9f3aaf5f2ebf83f1fc5995d38d`
+
+fzf: `63e82a9e3dd52cc67a46db842b8a29e0c1f83229`
+
+## Correction
+
+This report replaces the cross-fzf ratios in
+[`2026-09-09T18:56:18Z.md`](2026-09-09T18:56:18Z.md).
+Do not use the earlier fzf/candidate or fzf/base ratios as the parity result.
+
+The earlier driver ranked native matches with the public membership value.
+It did not use the raw aggregate score that fzf uses for rank order.
+When a fallback produces a negative raw score, the public value stays positive for a match.
+
+The earlier run used only `--literal --tiebreak=index`.
+That profile disables normalization and does not use the default length tiebreak.
+Thus, it did not measure the default fzf profile.
+
+The earlier output gate compared final lines only.
+It did not compare raw scores, match bounds, rank scores, or all rank points.
+The older timing text also rounded values to `0.01 ms` and used five process rounds.
+
+All subjects produced the same final output on the earlier 19 corpora.
+That result did not establish semantic parity outside those fixed inputs.
+The old ratios describe the old adapter and its selected profile.
+
+The earlier native base/candidate ratios remain a historical result for that adapter.
+This report gives new base/candidate ratios from the corrected driver and both profiles.
+
+## Result
+
+The default score/length profile is the primary result.
+Each ratio is numerator time divided by denominator time.
+A ratio greater than 1 favors the denominator in the ratio name.
+
+With one worker, fzf/candidate is 1.057 across 19 equally weighted cells.
+The 95% interval is [1.046, 1.064], and the candidate wins 11 cells.
+Thus, fzf used 1.057 times the candidate time in the aggregate.
+
+With eight workers, fzf/candidate is 0.743 across the same cells.
+The 95% interval is [0.722, 0.771], and the candidate wins 6 cells.
+Thus, fzf used 74.3% of the candidate time in this aggregate.
+
+The workload split is material.
+With one worker, fzf/candidate is 1.290 for all-match cells and 0.831 for no-match cells.
+With eight workers, these category ratios are 1.290 and 0.453.
+
+The base/candidate ratio is 1.020 with one worker and 1.018 with eight workers.
+The one-worker interval excludes 1, but the eight-worker interval includes 1.
+
+The normalization-disabled score/index profile is a secondary continuity result.
+Its fzf/candidate ratio is 1.064 with one worker and 0.760 with eight workers.
+
+## Profiles
+
+All lanes use filter mode, the default scoring scheme, fuzzy algorithm v2, extended queries, and sorted output.
+
+| Lane | Role | Normalization | Rank order | Workers |
+|---|---|---|---|---:|
+| `default-length-w1` | Primary | Enabled | Score, trimmed rune length, input index | 1 |
+| `default-length-w8` | Primary | Enabled | Score, trimmed rune length, input index | 8 |
+| `literal-index-w1` | Secondary | Disabled with `--literal` | Score, input index | 1 |
+| `literal-index-w8` | Secondary | Disabled with `--literal` | Score, input index | 8 |
+
+The primary profile matches the default fzf normalization and rank criteria.
+The secondary profile permits direct comparison with the earlier score/index report.
+
+## Exact semantic gates
+
+A Go oracle runs inside the pinned upstream fzf package.
+It uses the upstream matcher and rank comparator instead of a second implementation.
+
+For each targeted match, the gate compares these values exactly:
+
+- The input identity and final order.
+- The raw aggregate score.
+- The minimum begin, minimum end, and maximum end bounds.
+- The bounds-valid flag.
+- The 16-bit rank score.
+- All four upstream rank points.
+
+The gate contains 18 targeted cases.
+It runs each case with one native worker and eight native workers.
+The cases cover operators, duplicates, ties, normalization, Unicode, whitespace, and v2-to-v1 fallback.
+One case has 8,201 candidates and spans nine 1,024-item chunks.
+
+Before timing, a second gate compares full ordered output for every fixed cell and lane.
+The base, candidate, and fzf output must have the same byte hash within each cell and lane.
+This gate runs 228 full-corpus processes across 19 cells, four lanes, and three subjects.
+
+All 36 targeted oracle runs passed.
+All 228 full-corpus process outputs passed their 76 three-subject comparisons.
+These gates establish exact results for the selected cases and corpora.
+They do not prove equivalence for every possible query and candidate.
+
+## Parity corrections
+
+The native driver now separates match membership from the raw score used for rank order.
+It also implements the default trimmed-rune-length tiebreak and its lazy cache behavior.
+
+The first upstream-oracle run found four score-only start-boundary differences in the native matcher.
+The corrected paths cover general ASCII, general UTF-8, two-byte queries, and Unicode `Other_Letter` queries.
+
+The runner records exact integer nanoseconds.
+It also binds each native binary to clean source, compiler, options, and driver provenance.
+
+## Benchmark boundary
+
+Both subjects ingest input and parse the query before the timer starts.
+The C driver also starts its persistent pthread pool before the timer starts.
+fzf creates per-scan goroutines inside the timer and uses persistent Go runtime threads.
+
+Each timed scan performs these operations:
+
+- Create the pass merger and count its items.
+- Divide 1,024-item chunks among workers.
+- Score all candidates and collect every match.
+- Compute and cache trimmed rune length at the first use for a matching item.
+- Sort each worker-local result list.
+- Create the lazy result merger and its list descriptors.
+
+The timer stops after the lazy merger exists.
+The benchmark reads the match count after the timer stops.
+Neither subject materializes the global sorted result in the measured interval.
+
+fzf clears its chunk cache before each timed scan.
+The native scorer has no equivalent chunk cache.
+The C driver releases prior result buffers before each timer starts.
+A prior Go result becomes unreachable outside the measured scan, but garbage collection can occur during a later scan.
+
+## Protocol
+
+The campaign has 19 fixed cells.
+It contains three real corpora and four cells in each synthetic category.
+The synthetic categories are partial match, all match, partial miss, and no match.
+
+Each subject, cell, and lane runs in ten fresh processes.
+Each process repeats complete scans for one second.
+The full campaign contains 2,280 timed processes.
+
+The schedule uses five pairs of rounds.
+Each pair uses one random subject order and then its reverse.
+The runner also shuffles the cell and lane order with a fixed seed.
+
+Each process reports integer nanoseconds for total time, minimum time, maximum time, and ingestion time.
+The analysis uses the exact total and iteration count.
+It does not use the rounded human-readable value.
+
+Each cell ratio is the median of ten paired process ratios.
+Each aggregate is the geometric mean of the 19 cell ratios.
+Thus, each fixed cell has equal weight.
+
+The 95% interval uses 10,000 bootstrap samples.
+Each sample resamples ten ratios inside each cell.
+It then computes each cell median and the equal-cell geometric mean.
+The analysis removes no outliers.
+
+The runner records frozen corpus hashes, binary hashes, source trees, build commands, and the hardware identity.
+If a corpus, binary, driver, runner, or provenance file changes during the campaign, the runner stops.
+
+The fzf patch adds exact JSON timing output only.
+It does not change the measured scan.
+The candidate and base use the same C driver, compiler, options, and environment.
+
+## Primary aggregate summary
+
+| Lane | Ratio | Geometric mean | 95% interval | Denominator wins |
+|---|---|---:|---:|---:|
+| Default, 1 worker | base/candidate | 1.020 | [1.009, 1.029] | 9/19 |
+| Default, 1 worker | fzf/candidate | 1.057 | [1.046, 1.064] | 11/19 |
+| Default, 1 worker | fzf/base | 1.037 | [1.024, 1.043] | 9/19 |
+| Default, 8 workers | base/candidate | 1.018 | [0.985, 1.046] | 10/19 |
+| Default, 8 workers | fzf/candidate | 0.743 | [0.722, 0.771] | 6/19 |
+| Default, 8 workers | fzf/base | 0.732 | [0.710, 0.758] | 6/19 |
+
+## Primary category summary
+
+### `default-length-w1`
+
+| Category | Cells | Base/candidate | fzf/candidate | fzf/base |
+|---|---:|---:|---:|---:|
+| Real corpora | 3 | 1.331 [1.293, 1.334] | 1.208 [1.174, 1.222] | 0.908 [0.895, 0.921] |
+| Partial match | 4 | 0.982 [0.968, 0.995] | 1.188 [1.171, 1.196] | 1.207 [1.191, 1.219] |
+| All match | 4 | 1.001 [0.979, 1.003] | 1.290 [1.267, 1.307] | 1.289 [1.286, 1.311] |
+| Partial miss | 4 | 0.953 [0.920, 0.986] | 0.888 [0.870, 0.914] | 0.949 [0.916, 0.966] |
+| No match | 4 | 0.946 [0.936, 0.972] | 0.831 [0.803, 0.837] | 0.864 [0.833, 0.882] |
+
+### `default-length-w8`
+
+| Category | Cells | Base/candidate | fzf/candidate | fzf/base |
+|---|---:|---:|---:|---:|
+| Real corpora | 3 | 1.268 [1.199, 1.367] | 0.920 [0.852, 1.042] | 0.718 [0.666, 0.772] |
+| Partial match | 4 | 0.952 [0.919, 1.020] | 0.946 [0.865, 1.000] | 0.950 [0.899, 1.005] |
+| All match | 4 | 1.007 [0.961, 1.043] | 1.290 [1.232, 1.366] | 1.338 [1.275, 1.379] |
+| Partial miss | 4 | 0.974 [0.891, 1.028] | 0.470 [0.444, 0.504] | 0.492 [0.454, 0.542] |
+| No match | 4 | 0.973 [0.868, 1.057] | 0.453 [0.427, 0.500] | 0.465 [0.432, 0.525] |
+
+## Primary per-cell results
+
+The time columns contain medians of ten process averages.
+The ratio columns contain medians of ten paired ratios.
+Thus, a displayed ratio can differ from the ratio of displayed times.
+
+### `default-length-w1`
+
+| Cell | Base ms | Candidate ms | fzf ms | Base/candidate | fzf/candidate | fzf/base |
+|---|---:|---:|---:|---:|---:|---:|
+| chromium | 121.516333 | 118.639222 | 161.897435 | 1.025 | 1.361 | 1.328 |
+| arabic | 49.281524 | 30.927258 | 35.933719 | 1.594 | 1.159 | 0.729 |
+| korean | 36.335768 | 25.200475 | 28.208409 | 1.443 | 1.117 | 0.774 |
+| partial-16 | 3.314628 | 3.252281 | 4.076051 | 1.012 | 1.247 | 1.221 |
+| partial-32 | 4.393243 | 4.516018 | 5.091431 | 0.973 | 1.126 | 1.159 |
+| partial-64 | 6.321726 | 6.580041 | 7.569799 | 0.961 | 1.151 | 1.197 |
+| partial-128 | 10.734037 | 10.898755 | 13.451151 | 0.984 | 1.233 | 1.252 |
+| all-16 | 28.207333 | 28.263264 | 37.815974 | 0.997 | 1.334 | 1.338 |
+| all-32 | 47.220250 | 47.127295 | 58.059767 | 1.003 | 1.231 | 1.229 |
+| all-64 | 80.861000 | 80.531500 | 102.863606 | 1.004 | 1.277 | 1.272 |
+| all-128 | 161.573071 | 161.323929 | 213.115837 | 1.002 | 1.321 | 1.319 |
+| partial-miss-16 | 1.866677 | 1.809503 | 1.826544 | 1.003 | 0.981 | 0.994 |
+| partial-miss-32 | 1.991478 | 2.111818 | 1.842489 | 0.944 | 0.853 | 0.922 |
+| partial-miss-64 | 2.203045 | 2.447631 | 2.109974 | 0.903 | 0.866 | 0.960 |
+| partial-miss-128 | 2.650251 | 2.683641 | 2.433957 | 0.964 | 0.859 | 0.920 |
+| none-16 | 1.561920 | 1.482491 | 1.461010 | 1.009 | 0.976 | 0.935 |
+| none-32 | 1.723501 | 1.833015 | 1.454836 | 0.940 | 0.792 | 0.845 |
+| none-64 | 1.932367 | 2.188492 | 1.652272 | 0.883 | 0.752 | 0.847 |
+| none-128 | 2.419579 | 2.412158 | 1.983044 | 0.955 | 0.821 | 0.833 |
+
+### `default-length-w8`
+
+| Cell | Base ms | Candidate ms | fzf ms | Base/candidate | fzf/candidate | fzf/base |
+|---|---:|---:|---:|---:|---:|---:|
+| chromium | 36.121888 | 33.797733 | 39.966586 | 1.080 | 1.165 | 1.059 |
+| arabic | 13.509502 | 9.591380 | 9.427934 | 1.415 | 0.878 | 0.653 |
+| korean | 13.939961 | 10.056370 | 7.381750 | 1.334 | 0.761 | 0.536 |
+| partial-16 | 1.188184 | 1.215753 | 1.062827 | 0.967 | 0.914 | 0.796 |
+| partial-32 | 1.361407 | 1.618119 | 1.376699 | 0.861 | 0.836 | 0.988 |
+| partial-64 | 1.806608 | 1.970095 | 1.487706 | 0.950 | 0.868 | 0.900 |
+| partial-128 | 2.829240 | 2.570353 | 3.382252 | 1.038 | 1.205 | 1.153 |
+| all-16 | 8.186036 | 7.873818 | 11.788087 | 1.012 | 1.427 | 1.446 |
+| all-32 | 11.901139 | 12.169873 | 14.861421 | 0.996 | 1.243 | 1.279 |
+| all-64 | 20.895878 | 21.176827 | 26.434112 | 1.023 | 1.236 | 1.321 |
+| all-128 | 30.423216 | 36.675249 | 40.978055 | 1.000 | 1.261 | 1.311 |
+| partial-miss-16 | 0.839890 | 1.066781 | 0.506640 | 0.926 | 0.468 | 0.506 |
+| partial-miss-32 | 1.153864 | 1.153928 | 0.524064 | 0.978 | 0.460 | 0.470 |
+| partial-miss-64 | 1.052543 | 1.111544 | 0.564038 | 1.020 | 0.489 | 0.522 |
+| partial-miss-128 | 1.371145 | 1.457071 | 0.688341 | 0.975 | 0.463 | 0.474 |
+| none-16 | 0.919309 | 0.910043 | 0.415364 | 1.013 | 0.475 | 0.473 |
+| none-32 | 0.916999 | 1.019334 | 0.425687 | 0.913 | 0.403 | 0.451 |
+| none-64 | 1.055169 | 0.995425 | 0.485013 | 0.960 | 0.455 | 0.426 |
+| none-128 | 1.127943 | 1.281907 | 0.599095 | 1.009 | 0.485 | 0.515 |
+
+## Secondary score/index results
+
+These lanes disable normalization and rank equal scores by input index.
+They are secondary results for continuity with the earlier report.
+
+### Aggregate summary
+
+| Lane | Ratio | Geometric mean | 95% interval | Denominator wins |
+|---|---|---:|---:|---:|
+| Literal, 1 worker | base/candidate | 1.016 | [1.007, 1.022] | 10/19 |
+| Literal, 1 worker | fzf/candidate | 1.064 | [1.052, 1.066] | 12/19 |
+| Literal, 1 worker | fzf/base | 1.043 | [1.032, 1.049] | 10/19 |
+| Literal, 8 workers | base/candidate | 1.007 | [0.973, 1.042] | 8/19 |
+| Literal, 8 workers | fzf/candidate | 0.760 | [0.739, 0.791] | 6/19 |
+| Literal, 8 workers | fzf/base | 0.745 | [0.727, 0.777] | 6/19 |
+
+### Category summary for `literal-index-w1`
+
+| Category | Cells | Base/candidate | fzf/candidate | fzf/base |
+|---|---:|---:|---:|---:|
+| Real corpora | 3 | 1.264 [1.225, 1.267] | 1.205 [1.171, 1.218] | 0.954 [0.947, 0.964] |
+| Partial match | 4 | 0.983 [0.971, 0.999] | 1.189 [1.175, 1.206] | 1.209 [1.183, 1.226] |
+| All match | 4 | 1.002 [0.991, 1.018] | 1.287 [1.271, 1.297] | 1.283 [1.263, 1.294] |
+| Partial miss | 4 | 0.953 [0.935, 0.968] | 0.914 [0.888, 0.921] | 0.955 [0.930, 0.964] |
+| No match | 4 | 0.962 [0.943, 0.984] | 0.833 [0.811, 0.839] | 0.852 [0.830, 0.875] |
+
+### Category summary for `literal-index-w8`
+
+| Category | Cells | Base/candidate | fzf/candidate | fzf/base |
+|---|---:|---:|---:|---:|
+| Real corpora | 3 | 1.147 [1.086, 1.262] | 0.923 [0.864, 1.003] | 0.789 [0.751, 0.841] |
+| Partial match | 4 | 1.022 [0.959, 1.079] | 0.915 [0.868, 0.963] | 0.902 [0.861, 0.958] |
+| All match | 4 | 1.010 [0.957, 1.053] | 1.321 [1.262, 1.411] | 1.320 [1.242, 1.404] |
+| Partial miss | 4 | 0.946 [0.869, 1.026] | 0.510 [0.469, 0.578] | 0.534 [0.492, 0.585] |
+| No match | 4 | 0.956 [0.881, 1.062] | 0.467 [0.439, 0.505] | 0.465 [0.440, 0.530] |
+
+### Per-cell results for `literal-index-w1`
+
+| Cell | Base ms | Candidate ms | fzf ms | Base/candidate | fzf/candidate | fzf/base |
+|---|---:|---:|---:|---:|---:|---:|
+| chromium | 121.114111 | 118.311889 | 160.831292 | 1.024 | 1.355 | 1.326 |
+| arabic | 45.864023 | 30.760545 | 35.620794 | 1.492 | 1.155 | 0.776 |
+| korean | 33.130903 | 25.041725 | 28.001697 | 1.323 | 1.118 | 0.844 |
+| partial-16 | 3.263011 | 3.229560 | 4.032242 | 1.009 | 1.249 | 1.235 |
+| partial-32 | 4.392468 | 4.499410 | 5.069325 | 0.976 | 1.128 | 1.156 |
+| partial-64 | 6.314450 | 6.565271 | 7.562412 | 0.961 | 1.151 | 1.198 |
+| partial-128 | 10.731330 | 10.891027 | 13.436522 | 0.985 | 1.233 | 1.252 |
+| all-16 | 28.036167 | 28.119000 | 37.266607 | 0.997 | 1.325 | 1.328 |
+| all-32 | 47.076250 | 46.864295 | 57.725851 | 1.005 | 1.231 | 1.225 |
+| all-64 | 80.844577 | 80.465500 | 102.554065 | 1.003 | 1.272 | 1.265 |
+| all-128 | 161.115357 | 160.772214 | 212.427242 | 1.002 | 1.321 | 1.318 |
+| partial-miss-16 | 1.819677 | 1.848028 | 1.826769 | 1.008 | 1.014 | 1.004 |
+| partial-miss-32 | 1.991451 | 2.103799 | 1.846156 | 0.948 | 0.868 | 0.917 |
+| partial-miss-64 | 2.204261 | 2.461101 | 2.107711 | 0.896 | 0.859 | 0.945 |
+| partial-miss-128 | 2.575948 | 2.675376 | 2.470041 | 0.963 | 0.924 | 0.958 |
+| none-16 | 1.593789 | 1.495821 | 1.459915 | 1.015 | 0.977 | 0.916 |
+| none-32 | 1.724998 | 1.833234 | 1.456242 | 0.941 | 0.796 | 0.844 |
+| none-64 | 1.939343 | 2.185659 | 1.658404 | 0.886 | 0.754 | 0.856 |
+| none-128 | 2.471116 | 2.410498 | 1.987485 | 1.012 | 0.822 | 0.796 |
+
+### Per-cell results for `literal-index-w8`
+
+| Cell | Base ms | Candidate ms | fzf ms | Base/candidate | fzf/candidate | fzf/base |
+|---|---:|---:|---:|---:|---:|---:|
+| chromium | 33.314320 | 34.065684 | 41.330525 | 0.974 | 1.220 | 1.187 |
+| arabic | 12.203795 | 9.832079 | 8.656776 | 1.299 | 0.829 | 0.688 |
+| korean | 11.210708 | 8.447394 | 6.906961 | 1.194 | 0.776 | 0.602 |
+| partial-16 | 1.375014 | 1.314639 | 1.096596 | 0.999 | 0.781 | 0.802 |
+| partial-32 | 1.466870 | 1.418342 | 1.270678 | 1.088 | 0.895 | 0.805 |
+| partial-64 | 1.922708 | 1.854011 | 1.673384 | 1.006 | 0.941 | 0.929 |
+| partial-128 | 2.690329 | 2.846627 | 2.954451 | 0.999 | 1.066 | 1.104 |
+| all-16 | 8.043445 | 8.223740 | 11.096065 | 0.960 | 1.425 | 1.498 |
+| all-32 | 11.925650 | 10.853975 | 14.053665 | 1.082 | 1.302 | 1.207 |
+| all-64 | 18.377425 | 17.995238 | 25.212313 | 1.025 | 1.325 | 1.310 |
+| all-128 | 33.564117 | 37.470431 | 46.072636 | 0.978 | 1.240 | 1.283 |
+| partial-miss-16 | 1.033249 | 0.960984 | 0.490158 | 1.016 | 0.499 | 0.487 |
+| partial-miss-32 | 0.963332 | 1.165707 | 0.510984 | 0.916 | 0.442 | 0.495 |
+| partial-miss-64 | 1.008571 | 1.176303 | 0.593269 | 0.874 | 0.510 | 0.576 |
+| partial-miss-128 | 1.250105 | 1.195406 | 0.703257 | 0.987 | 0.602 | 0.586 |
+| none-16 | 0.856950 | 0.840716 | 0.434954 | 0.963 | 0.517 | 0.532 |
+| none-32 | 0.812718 | 0.979955 | 0.386593 | 0.856 | 0.418 | 0.462 |
+| none-64 | 1.027383 | 1.201043 | 0.495949 | 0.903 | 0.396 | 0.432 |
+| none-128 | 1.324638 | 1.078613 | 0.597374 | 1.121 | 0.555 | 0.441 |
+
+## Test results
+
+- The exact upstream semantic gate passed 18 cases at one and eight native workers.
+- The 228 full ordered-output processes passed all 76 three-subject comparisons.
+- The complete native C suite passed with `make ctest`.
+- ASan and UBSan passed all suites, including the parser OOM, scorer OOM, and session-growth rank-oracle suites.
+- TSan passed 18 state corpus replays and 18 reader corpus replays with `make fuzz-session-tsan`.
+- The benchmark driver unit tests passed, including raw-score, duplicate, radix, JSON, and lazy-length-cache cases.
+
+## Build and host provenance
+
+| Item | Value |
+|---|---|
+| Candidate commit | `2a1920356695b4f5403258cfc031a04378e0add9` |
+| Candidate tree | `cb26b59b8542088cec19f26ae728195f313fce47` |
+| Candidate binary SHA-256 | `09cbb0ffc432d23a2ee933f336d7c2fd46604d8efcbb2e740f2688554a400430` |
+| Base commit | `4b9236e8cd1e9f9f3aaf5f2ebf83f1fc5995d38d` |
+| Base tree | `addf72bc226e4df1840ccf02f56b0903c6f1ba7a` |
+| Base binary SHA-256 | `bd6a473b0881767ae049b7507a70c8461eb8144d6cf688a75bce0048ee061ee1` |
+| fzf commit | `63e82a9e3dd52cc67a46db842b8a29e0c1f83229` |
+| fzf tree | `07f9582f3003315a1ff096e7ed7ac16d52b30e77` |
+| fzf binary SHA-256 | `7ac16e86bba4ba542583541373041247f8fc7391cb715508ccf791a446f5ac36` |
+| fzf timing patch SHA-256 | `d666359f1bacf6ec7e7d43e7570917434ee1ff115011e1f3ca42f1b3d8487e89` |
+| Native driver SHA-256 | `298865563310629255954472a6f79036b958da17c70df2594ebed703926990af` |
+| Runner SHA-256 | `93c9082d7ecad3185d616e0aa27c57b5d4716719a098b5a683f21c16343b8a72` |
+| Analyzer SHA-256 | `95588242588fe5f0c137e3f7aa8d213f01cfa55d8784142403668324d68ff377` |
+| Campaign SHA-256 | `0b148c1cb7e2702c6954ef43f5f7dd147d8ec87d0032908392488fe44584ef78` |
+| Ordered-output manifest SHA-256 | `e0b0f05b1005a34c7c368ebbfbd967a9fcb5bccf1cb4d3e7c461b61112d3e749` |
+| Native compiler | Apple clang 21.0.0, arm64 target |
+| Native options | `-std=gnu11 -Wall -Wextra -O3 -DNDEBUG -pthread` |
+| Go toolchain | Go 1.27.1, `CGO_ENABLED=0`, `GOARCH=arm64` |
+| Host | MacBook Air `Mac15,12`, Apple M3, 8 logical CPUs, 16 GB |
+| Operating system | macOS 26.5.2, Darwin 25.5.0, arm64 |
+
+The build script recorded both native source trees as clean.
+The campaign ran with `LANG=C`, `LC_ALL=C`, and `TZ=UTC`.
+The campaign started at `2026-09-09T23:52:42.254852Z`.
+It completed at `2026-09-10T00:32:37.823783Z`.
+
+## Reproduction commands
+
+The build records contain the complete compiler commands and environment.
+If each source tree is at its recorded commit, the following script invocations reproduce the build procedure:
+
+```sh
+python3 benchmarks/build-native-fzf-bench.py \
+  --source /private/tmp/fzf-final-frozen.gXHD88/base \
+  --output /private/tmp/fzf-parity-final-20260909T234656Z/bin/base \
+  --provenance /private/tmp/fzf-parity-final-20260909T234656Z/provenance/base.json
+
+python3 benchmarks/build-native-fzf-bench.py \
+  --source /private/tmp/fzf-parity-integration \
+  --output /private/tmp/fzf-parity-final-20260909T234656Z/bin/candidate \
+  --provenance /private/tmp/fzf-parity-final-20260909T234656Z/provenance/candidate.json
+
+python3 benchmarks/build-pinned-fzf-bench.py \
+  --fzf-source /private/tmp/fzf-vs-native.Fze9YH/fzf \
+  --output /private/tmp/fzf-parity-final-20260909T234656Z/bin/fzf \
+  --provenance /private/tmp/fzf-parity-final-20260909T234656Z/provenance/fzf.json
+```
+
+The campaign recorded this command and these artifact paths:
+
+```sh
+python3 benchmarks/run-fzf-envelope.py \
+  --artifact-root /private/tmp/fzf-parity-final-20260909T234656Z/full-2 \
+  --corpus-root /private/tmp/fzf-vs-native.Fze9YH/corpora \
+  --candidate /private/tmp/fzf-parity-final-20260909T234656Z/bin/candidate \
+  --candidate-build-provenance /private/tmp/fzf-parity-final-20260909T234656Z/provenance/candidate.json \
+  --base /private/tmp/fzf-parity-final-20260909T234656Z/bin/base \
+  --base-build-provenance /private/tmp/fzf-parity-final-20260909T234656Z/provenance/base.json \
+  --fzf /private/tmp/fzf-parity-final-20260909T234656Z/bin/fzf \
+  --fzf-build-provenance /private/tmp/fzf-parity-final-20260909T234656Z/provenance/fzf.json
+```
+
+Use a fresh artifact root for another campaign.
+The runner does not overwrite an existing campaign.
+
+This command creates the JSON, Markdown, and TSV analysis files:
+
+```sh
+python3 benchmarks/analyze-fzf-envelope.py \
+  /private/tmp/fzf-parity-final-20260909T234656Z/full-2/campaign.json \
+  --output-prefix /private/tmp/fzf-parity-final-20260909T234656Z/full-2/analysis
+```
+
+These commands run the named gates and sanitizer suites:
+
+```sh
+make ctest-fzf-bench-driver
+make ctest-fzf-upstream-semantic \
+  FZF_SOURCE=/private/tmp/fzf-vs-native.Fze9YH/fzf \
+  BUILD_DIR=/private/tmp/fzf-parity-semantic-build
+make ctest
+make ctest-asan
+make fuzz-session-tsan
+```
+
+## Scope and limits
+
+This benchmark matches inputs, options, observable rank data, ordered output, and the scan timer boundary.
+It does not force the implementations to use identical internal work.
+
+fzf stores decoded runes during ingestion.
+The native driver stores raw UTF-8, byte lengths, and ASCII status.
+The native matcher decodes non-ASCII candidates during each scan.
+
+fzf uses Go goroutines, channels, cancellation polling, progress polling, and chunk-cache bookkeeping.
+The native driver uses persistent pthreads, condition variables, and direct worker-local lists.
+
+Go manages result memory through garbage collection.
+The C driver releases merger and match-list memory explicitly outside the timer.
+Per-worker slabs and sort scratch persist in both implementations.
+
+The corpora contain valid UTF-8.
+fzf replaces malformed bytes with U+FFFD, while the native dump preserves malformed bytes.
+
+This benchmark excludes process startup, input ingestion, query parsing, global result materialization, Emacs calls, and interactive-session behavior.
+It measures repeated full scans after ingestion.
+
+The intervals describe process noise for these fixed cells on one host.
+They do not establish performance on other machines or workloads.
+
+The semantic gates are broad regression gates, not a formal proof of equivalence.
+
+## Artifact index
+
+- `campaign.json` contains all timing records, the hardware record, and embedded build provenance.
+- `commands.jsonl` contains every timed command and output hash.
+- `ordered-output.json` contains every full-corpus gate and hash.
+- `analysis.json` contains paired ratios, intervals, categories, and aggregates.
+- `analysis.md` contains the generated tables in human-readable form.
+- `analysis.tsv` contains the generated table data.
+- `timings/` contains every timed process output.
+- `ordered-output/` contains every full ordered-output dump.
+- `/private/tmp/fzf-parity-final-20260909T234656Z/provenance/` contains the three build records.

--- a/benchmarks/analyze-fzf-envelope.py
+++ b/benchmarks/analyze-fzf-envelope.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python3
+"""Analyze a completed fzf matched-envelope benchmark campaign.
+
+The campaign runner randomizes process order, but emits one measurement for
+each subject in every fixed (lane, cell, round) block.  This analyzer keeps
+that pairing: it divides same-round average nanosecond measurements, takes the
+median ratio for each fixed cell, and gives every cell equal weight when it
+forms an aggregate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import math
+import pathlib
+import random
+import statistics
+import sys
+from typing import Iterable, Optional, Sequence
+
+
+SUBJECTS = ("base", "candidate", "fzf")
+RATIOS = {
+    "base/candidate": ("base", "candidate"),
+    "fzf/candidate": ("fzf", "candidate"),
+    "fzf/base": ("fzf", "base"),
+}
+CATEGORY_ORDER = ("real", "partial", "all", "partial-miss", "none")
+REAL_CELLS = frozenset(("chromium", "arabic", "korean"))
+DEFAULT_BOOTSTRAP_SAMPLES = 10_000
+DEFAULT_BOOTSTRAP_SEED = 0xA11CE20260909
+
+
+def sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def category_for_cell(name: str) -> str:
+    if name in REAL_CELLS:
+        return "real"
+    if name.startswith("partial-miss-"):
+        return "partial-miss"
+    if name.startswith("partial-"):
+        return "partial"
+    if name.startswith("all-"):
+        return "all"
+    if name.startswith("none-"):
+        return "none"
+    raise ValueError(f"cannot assign benchmark category to cell {name!r}")
+
+
+def percentile(sorted_values: Sequence[float], probability: float) -> float:
+    """Return a linearly interpolated percentile from sorted values."""
+    if not sorted_values:
+        raise ValueError("a percentile needs at least one value")
+    if not 0.0 <= probability <= 1.0:
+        raise ValueError("percentile probability must be in [0, 1]")
+    position = (len(sorted_values) - 1) * probability
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return sorted_values[lower]
+    fraction = position - lower
+    return (
+        sorted_values[lower] * (1.0 - fraction)
+        + sorted_values[upper] * fraction
+    )
+
+
+def geometric_mean(values: Iterable[float]) -> float:
+    materialized = list(values)
+    if not materialized:
+        raise ValueError("a geometric mean needs at least one value")
+    if any(value <= 0.0 or not math.isfinite(value) for value in materialized):
+        raise ValueError("geometric mean values must be finite and positive")
+    return math.exp(math.fsum(math.log(value) for value in materialized) /
+                    len(materialized))
+
+
+def stable_seed(seed: int, *parts: str) -> int:
+    encoded = "\0".join((str(seed), *parts)).encode("utf-8")
+    return int.from_bytes(hashlib.sha256(encoded).digest()[:16], "big")
+
+
+def bootstrap_cell_medians(
+    values: Sequence[float], samples: int, seed: int
+) -> list[float]:
+    if samples < 1:
+        raise ValueError("bootstrap sample count must be positive")
+    if not values:
+        raise ValueError("bootstrap needs at least one observed value")
+    generator = random.Random(seed)
+    count = len(values)
+    return [
+        statistics.median(generator.choice(values) for _ in range(count))
+        for _ in range(samples)
+    ]
+
+
+def confidence_interval(values: Sequence[float]) -> dict[str, float]:
+    ordered = sorted(values)
+    return {
+        "lower": percentile(ordered, 0.025),
+        "upper": percentile(ordered, 0.975),
+    }
+
+
+def ratio_summary(
+    estimate: float, bootstrap_values: Sequence[float]
+) -> dict[str, object]:
+    return {
+        "estimate": estimate,
+        "ci95": confidence_interval(bootstrap_values),
+        "bootstrap_samples": len(bootstrap_values),
+    }
+
+
+def average_ns(record: dict[str, object]) -> float:
+    value = record.get("average_ns")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("timing record lacks numeric average_ns")
+    value = float(value)
+    if value <= 0.0 or not math.isfinite(value):
+        raise ValueError("average_ns must be finite and positive")
+
+    iterations = record.get("iterations")
+    total_ns = record.get("total_ns")
+    if type(iterations) is not int or type(total_ns) is not int:
+        raise ValueError("timing record lacks exact iterations or total_ns")
+    if iterations < 1 or total_ns < 1:
+        raise ValueError("iterations and total_ns must be positive")
+    exact_average = total_ns / iterations
+    if not math.isclose(value, exact_average, rel_tol=1e-15, abs_tol=0.0):
+        raise ValueError(
+            f"average_ns {value!r} differs from total_ns/iterations "
+            f"{exact_average!r}"
+        )
+    return value
+
+
+def validate_campaign(campaign: dict[str, object]) -> None:
+    if campaign.get("schema") != 1:
+        raise ValueError("unsupported campaign schema")
+    if campaign.get("status") != "ordered-output-and-timings-complete":
+        raise ValueError("campaign did not complete ordered-output and timings")
+    rounds = campaign.get("rounds")
+    if type(rounds) is not int or rounds < 2:
+        raise ValueError("campaign rounds must be an integer of at least 2")
+    lanes = campaign.get("lanes")
+    cells = campaign.get("cells")
+    records = campaign.get("records")
+    if not isinstance(lanes, dict) or not lanes:
+        raise ValueError("campaign has no lanes")
+    if not isinstance(cells, dict) or not cells:
+        raise ValueError("campaign has no cells")
+    if not isinstance(records, list):
+        raise ValueError("campaign records must be a list")
+    if campaign.get("record_count") != len(records):
+        raise ValueError("campaign record_count differs from records length")
+
+    expected = rounds * len(lanes) * len(cells) * len(SUBJECTS)
+    if len(records) != expected:
+        raise ValueError(
+            f"campaign has {len(records)} timing records; expected {expected}"
+        )
+
+
+def index_records(
+    campaign: dict[str, object]
+) -> dict[tuple[str, str, int], dict[str, dict[str, object]]]:
+    lanes = campaign["lanes"]
+    cells = campaign["cells"]
+    rounds = campaign["rounds"]
+    assert isinstance(lanes, dict)
+    assert isinstance(cells, dict)
+    assert isinstance(rounds, int)
+    indexed: dict[
+        tuple[str, str, int], dict[str, dict[str, object]]
+    ] = {}
+    records = campaign["records"]
+    assert isinstance(records, list)
+    for raw_record in records:
+        if not isinstance(raw_record, dict):
+            raise ValueError("campaign contains a non-object timing record")
+        record = raw_record
+        lane = record.get("lane")
+        cell = record.get("cell")
+        round_number = record.get("round")
+        subject = record.get("subject")
+        if lane not in lanes or cell not in cells:
+            raise ValueError(f"timing record names unknown lane or cell: {record}")
+        if type(round_number) is not int or not 1 <= round_number <= rounds:
+            raise ValueError(f"invalid round in timing record: {record}")
+        if subject not in SUBJECTS:
+            raise ValueError(f"invalid subject in timing record: {record}")
+        average_ns(record)
+        key = (str(lane), str(cell), round_number)
+        subjects = indexed.setdefault(key, {})
+        if subject in subjects:
+            raise ValueError(
+                f"duplicate {subject} timing for lane={lane} cell={cell} "
+                f"round={round_number}"
+            )
+        subjects[str(subject)] = record
+
+    expected_rounds = set(range(1, rounds + 1))
+    for lane in lanes:
+        for cell in cells:
+            seen_rounds = {
+                round_number for (seen_lane, seen_cell, round_number), subjects
+                in indexed.items()
+                if seen_lane == lane and seen_cell == cell and
+                set(subjects) == set(SUBJECTS)
+            }
+            if seen_rounds != expected_rounds:
+                raise ValueError(
+                    f"incomplete same-round subject pairing for lane={lane} "
+                    f"cell={cell}; complete rounds={sorted(seen_rounds)}"
+                )
+    return indexed
+
+
+def aggregate_bootstrap(
+    cell_names: Sequence[str],
+    cell_bootstraps: dict[str, list[float]],
+    samples: int,
+) -> list[float]:
+    return [
+        geometric_mean(cell_bootstraps[cell][sample] for cell in cell_names)
+        for sample in range(samples)
+    ]
+
+
+def analyze_campaign(
+    campaign: dict[str, object],
+    campaign_path: pathlib.Path,
+    bootstrap_samples: int = DEFAULT_BOOTSTRAP_SAMPLES,
+    bootstrap_seed: int = DEFAULT_BOOTSTRAP_SEED,
+    analyzer_path: Optional[pathlib.Path] = None,
+) -> dict[str, object]:
+    validate_campaign(campaign)
+    indexed = index_records(campaign)
+    lanes = campaign["lanes"]
+    cells = campaign["cells"]
+    rounds = campaign["rounds"]
+    assert isinstance(lanes, dict)
+    assert isinstance(cells, dict)
+    assert isinstance(rounds, int)
+    cell_names = list(cells)
+
+    lane_analyses = []
+    for lane_name, lane_metadata in lanes.items():
+        cell_analyses = []
+        observed_ratios: dict[str, dict[str, list[float]]] = {
+            ratio_name: {} for ratio_name in RATIOS
+        }
+        bootstrap_medians: dict[str, dict[str, list[float]]] = {
+            ratio_name: {} for ratio_name in RATIOS
+        }
+        for cell_name in cell_names:
+            subject_measurements = {subject: [] for subject in SUBJECTS}
+            round_ratios = {ratio_name: [] for ratio_name in RATIOS}
+            for round_number in range(1, rounds + 1):
+                records = indexed[(lane_name, cell_name, round_number)]
+                measurements = {
+                    subject: average_ns(records[subject])
+                    for subject in SUBJECTS
+                }
+                for subject in SUBJECTS:
+                    subject_measurements[subject].append(measurements[subject])
+                for ratio_name, (numerator, denominator) in RATIOS.items():
+                    round_ratios[ratio_name].append(
+                        measurements[numerator] / measurements[denominator]
+                    )
+
+            cell_ratio_analysis = {}
+            for ratio_name, values in round_ratios.items():
+                observed_ratios[ratio_name][cell_name] = values
+                bootstraps = bootstrap_cell_medians(
+                    values,
+                    bootstrap_samples,
+                    stable_seed(
+                        bootstrap_seed, lane_name, cell_name, ratio_name
+                    ),
+                )
+                bootstrap_medians[ratio_name][cell_name] = bootstraps
+                cell_ratio_analysis[ratio_name] = {
+                    **ratio_summary(statistics.median(values), bootstraps),
+                    "same_round_values": values,
+                }
+
+            metadata = cells[cell_name]
+            if not isinstance(metadata, dict):
+                raise ValueError(f"cell metadata is not an object: {cell_name}")
+            cell_analyses.append({
+                "name": cell_name,
+                "category": category_for_cell(cell_name),
+                "items": metadata.get("items"),
+                "matches": metadata.get("matches"),
+                "median_ns": {
+                    subject: statistics.median(values)
+                    for subject, values in subject_measurements.items()
+                },
+                "observed_average_ns": subject_measurements,
+                "ratios": cell_ratio_analysis,
+            })
+
+        aggregate_ratios = {}
+        for ratio_name in RATIOS:
+            cell_estimates = {
+                cell_name: statistics.median(
+                    observed_ratios[ratio_name][cell_name]
+                )
+                for cell_name in cell_names
+            }
+            aggregate_draws = aggregate_bootstrap(
+                cell_names,
+                bootstrap_medians[ratio_name],
+                bootstrap_samples,
+            )
+            aggregate_ratios[ratio_name] = {
+                **ratio_summary(
+                    geometric_mean(cell_estimates.values()), aggregate_draws
+                ),
+                "denominator_wins": sum(
+                    estimate > 1.0 for estimate in cell_estimates.values()
+                ),
+                "ties": sum(
+                    estimate == 1.0 for estimate in cell_estimates.values()
+                ),
+                "cell_count": len(cell_names),
+            }
+
+        categories = {}
+        for category in CATEGORY_ORDER:
+            category_cells = [
+                cell_name for cell_name in cell_names
+                if category_for_cell(cell_name) == category
+            ]
+            if not category_cells:
+                categories[category] = {
+                    "cells": [], "cell_count": 0, "ratios": None,
+                }
+                continue
+            category_ratios = {}
+            for ratio_name in RATIOS:
+                estimates = [
+                    statistics.median(
+                        observed_ratios[ratio_name][cell_name]
+                    )
+                    for cell_name in category_cells
+                ]
+                draws = aggregate_bootstrap(
+                    category_cells,
+                    bootstrap_medians[ratio_name],
+                    bootstrap_samples,
+                )
+                category_ratios[ratio_name] = ratio_summary(
+                    geometric_mean(estimates), draws
+                )
+            categories[category] = {
+                "cells": category_cells,
+                "cell_count": len(category_cells),
+                "ratios": category_ratios,
+            }
+
+        lane_analyses.append({
+            "name": lane_name,
+            "metadata": lane_metadata,
+            "rounds": rounds,
+            "cell_count": len(cell_names),
+            "aggregate": {"ratios": aggregate_ratios},
+            "categories": categories,
+            "cells": cell_analyses,
+        })
+
+    result: dict[str, object] = {
+        "schema": 1,
+        "status": "complete",
+        "campaign": str(campaign_path.resolve()),
+        "campaign_sha256": sha256(campaign_path),
+        "campaign_started_utc": campaign.get("started_utc"),
+        "campaign_completed_utc": campaign.get("completed_utc"),
+        "rounds": rounds,
+        "fixed_cells": len(cell_names),
+        "bootstrap": {
+            "samples": bootstrap_samples,
+            "seed": bootstrap_seed,
+            "confidence_level": 0.95,
+            "method": (
+                "independently resample same-round ratios with replacement "
+                "inside each fixed cell; take each cell median; take the "
+                "equal-cell geometric mean"
+            ),
+            "percentile_interpolation": "linear",
+        },
+        "point_estimate": (
+            "median same-round ratio per fixed cell, then equal-cell "
+            "geometric mean"
+        ),
+        "ratio_semantics": {
+            ratio_name: {
+                "numerator": numerator,
+                "denominator": denominator,
+                "greater_than_one_favors": denominator,
+            }
+            for ratio_name, (numerator, denominator) in RATIOS.items()
+        },
+        "category_order": list(CATEGORY_ORDER),
+        "lanes": lane_analyses,
+    }
+    if analyzer_path is not None:
+        result["analyzer"] = str(analyzer_path.resolve())
+        result["analyzer_sha256"] = sha256(analyzer_path)
+    return result
+
+
+def format_ratio(summary: dict[str, object], digits: int = 3) -> str:
+    estimate = summary["estimate"]
+    interval = summary["ci95"]
+    assert isinstance(estimate, float)
+    assert isinstance(interval, dict)
+    return (
+        f"{estimate:.{digits}f} "
+        f"[{interval['lower']:.{digits}f}, {interval['upper']:.{digits}f}]"
+    )
+
+
+def render_markdown(analysis: dict[str, object]) -> str:
+    lines = [
+        "# fzf matched-envelope analysis",
+        "",
+        f"Campaign: `{analysis['campaign']}`",
+        "",
+        f"Campaign SHA-256: `{analysis['campaign_sha256']}`",
+        "",
+        (
+            f"Each cell uses {analysis['rounds']} same-round process ratios. "
+            f"Intervals use {analysis['bootstrap']['samples']:,} deterministic "
+            "bootstrap samples."
+        ),
+        "",
+        "Ratios greater than 1 favor the denominator named in the ratio.",
+        "",
+    ]
+    lanes = analysis["lanes"]
+    assert isinstance(lanes, list)
+    for lane in lanes:
+        assert isinstance(lane, dict)
+        lines.extend((f"## {lane['name']}", "", "### Aggregate", ""))
+        lines.extend((
+            "| Ratio | Estimate and 95% interval | Denominator wins |",
+            "|---|---:|---:|",
+        ))
+        aggregate = lane["aggregate"]
+        assert isinstance(aggregate, dict)
+        aggregate_ratios = aggregate["ratios"]
+        assert isinstance(aggregate_ratios, dict)
+        for ratio_name in RATIOS:
+            summary = aggregate_ratios[ratio_name]
+            lines.append(
+                f"| {ratio_name} | {format_ratio(summary)} | "
+                f"{summary['denominator_wins']}/{summary['cell_count']} |"
+            )
+
+        lines.extend(("", "### Categories", ""))
+        lines.extend((
+            "| Category | Cells | Base/candidate | Fzf/candidate | Fzf/base |",
+            "|---|---:|---:|---:|---:|",
+        ))
+        categories = lane["categories"]
+        assert isinstance(categories, dict)
+        for category in CATEGORY_ORDER:
+            details = categories[category]
+            if details["ratios"] is None:
+                continue
+            ratio_details = details["ratios"]
+            lines.append(
+                f"| {category} | {details['cell_count']} | "
+                f"{format_ratio(ratio_details['base/candidate'])} | "
+                f"{format_ratio(ratio_details['fzf/candidate'])} | "
+                f"{format_ratio(ratio_details['fzf/base'])} |"
+            )
+
+        lines.extend(("", "### Fixed cells", ""))
+        lines.extend((
+            "| Cell | Base ms | Candidate ms | Fzf ms | Base/candidate | "
+            "Fzf/candidate | Fzf/base |",
+            "|---|---:|---:|---:|---:|---:|---:|",
+        ))
+        cell_details = lane["cells"]
+        assert isinstance(cell_details, list)
+        for cell in cell_details:
+            median_ns = cell["median_ns"]
+            ratios = cell["ratios"]
+            lines.append(
+                f"| {cell['name']} | {median_ns['base'] / 1e6:.6f} | "
+                f"{median_ns['candidate'] / 1e6:.6f} | "
+                f"{median_ns['fzf'] / 1e6:.6f} | "
+                f"{ratios['base/candidate']['estimate']:.3f} | "
+                f"{ratios['fzf/candidate']['estimate']:.3f} | "
+                f"{ratios['fzf/base']['estimate']:.3f} |"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def render_tsv(analysis: dict[str, object]) -> str:
+    output = io.StringIO()
+    writer = csv.writer(output, delimiter="\t", lineterminator="\n")
+    writer.writerow((
+        "lane", "profile", "threads", "primary", "cell", "category",
+        "base_median_ns", "candidate_median_ns", "fzf_median_ns",
+        "base_candidate", "base_candidate_ci95_low",
+        "base_candidate_ci95_high", "fzf_candidate",
+        "fzf_candidate_ci95_low", "fzf_candidate_ci95_high", "fzf_base",
+        "fzf_base_ci95_low", "fzf_base_ci95_high",
+    ))
+    lanes = analysis["lanes"]
+    assert isinstance(lanes, list)
+    for lane in lanes:
+        metadata = lane["metadata"]
+        for cell in lane["cells"]:
+            row = [
+                lane["name"], metadata.get("profile"), metadata.get("threads"),
+                metadata.get("primary"), cell["name"], cell["category"],
+                cell["median_ns"]["base"], cell["median_ns"]["candidate"],
+                cell["median_ns"]["fzf"],
+            ]
+            for ratio_name in RATIOS:
+                summary = cell["ratios"][ratio_name]
+                row.extend((
+                    summary["estimate"], summary["ci95"]["lower"],
+                    summary["ci95"]["upper"],
+                ))
+            writer.writerow(row)
+    return output.getvalue()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("campaign", type=pathlib.Path)
+    parser.add_argument(
+        "--output-prefix", type=pathlib.Path,
+        help=(
+            "output path without extension (default: analysis beside campaign)"
+        ),
+    )
+    parser.add_argument(
+        "--bootstrap-samples", type=int, default=DEFAULT_BOOTSTRAP_SAMPLES
+    )
+    parser.add_argument(
+        "--bootstrap-seed",
+        type=lambda value: int(value, 0),
+        default=DEFAULT_BOOTSTRAP_SEED,
+    )
+    arguments = parser.parse_args()
+    campaign_path = arguments.campaign.resolve()
+    campaign = json.loads(campaign_path.read_text(encoding="utf-8"))
+    if not isinstance(campaign, dict):
+        raise ValueError("campaign JSON must contain an object")
+    script_path = pathlib.Path(__file__).resolve()
+    analysis = analyze_campaign(
+        campaign,
+        campaign_path,
+        bootstrap_samples=arguments.bootstrap_samples,
+        bootstrap_seed=arguments.bootstrap_seed,
+        analyzer_path=script_path,
+    )
+
+    prefix = arguments.output_prefix
+    if prefix is None:
+        prefix = campaign_path.with_name("analysis")
+    prefix = prefix.resolve()
+    prefix.parent.mkdir(parents=True, exist_ok=True)
+    outputs = {
+        ".json": json.dumps(analysis, indent=2, ensure_ascii=False) + "\n",
+        ".md": render_markdown(analysis),
+        ".tsv": render_tsv(analysis),
+    }
+    for suffix, contents in outputs.items():
+        prefix.with_suffix(suffix).write_text(contents, encoding="utf-8")
+    print(f"analysis-json {prefix.with_suffix('.json')}")
+    print(f"analysis-markdown {prefix.with_suffix('.md')}")
+    print(f"analysis-tsv {prefix.with_suffix('.tsv')}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(f"fzf envelope analysis: FAIL: {error}", file=sys.stderr)
+        raise

--- a/benchmarks/api-overhead-probe.c
+++ b/benchmarks/api-overhead-probe.c
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+/*
+ * Measure the fixed work around the scorer on deterministic synthetic ASCII
+ * misses.  This is not a corpus benchmark.  It separates the public C-string
+ * entry point from the bounded and preclassified entry points so benchmark
+ * adapters do not accidentally attribute candidate metadata work to the
+ * matching algorithm.
+ */
+
+#include "../fzf.h"
+#include "../fzf-private.h"
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define ITEMS 100000u
+#define SAMPLES 15u
+
+typedef struct {
+  char *text;
+  size_t length;
+} item_t;
+
+typedef enum {
+  API_C_STRING,
+  API_BOUNDED,
+  API_PRECLASSIFIED,
+} api_t;
+
+static volatile uint64_t result_sink;
+
+static uint64_t now_ns(void) {
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) abort();
+  return (uint64_t)ts.tv_sec * UINT64_C(1000000000) + (uint64_t)ts.tv_nsec;
+}
+
+static int compare_u64(const void *left, const void *right) {
+  uint64_t a = *(const uint64_t *)left;
+  uint64_t b = *(const uint64_t *)right;
+  return (a > b) - (a < b);
+}
+
+static item_t *make_items(size_t length, bool progressive) {
+  item_t *items = calloc(ITEMS, sizeof *items);
+  if (!items) abort();
+  static const char alphabet[] = "acgijklmnoqrstuvwxyz0123456789_/";
+  const size_t alphabet_length = sizeof alphabet - 1;
+  for (size_t i = 0; i < ITEMS; i++) {
+    char *text = malloc(length + 1);
+    if (!text) abort();
+    for (size_t j = 0; j < length; j++)
+      text[j] = alphabet[(i * 17 + j * 29) % alphabet_length];
+    if (progressive && length >= 8)
+      memcpy(text + length - 8, "deadbeex", 8);
+    text[length] = '\0';
+    items[i] = (item_t){text, length};
+  }
+  return items;
+}
+
+static uint64_t score_once(api_t api, const item_t *items,
+                           fzf_pattern_t *pattern, fzf_slab_t *slab,
+                           uint64_t *checksum) {
+  uint64_t sum = 0;
+  uint64_t start = now_ns();
+  for (size_t i = 0; i < ITEMS; i++) {
+    int32_t score;
+    if (api == API_C_STRING)
+      score = fzf_get_score(items[i].text, pattern, slab);
+    else if (api == API_BOUNDED)
+      score = fzf_get_score_bytes(
+          items[i].text, items[i].length, pattern, slab);
+    else
+      score = fzf_get_score_bytes_preclassified(
+          items[i].text, items[i].length, true, pattern, slab);
+    if (fzf_allocation_failed()) abort();
+    sum = sum * UINT64_C(0x9e3779b185ebca87) + (uint32_t)score + i;
+  }
+  uint64_t elapsed = now_ns() - start;
+  result_sink ^= sum;
+  *checksum = sum;
+  return elapsed;
+}
+
+static void print_api(const char *shape, api_t api,
+                      uint64_t samples[SAMPLES], uint64_t checksum) {
+  static const char *names[] = {"c-string", "bounded", "preclassified"};
+  printf("%-12s %-13s %8.3f ms %7.2f ns/item checksum=%016" PRIx64 "\n",
+         shape, names[api], (double)samples[SAMPLES / 2] / 1e6,
+         (double)samples[SAMPLES / 2] / ITEMS, checksum);
+}
+
+static void run_shape(const char *shape, size_t length, bool progressive) {
+  item_t *items = make_items(length, progressive);
+  char query[] = "deadbeef";
+  fzf_pattern_t *pattern = fzf_parse_pattern(CaseIgnore, false, query, true);
+  fzf_slab_t *slab = fzf_make_default_slab();
+  if (!pattern || !slab) abort();
+
+  uint64_t expected_checksum = 0;
+  (void)score_once(
+      API_PRECLASSIFIED, items, pattern, slab, &expected_checksum);
+
+  uint64_t samples[3][SAMPLES];
+  uint64_t checksums[3] = {0};
+  for (api_t api = API_C_STRING; api <= API_PRECLASSIFIED; api++) {
+    for (size_t warmup = 0; warmup < 3; warmup++)
+      (void)score_once(api, items, pattern, slab, &checksums[api]);
+    if (checksums[api] != expected_checksum) abort();
+  }
+  /* Rotate the order on every sample to reduce frequency and temperature
+     drift between the three API paths. */
+  for (size_t sample = 0; sample < SAMPLES; sample++) {
+    for (size_t offset = 0; offset < 3; offset++) {
+      api_t api = (api_t)((sample + offset) % 3);
+      samples[api][sample] = score_once(
+          api, items, pattern, slab, &checksums[api]);
+      if (checksums[api] != expected_checksum) abort();
+    }
+  }
+  for (api_t api = API_C_STRING; api <= API_PRECLASSIFIED; api++) {
+    qsort(samples[api], SAMPLES, sizeof samples[api][0], compare_u64);
+    print_api(shape, api, samples[api], checksums[api]);
+  }
+
+  fzf_free_slab(slab);
+  fzf_free_pattern(pattern);
+  for (size_t i = 0; i < ITEMS; i++) free(items[i].text);
+  free(items);
+}
+
+int main(void) {
+  run_shape("early-32", 32, false);
+  run_shape("late-32", 32, true);
+  run_shape("early-128", 128, false);
+  run_shape("late-128", 128, true);
+  return 0;
+}

--- a/benchmarks/build-native-fzf-bench.py
+++ b/benchmarks/build-native-fzf-bench.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Build one native scan benchmark and record its exact inputs."""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+
+
+BUILD_OPTIONS = [
+    "-std=gnu11", "-Wall", "-Wextra", "-O3", "-DNDEBUG", "-pthread",
+]
+
+PRODUCT_SOURCES = [
+    "fzf.c",
+    "fzf.h",
+    "fzf-private.h",
+    "fzf-simd-prefilter.h",
+    "fzf-normalize.inc",
+    "fzf-score-input.inc",
+    "utf8_char_index.h",
+    "utf8proc-2.10.0/utf8proc.c",
+    "utf8proc-2.10.0/utf8proc.h",
+    "utf8proc-2.10.0/utf8proc_data.c",
+]
+
+
+def utc_now() -> str:
+    return datetime.datetime.now(
+        datetime.timezone.utc
+    ).isoformat().replace("+00:00", "Z")
+
+
+def sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def output(argv: list[str], **kwargs: object) -> str:
+    return subprocess.check_output(argv, text=True, **kwargs).strip()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=pathlib.Path, required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument("--provenance", type=pathlib.Path, required=True)
+    parser.add_argument("--cc", default="cc")
+    parser.add_argument(
+        "--driver",
+        type=pathlib.Path,
+        default=pathlib.Path(__file__).with_name("fzf-bench-driver.c"),
+    )
+    arguments = parser.parse_args()
+
+    source = arguments.source.resolve()
+    binary = arguments.output.resolve()
+    provenance_path = arguments.provenance.resolve()
+    driver = arguments.driver.resolve()
+    compiler = pathlib.Path(
+        shutil.which(arguments.cc) or arguments.cc
+    ).resolve()
+    compiler_hash = sha256(compiler)
+
+    source_commit = output(["git", "-C", str(source), "rev-parse", "HEAD"])
+    source_tree = output([
+        "git", "-C", str(source), "rev-parse", "HEAD^{tree}",
+    ])
+    if output(["git", "-C", str(source), "status", "--porcelain"]):
+        raise RuntimeError("native product source is not clean")
+
+    driver_root = pathlib.Path(output([
+        "git", "-C", str(driver.parent), "rev-parse", "--show-toplevel",
+    ]))
+    driver_relative = driver.relative_to(driver_root)
+    driver_commit = output([
+        "git", "-C", str(driver_root), "rev-parse", "HEAD",
+    ])
+    driver_tree = output([
+        "git", "-C", str(driver_root), "rev-parse", "HEAD^{tree}",
+    ])
+    if output([
+        "git", "-C", str(driver_root), "status", "--porcelain", "--",
+        str(driver_relative),
+    ]):
+        raise RuntimeError("benchmark driver is not clean")
+
+    product_paths = {name: source / name for name in PRODUCT_SOURCES}
+    missing = [name for name, path in product_paths.items() if not path.is_file()]
+    if missing:
+        raise RuntimeError(f"missing native product sources: {', '.join(missing)}")
+    product_hashes = {
+        name: sha256(path) for name, path in product_paths.items()
+    }
+    driver_hash = sha256(driver)
+
+    build_environment = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", ""),
+        "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
+        "LC_ALL": "C",
+        "LANG": "C",
+        "TZ": "UTC",
+    }
+    compiler_version = subprocess.run(
+        [str(compiler), "--version"], capture_output=True, text=True,
+        env=build_environment, check=True,
+    )
+
+    binary.parent.mkdir(parents=True, exist_ok=True)
+    provenance_path.parent.mkdir(parents=True, exist_ok=True)
+    build_argv = [
+        str(compiler), *BUILD_OPTIONS,
+        f"-I{source}", f"-I{source / 'utf8proc-2.10.0'}",
+        "-o", str(binary), str(driver), str(source / "fzf.c"),
+        str(source / "utf8proc-2.10.0/utf8proc.c"),
+    ]
+    completed = subprocess.run(
+        build_argv, capture_output=True, text=True,
+        env=build_environment, check=True,
+    )
+
+    if sha256(driver) != driver_hash or {
+        name: sha256(path) for name, path in product_paths.items()
+    } != product_hashes:
+        raise RuntimeError("native benchmark source changed during the build")
+    if output(["git", "-C", str(source), "rev-parse", "HEAD"]) != source_commit:
+        raise RuntimeError("native product revision changed during the build")
+    if output(["git", "-C", str(source), "status", "--porcelain"]):
+        raise RuntimeError("native product source changed during the build")
+    if sha256(compiler) != compiler_hash:
+        raise RuntimeError("compiler changed during the build")
+
+    provenance = {
+        "schema": 1,
+        "kind": "fzf-native-scan-benchmark-build",
+        "recorded_utc": utc_now(),
+        "source": str(source),
+        "source_commit": source_commit,
+        "source_tree": source_tree,
+        "source_status": "clean",
+        "product_source_sha256": product_hashes,
+        "driver": str(driver),
+        "driver_commit": driver_commit,
+        "driver_tree": driver_tree,
+        "driver_source_sha256": driver_hash,
+        "compiler": str(compiler),
+        "compiler_sha256": compiler_hash,
+        "compiler_version_argv": [str(compiler), "--version"],
+        "compiler_version_stdout": compiler_version.stdout,
+        "compiler_version_stderr": compiler_version.stderr,
+        "build_options": BUILD_OPTIONS,
+        "build_cwd": str(pathlib.Path.cwd()),
+        "build_argv": build_argv,
+        "build_environment": build_environment,
+        "build_stdout": completed.stdout,
+        "build_stderr": completed.stderr,
+        "binary": str(binary),
+        "binary_sha256": sha256(binary),
+    }
+    provenance_path.write_text(
+        json.dumps(provenance, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/build-pinned-fzf-bench.py
+++ b/benchmarks/build-pinned-fzf-bench.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Build the pinned fzf benchmark subject and record the exact build."""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+
+
+PINNED_FZF_COMMIT = "63e82a9e3dd52cc67a46db842b8a29e0c1f83229"
+
+
+def sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def output(argv: list[str], **kwargs: object) -> str:
+    return subprocess.check_output(argv, text=True, **kwargs).strip()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fzf-source", type=pathlib.Path, required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument("--provenance", type=pathlib.Path, required=True)
+    parser.add_argument("--go", default="go")
+    arguments = parser.parse_args()
+
+    source = arguments.fzf_source.resolve()
+    binary = arguments.output.resolve()
+    provenance_path = arguments.provenance.resolve()
+    go = pathlib.Path(shutil.which(arguments.go) or arguments.go).resolve()
+    patch = pathlib.Path(__file__).with_name("fzf-bench-json.patch").resolve()
+
+    revision = output(["git", "-C", str(source), "rev-parse", "HEAD"])
+    if revision != PINNED_FZF_COMMIT:
+        raise RuntimeError(
+            f"fzf source is {revision}, expected {PINNED_FZF_COMMIT}"
+        )
+    if output(["git", "-C", str(source), "status", "--porcelain"]):
+        raise RuntimeError("fzf source is not clean")
+
+    query_keys = [
+        "GOOS", "GOARCH", "CGO_ENABLED", "GOCACHE", "GOMODCACHE", "GOPATH",
+        "GOPROXY", "GOSUMDB", "GONOSUMDB", "GOPRIVATE", "GONOPROXY",
+        "GOENV", "GOFLAGS", "GOTOOLCHAIN", "GOWORK", "GOVERSION",
+    ]
+    host_go = json.loads(output([str(go), "env", "-json", *query_keys]))
+    build_environment = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", ""),
+        "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
+        "CGO_ENABLED": "0",
+        "GOOS": host_go["GOOS"],
+        "GOARCH": host_go["GOARCH"],
+        "GOCACHE": host_go["GOCACHE"],
+        "GOMODCACHE": host_go["GOMODCACHE"],
+        "GOPATH": host_go["GOPATH"],
+        "GOPROXY": host_go["GOPROXY"],
+        "GOSUMDB": host_go["GOSUMDB"],
+        "GONOSUMDB": host_go["GONOSUMDB"],
+        "GOPRIVATE": host_go["GOPRIVATE"],
+        "GONOPROXY": host_go["GONOPROXY"],
+        "GOENV": "off",
+        "GOFLAGS": "",
+        "GOTOOLCHAIN": "local",
+        "GOWORK": "off",
+    }
+
+    binary.parent.mkdir(parents=True, exist_ok=True)
+    provenance_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="fzf-bench-build-") as directory:
+        checkout = pathlib.Path(directory) / "fzf"
+        build_cwd = str(checkout)
+        subprocess.run(
+            ["git", "-C", str(source), "worktree", "add", "--detach",
+             str(checkout), PINNED_FZF_COMMIT],
+            check=True,
+        )
+        try:
+            subprocess.run(
+                ["git", "-C", str(checkout), "apply", str(patch)],
+                check=True,
+            )
+            build_argv = [
+                str(go), "build", "-trimpath", "-buildvcs=false",
+                "-o", str(binary), ".",
+            ]
+            subprocess.run(
+                build_argv, cwd=checkout, env=build_environment, check=True
+            )
+            effective_go = json.loads(output(
+                [str(go), "env", "-json", *query_keys],
+                cwd=checkout,
+                env=build_environment,
+            ))
+            patched_core_sha256 = sha256(checkout / "src/core.go")
+        finally:
+            subprocess.run(
+                ["git", "-C", str(source), "worktree", "remove", "--force",
+                 str(checkout)],
+                check=True,
+            )
+
+    build_info = output([str(go), "version", "-m", str(binary)])
+    provenance = {
+        "schema": 1,
+        "recorded_utc": datetime.datetime.now(
+            datetime.timezone.utc
+        ).isoformat().replace("+00:00", "Z"),
+        "fzf_commit": revision,
+        "fzf_tree": output(
+            ["git", "-C", str(source), "rev-parse", "HEAD^{tree}"]
+        ),
+        "patch": str(patch),
+        "patch_sha256": sha256(patch),
+        "patched_core_sha256": patched_core_sha256,
+        "build_cwd": build_cwd,
+        "cwd_kind": "temporary detached worktree at the pinned commit",
+        "build_argv": build_argv,
+        "build_environment": build_environment,
+        "effective_go_environment": effective_go,
+        "binary": str(binary),
+        "binary_sha256": sha256(binary),
+        "go_version_m": build_info.splitlines(),
+    }
+    provenance_path.write_text(
+        json.dumps(provenance, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/build-pinned-fzf-bench.py
+++ b/benchmarks/build-pinned-fzf-bench.py
@@ -42,6 +42,8 @@ def main() -> None:
     provenance_path = arguments.provenance.resolve()
     go = pathlib.Path(shutil.which(arguments.go) or arguments.go).resolve()
     patch = pathlib.Path(__file__).with_name("fzf-bench-json.patch").resolve()
+    patch_bytes = patch.read_bytes()
+    patch_sha256 = hashlib.sha256(patch_bytes).hexdigest()
 
     revision = output(["git", "-C", str(source), "rev-parse", "HEAD"])
     if revision != PINNED_FZF_COMMIT:
@@ -50,6 +52,10 @@ def main() -> None:
         )
     if output(["git", "-C", str(source), "status", "--porcelain"]):
         raise RuntimeError("fzf source is not clean")
+    pinned_tree = output([
+        "git", "-C", str(source), "rev-parse",
+        f"{PINNED_FZF_COMMIT}^{{tree}}",
+    ])
 
     query_keys = [
         "GOOS", "GOARCH", "CGO_ENABLED", "GOCACHE", "GOMODCACHE", "GOPATH",
@@ -82,6 +88,8 @@ def main() -> None:
     provenance_path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="fzf-bench-build-") as directory:
         checkout = pathlib.Path(directory) / "fzf"
+        frozen_patch = pathlib.Path(directory) / "fzf-bench-json.patch"
+        frozen_patch.write_bytes(patch_bytes)
         build_cwd = str(checkout)
         subprocess.run(
             ["git", "-C", str(source), "worktree", "add", "--detach",
@@ -90,7 +98,7 @@ def main() -> None:
         )
         try:
             subprocess.run(
-                ["git", "-C", str(checkout), "apply", str(patch)],
+                ["git", "-C", str(checkout), "apply", str(frozen_patch)],
                 check=True,
             )
             build_argv = [
@@ -120,11 +128,9 @@ def main() -> None:
             datetime.timezone.utc
         ).isoformat().replace("+00:00", "Z"),
         "fzf_commit": revision,
-        "fzf_tree": output(
-            ["git", "-C", str(source), "rev-parse", "HEAD^{tree}"]
-        ),
+        "fzf_tree": pinned_tree,
         "patch": str(patch),
-        "patch_sha256": sha256(patch),
+        "patch_sha256": patch_sha256,
         "patched_core_sha256": patched_core_sha256,
         "build_cwd": build_cwd,
         "cwd_kind": "temporary detached worktree at the pinned commit",

--- a/benchmarks/check-fzf-semantic-parity.py
+++ b/benchmarks/check-fzf-semantic-parity.py
@@ -17,7 +17,7 @@ PINNED_FZF_COMMIT = "63e82a9e3dd52cc67a46db842b8a29e0c1f83229"
 def cases():
     fallback_long = "a" + "x" * 60_000 + "b c"
     fallback_short = "za" + "x" * 60 + "b" + "x" * 20 + "c"
-    return [
+    literal_cases = [
         {
             "id": "duplicates-and-score-ties",
             "query": "abc",
@@ -123,6 +123,55 @@ def cases():
         },
     ]
 
+    default_cases = [
+        case for case in literal_cases
+        if case["id"] == "normalization-enabled"
+    ]
+    literal_cases = [
+        case for case in literal_cases
+        if case["id"] != "normalization-enabled"
+    ]
+    for case in literal_cases:
+        case["profile"] = "literal-score-index"
+    for case in default_cases:
+        case["profile"] = "default-score-length"
+
+    default_cases.extend([
+        {
+            "id": "default-unicode-whitespace-and-length",
+            "profile": "default-score-length",
+            "query": "needle",
+            "normalize": True,
+            "candidates": [
+                "needle", "needle-long", "\u3000needle\u00a0",
+                "\u2003needle-long\u202f", " needle ", "needle",
+                "xxneedle", "does not match",
+            ],
+        },
+        {
+            "id": "default-v2-to-v1-fallback-negative-raw-score",
+            "profile": "default-score-length",
+            "query": "ab c",
+            "normalize": True,
+            "candidates": [fallback_long, fallback_short, "does not match"],
+        },
+        {
+            "id": "default-eight-worker-order",
+            "profile": "default-score-length",
+            "query": "needle",
+            "normalize": True,
+            "candidates": [
+                (
+                    "needle", "needle-long", "\u3000needle\u00a0",
+                    "\u2003needle-long\u202f", " needle ", "needle",
+                    "xxneedle", "prefix-needle",
+                )[index % 8]
+                for index in range(8_201)
+            ],
+        },
+    ])
+    return literal_cases + default_cases
+
 
 def run(command, *, cwd=None, env=None, input_bytes=None):
     completed = subprocess.run(
@@ -206,13 +255,17 @@ def parse_native_record(line):
     }
 
 
-def run_native_oracle(binary, oracle_case):
+def run_native_oracle(binary, oracle_case, threads):
     command = [
         str(binary), f"--filter={oracle_case['query']}",
-        "--tiebreak=index", "--threads=1", "--algo=v2", "--sort",
+        f"--threads={threads}", "--algo=v2", "--sort",
         "--no-literal" if oracle_case["normalize"] else "--literal",
         "--dump-semantic",
     ]
+    if oracle_case["profile"] == "literal-score-index":
+        command.append("--tiebreak=index")
+    elif oracle_case["profile"] != "default-score-length":
+        raise RuntimeError(f"unknown profile: {oracle_case['profile']}")
     corpus = "".join(candidate + "\n" for candidate in oracle_case["candidates"])
     stdout = run(command, input_bytes=corpus.encode("utf-8"))
     return [
@@ -227,23 +280,53 @@ def compare(native_binary, payload, upstream):
     failures = []
     for oracle_case in payload["cases"]:
         case_id = oracle_case["id"]
-        native = run_native_oracle(native_binary, oracle_case)
         expected = upstream_by_id.get(case_id)
-        if native != expected:
-            expected_text = json.dumps(expected, indent=2, sort_keys=True).splitlines()
-            native_text = json.dumps(native, indent=2, sort_keys=True).splitlines()
-            failures.append("\n".join(difflib.unified_diff(
-                expected_text, native_text,
-                fromfile=f"upstream/{case_id}",
-                tofile=f"native/{case_id}",
-                lineterm="",
-            )))
-        else:
-            print(f"semantic parity {case_id}: {len(native)} matches")
+        for threads in (1, 8):
+            native = run_native_oracle(native_binary, oracle_case, threads)
+            if native != expected:
+                expected_text = json.dumps(
+                    expected, indent=2, sort_keys=True).splitlines()
+                native_text = json.dumps(
+                    native, indent=2, sort_keys=True).splitlines()
+                failures.append("\n".join(difflib.unified_diff(
+                    expected_text, native_text,
+                    fromfile=f"upstream/{case_id}",
+                    tofile=f"native/{case_id}/threads-{threads}",
+                    lineterm="",
+                )))
+            else:
+                print(
+                    f"semantic parity {case_id} threads={threads}: "
+                    f"{len(native)} matches"
+                )
 
-    fallback = upstream_by_id["v2-to-v1-fallback-negative-raw-score"]
-    if not any(record["raw_score"] < 0 for record in fallback):
-        failures.append("fallback fixture did not produce a negative raw score")
+    for fallback_id in (
+        "v2-to-v1-fallback-negative-raw-score",
+        "default-v2-to-v1-fallback-negative-raw-score",
+    ):
+        fallback = upstream_by_id[fallback_id]
+        if not any(record["raw_score"] < 0 for record in fallback):
+            failures.append(
+                f"{fallback_id} did not produce a negative raw score"
+            )
+
+    length_records = upstream_by_id["default-unicode-whitespace-and-length"]
+    scores_to_lengths = {}
+    for record in length_records:
+        scores_to_lengths.setdefault(record["raw_score"], set()).add(
+            record["points"][2]
+        )
+    if not any(len(lengths) > 1 for lengths in scores_to_lengths.values()):
+        failures.append(
+            "length fixture lacks an equal-score pair with distinct lengths"
+        )
+
+    large_case = next(
+        case for case in payload["cases"]
+        if case["id"] == "default-eight-worker-order"
+    )
+    if len(large_case["candidates"]) < 8_193:
+        failures.append("eight-worker fixture does not span nine chunks")
     if failures:
         raise RuntimeError("semantic parity failed:\n" + "\n\n".join(failures))
 

--- a/benchmarks/check-fzf-semantic-parity.py
+++ b/benchmarks/check-fzf-semantic-parity.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Compare the benchmark adapter with a pinned upstream fzf semantic oracle."""
+
+import argparse
+import difflib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+PINNED_FZF_COMMIT = "63e82a9e3dd52cc67a46db842b8a29e0c1f83229"
+
+
+def cases():
+    fallback_long = "a" + "x" * 60_000 + "b c"
+    fallback_short = "za" + "x" * 60 + "b" + "x" * 20 + "c"
+    return [
+        {
+            "id": "duplicates-and-score-ties",
+            "query": "abc",
+            "normalize": False,
+            "candidates": [
+                "abc", "abc", "a-b-c", "ABC", "zabc", "abbc",
+                "nope", "abc",
+            ],
+        },
+        {
+            "id": "compound-and-inverse",
+            "query": "foo !bar",
+            "normalize": False,
+            "candidates": [
+                "foo", "foo bar", "xxfooz", "bar foo", "FOO", "baz",
+                "a foo value", "a foo value",
+            ],
+        },
+        {
+            "id": "or-terms",
+            "query": "foo | baz",
+            "normalize": False,
+            "candidates": [
+                "foo", "baz", "food", "embaz", "neither", "foo baz",
+                "baz", "FOO",
+            ],
+        },
+        {
+            "id": "exact-term",
+            "query": "'foo",
+            "normalize": False,
+            "candidates": ["foo", "xxfooz", "f-o-o", "FOO", "bar", "foo"],
+        },
+        {
+            "id": "prefix-term",
+            "query": "^foo",
+            "normalize": False,
+            "candidates": ["foo", "foobar", "afoo", "FOO", " foo", "foo"],
+        },
+        {
+            "id": "suffix-term",
+            "query": "bar$",
+            "normalize": False,
+            "candidates": ["bar", "foobar", "barx", "BAR", "bar ", "bar"],
+        },
+        {
+            "id": "equal-term",
+            "query": "^whole$",
+            "normalize": False,
+            "candidates": ["whole", "wholex", "xwhole", "WHOLE", "whole"],
+        },
+        {
+            "id": "exact-boundary-term",
+            "query": "'word'",
+            "normalize": False,
+            "candidates": [
+                "word", "a word", "sword", "word-boundary", "WORD", "word",
+            ],
+        },
+        {
+            "id": "normalization-enabled",
+            "query": "cafe",
+            "normalize": True,
+            "candidates": ["cafe", "café", "CAFÉ", "cafeteria", "caff", "café"],
+        },
+        {
+            "id": "normalization-disabled",
+            "query": "cafe",
+            "normalize": False,
+            "candidates": ["cafe", "café", "CAFÉ", "cafeteria", "caff", "café"],
+        },
+        {
+            "id": "case-smart-respect",
+            "query": "Foo",
+            "normalize": False,
+            "candidates": ["Foo", "foo", "xFoo", "FOO", "Foo", "food"],
+        },
+        {
+            "id": "unicode-case-ignore",
+            "query": "ång",
+            "normalize": False,
+            "candidates": ["ångström", "Ångström", "xång", "ang", "ång"],
+        },
+        {
+            "id": "unicode-other-letter-score-rows",
+            "query": "中文",
+            "normalize": False,
+            "candidates": [
+                "中文", "中-文", "前中文", "中文字", "文中", "中文",
+            ],
+        },
+        {
+            "id": "inverse-only",
+            "query": "!drop",
+            "normalize": False,
+            "candidates": ["keep", "drop", "also keep", "DROP", "keep"],
+        },
+        {
+            "id": "v2-to-v1-fallback-negative-raw-score",
+            "query": "ab c",
+            "normalize": False,
+            "candidates": [fallback_long, fallback_short, "does not match"],
+        },
+    ]
+
+
+def run(command, *, cwd=None, env=None, input_bytes=None):
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        input=input_bytes,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"command failed ({completed.returncode}): {command!r}\n"
+            f"stdout:\n{completed.stdout.decode(errors='replace')}\n"
+            f"stderr:\n{completed.stderr.decode(errors='replace')}"
+        )
+    return completed.stdout
+
+
+def require_pinned_source(source):
+    if not (source / "go.mod").is_file() or not (source / "src").is_dir():
+        raise RuntimeError(f"not an fzf source tree: {source}")
+    commit = run(["git", "rev-parse", "HEAD"], cwd=source).decode().strip()
+    if commit != PINNED_FZF_COMMIT:
+        raise RuntimeError(
+            f"FZF_SOURCE must be pinned to {PINNED_FZF_COMMIT}; got {commit}"
+        )
+    status = run(
+        ["git", "status", "--porcelain", "--untracked-files=all"],
+        cwd=source,
+    ).decode()
+    if status:
+        raise RuntimeError("FZF_SOURCE must be clean; git status was:\n" + status)
+
+
+def run_upstream_oracle(source, helper, payload, temporary):
+    input_path = temporary / "cases.json"
+    output_path = temporary / "upstream.json"
+    overlay_path = temporary / "overlay.json"
+    go_cache = temporary / "go-cache"
+    go_tmp = temporary / "go-tmp"
+    go_cache.mkdir()
+    go_tmp.mkdir()
+    input_path.write_text(json.dumps(payload, ensure_ascii=False) + "\n")
+    injected_path = (source / "src" / "fzf_native_semantic_oracle_test.go").resolve()
+    overlay_path.write_text(json.dumps({
+        "Replace": {str(injected_path): str(helper.resolve())}
+    }) + "\n")
+
+    environment = os.environ.copy()
+    environment.update({
+        "FZF_SEMANTIC_ORACLE_INPUT": str(input_path),
+        "FZF_SEMANTIC_ORACLE_OUTPUT": str(output_path),
+        "GOPROXY": "off",
+        "GOSUMDB": "off",
+        "GOTOOLCHAIN": "local",
+        "GOCACHE": str(go_cache),
+        "GOTMPDIR": str(go_tmp),
+    })
+    run([
+        "go", "test", "-overlay", str(overlay_path), "./src",
+        "-run", "^TestFzfNativeSemanticOracle$", "-count=1",
+    ], cwd=source, env=environment)
+    return json.loads(output_path.read_text())
+
+
+def parse_native_record(line):
+    fields = line.split("\t")
+    if len(fields) != 11:
+        raise RuntimeError(f"bad native semantic record: {line!r}")
+    values = [int(value) for value in fields]
+    return {
+        "index": values[0],
+        "raw_score": values[1],
+        "min_begin": values[2],
+        "min_end": values[3],
+        "max_end": values[4],
+        "bounds_valid": bool(values[5]),
+        "rank_score": values[6],
+        "points": values[7:11],
+    }
+
+
+def run_native_oracle(binary, oracle_case):
+    command = [
+        str(binary), f"--filter={oracle_case['query']}",
+        "--tiebreak=index", "--threads=1", "--algo=v2", "--sort",
+        "--no-literal" if oracle_case["normalize"] else "--literal",
+        "--dump-semantic",
+    ]
+    corpus = "".join(candidate + "\n" for candidate in oracle_case["candidates"])
+    stdout = run(command, input_bytes=corpus.encode("utf-8"))
+    return [
+        parse_native_record(line)
+        for line in stdout.decode().splitlines()
+        if line
+    ]
+
+
+def compare(native_binary, payload, upstream):
+    upstream_by_id = {case["id"]: case["records"] for case in upstream["cases"]}
+    failures = []
+    for oracle_case in payload["cases"]:
+        case_id = oracle_case["id"]
+        native = run_native_oracle(native_binary, oracle_case)
+        expected = upstream_by_id.get(case_id)
+        if native != expected:
+            expected_text = json.dumps(expected, indent=2, sort_keys=True).splitlines()
+            native_text = json.dumps(native, indent=2, sort_keys=True).splitlines()
+            failures.append("\n".join(difflib.unified_diff(
+                expected_text, native_text,
+                fromfile=f"upstream/{case_id}",
+                tofile=f"native/{case_id}",
+                lineterm="",
+            )))
+        else:
+            print(f"semantic parity {case_id}: {len(native)} matches")
+
+    fallback = upstream_by_id["v2-to-v1-fallback-negative-raw-score"]
+    if not any(record["raw_score"] < 0 for record in fallback):
+        failures.append("fallback fixture did not produce a negative raw score")
+    if failures:
+        raise RuntimeError("semantic parity failed:\n" + "\n\n".join(failures))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fzf-source", required=True, type=Path)
+    parser.add_argument("--native-driver", required=True, type=Path)
+    arguments = parser.parse_args()
+
+    source = arguments.fzf_source.resolve()
+    native_binary = arguments.native_driver.resolve()
+    helper = Path(__file__).with_name("fzf-upstream-semantic-oracle_test.go")
+    require_pinned_source(source)
+    if not native_binary.is_file():
+        raise RuntimeError(f"native driver does not exist: {native_binary}")
+
+    payload = {"cases": cases()}
+    with tempfile.TemporaryDirectory(prefix="fzf-semantic-parity-") as directory:
+        upstream = run_upstream_oracle(source, helper, payload, Path(directory))
+    compare(native_binary, payload, upstream)
+    print(
+        f"semantic parity: {len(payload['cases'])} cases agree with "
+        f"fzf {PINNED_FZF_COMMIT}"
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(f"semantic parity: FAIL: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/benchmarks/check-fzf-semantic-parity.py
+++ b/benchmarks/check-fzf-semantic-parity.py
@@ -170,7 +170,54 @@ def cases():
             ],
         },
     ])
-    return literal_cases + default_cases
+    path_cases = [
+        {
+            "id": "path-backtracked-fuzzy-begin",
+            "profile": "path-score-pathname-length",
+            "query": "alpha",
+            "normalize": True,
+            "candidates": [
+                "beta alpha", "FOO alpha", "dir/x alpha",
+                "dir/yz alpha", "does not match",
+            ],
+        },
+        {
+            "id": "path-unicode-rune-distance",
+            "profile": "path-score-pathname-length",
+            "query": "alpha",
+            "normalize": True,
+            "candidates": [
+                "目录/x alpha", "目录/yz alpha", "目录/alpha",
+                "other alpha", "does not match",
+            ],
+        },
+        {
+            "id": "path-compound-and-or",
+            "profile": "path-score-pathname-length",
+            "query": "'alpha | 'omega 'beta",
+            "normalize": True,
+            "candidates": [
+                "dir/x omega beta", "dir/yz omega beta",
+                "dir/x alpha beta", "omega only", "does not match",
+            ],
+        },
+        {
+            "id": "path-eight-worker-merge",
+            "profile": "path-score-pathname-length",
+            "query": "alpha",
+            "normalize": True,
+            # The longer candidate has the better pathname point.  Repeating
+            # this pair across nine chunks makes the final merge compare that
+            # criterion across independently sorted worker lists.
+            "candidates": [
+                ("beta alpha", "long-directory/FOO alpha")[index % 2]
+                for index in range(8_201)
+            ],
+        },
+    ]
+    # The injected fzf oracle changes process-global scoring tables.  Keep all
+    # path cases last so it never has to switch back from path to default.
+    return literal_cases + default_cases + path_cases
 
 
 def run(command, *, cwd=None, env=None, input_bytes=None):
@@ -264,6 +311,8 @@ def run_native_oracle(binary, oracle_case, threads):
     ]
     if oracle_case["profile"] == "literal-score-index":
         command.append("--tiebreak=index")
+    elif oracle_case["profile"] == "path-score-pathname-length":
+        command.append("--scheme=path")
     elif oracle_case["profile"] != "default-score-length":
         raise RuntimeError(f"unknown profile: {oracle_case['profile']}")
     corpus = "".join(candidate + "\n" for candidate in oracle_case["candidates"])
@@ -327,6 +376,12 @@ def compare(native_binary, payload, upstream):
     )
     if len(large_case["candidates"]) < 8_193:
         failures.append("eight-worker fixture does not span nine chunks")
+    large_path_case = next(
+        case for case in payload["cases"]
+        if case["id"] == "path-eight-worker-merge"
+    )
+    if len(large_path_case["candidates"]) < 8_193:
+        failures.append("path worker-merge fixture does not span nine chunks")
     if failures:
         raise RuntimeError("semantic parity failed:\n" + "\n\n".join(failures))
 

--- a/benchmarks/first-query-probe.c
+++ b/benchmarks/first-query-probe.c
@@ -111,15 +111,11 @@ static bool first_query_append_candidate(AsyncSession *session,
 
 static AsyncSession *first_query_create_session(size_t candidate_count,
                                                 FirstQueryCorpus corpus) {
-  /* Reuse the benchmark's complete session initializer, then remove its
-     private pool before starting the coordinator.  Production sessions also
-     begin with worker_pool == NULL and acquire the process-wide pool. */
-  AsyncSession *session = bench_session_create(1);
+  /* Production sessions begin with worker_pool == NULL.  Do not create and
+     destroy a private pool here: that would warm pthread and allocator state
+     before the supposedly cold first request creates the process-wide pool. */
+  AsyncSession *session = bench_session_create(0);
   if (!session) return NULL;
-  struct AsyncWorkerPool *private_pool = atomic_exchange_explicit(
-      &session->worker_pool, NULL, memory_order_acq_rel);
-  session->worker_pool_owned = false;
-  async_worker_pool_destroy(private_pool);
 
   if (!bench_start_coordinator(session)) {
     async_session_destroy(session);

--- a/benchmarks/first-query-probe.c
+++ b/benchmarks/first-query-probe.c
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MIT
+/*
+ * Single-process cold first-query probe for the persistent session.
+ *
+ * Run this executable once per sample: the process-wide worker pool is meant
+ * to be uninitialized when the coordinator starts.  Corpus construction is
+ * outside the timed interval, matching interactive sessions that receive
+ * their first query after the producer has populated the candidate pool.
+ */
+
+#define main fzf_native_embedded_session_growth_benchmark_main
+#include "../etc/session-growth-benchmark.c"
+#undef main
+
+typedef enum {
+  FirstQueryAscii,
+  FirstQueryArabic,
+  FirstQueryKorean,
+} FirstQueryCorpus;
+
+static bool first_query_append_candidate(AsyncSession *session,
+                                         AsyncLineDecoder *line,
+                                         size_t ordinal,
+                                         FirstQueryCorpus corpus) {
+  char candidate[160];
+  int length;
+  if (corpus == FirstQueryArabic) {
+    switch (ordinal % 4) {
+      case 0:
+        length = snprintf(candidate, sizeof candidate,
+                          "workspace/إنشاء/ملف_%08zu.txt", ordinal);
+        break;
+      case 1:
+        length = snprintf(candidate, sizeof candidate,
+                          "workspace/مشروع/اختبار_%08zu.c", ordinal);
+        break;
+      case 2:
+        length = snprintf(candidate, sizeof candidate,
+                          "workspace/مكتبة/بيانات_%08zu.el", ordinal);
+        break;
+      default:
+        length = snprintf(candidate, sizeof candidate,
+                          "misc/عنصر_%08zu_payload.bin", ordinal);
+        break;
+    }
+    return length > 0 && (size_t)length < sizeof candidate &&
+           async_line_feed_bytes(session, line, candidate, (size_t)length) &&
+           async_line_finish(session, line);
+  }
+  if (corpus == FirstQueryKorean) {
+    switch (ordinal % 4) {
+      case 0:
+        length = snprintf(candidate, sizeof candidate,
+                          "workspace/프로젝트/합니다_%08zu.txt", ordinal);
+        break;
+      case 1:
+        length = snprintf(candidate, sizeof candidate,
+                          "workspace/소스/테스트_%08zu.c", ordinal);
+        break;
+      case 2:
+        length = snprintf(candidate, sizeof candidate,
+                          "workspace/라이브러리/데이터_%08zu.el", ordinal);
+        break;
+      default:
+        length = snprintf(candidate, sizeof candidate,
+                          "misc/항목_%08zu_payload.bin", ordinal);
+        break;
+    }
+    return length > 0 && (size_t)length < sizeof candidate &&
+           async_line_feed_bytes(session, line, candidate, (size_t)length) &&
+           async_line_finish(session, line);
+  }
+  switch (ordinal % 8) {
+    case 0:
+      length = snprintf(candidate, sizeof candidate,
+                        "workspace/src/omega_pipeline_%08zu.go", ordinal);
+      break;
+    case 1:
+      length = snprintf(candidate, sizeof candidate,
+                        "workspace/lib/gamma_worker_%08zu.rs", ordinal);
+      break;
+    case 2:
+      length = snprintf(candidate, sizeof candidate,
+                        "workspace/docs/delta_notes_%08zu.md", ordinal);
+      break;
+    case 3:
+      length = snprintf(candidate, sizeof candidate,
+                        "workspace/tests/fuzzy_native_%08zu.test", ordinal);
+      break;
+    case 4:
+      length = snprintf(candidate, sizeof candidate,
+                        "workspace/src/http_request_%08zu.ts", ordinal);
+      break;
+    case 5:
+      length = snprintf(candidate, sizeof candidate,
+                        "workspace/src/alpha_component_%08zu.c", ordinal);
+      break;
+    case 6:
+      length = snprintf(candidate, sizeof candidate,
+                        "workspace/lib/algebra_table_%08zu.el", ordinal);
+      break;
+    default:
+      length = snprintf(candidate, sizeof candidate,
+                        "misc/item_%08zu_payload.bin", ordinal);
+      break;
+  }
+  return length > 0 && (size_t)length < sizeof candidate &&
+         async_line_feed_bytes(session, line, candidate, (size_t)length) &&
+         async_line_finish(session, line);
+}
+
+static AsyncSession *first_query_create_session(size_t candidate_count,
+                                                FirstQueryCorpus corpus) {
+  /* Reuse the benchmark's complete session initializer, then remove its
+     private pool before starting the coordinator.  Production sessions also
+     begin with worker_pool == NULL and acquire the process-wide pool. */
+  AsyncSession *session = bench_session_create(1);
+  if (!session) return NULL;
+  struct AsyncWorkerPool *private_pool = atomic_exchange_explicit(
+      &session->worker_pool, NULL, memory_order_acq_rel);
+  session->worker_pool_owned = false;
+  async_worker_pool_destroy(private_pool);
+
+  if (!bench_start_coordinator(session)) {
+    async_session_destroy(session);
+    return NULL;
+  }
+  AsyncLineDecoder line = {0};
+  for (size_t i = 0; i < candidate_count; i++) {
+    if (!first_query_append_candidate(session, &line, i, corpus)) {
+      free(line.output);
+      async_session_destroy(session);
+      return NULL;
+    }
+  }
+  free(line.output);
+  return session;
+}
+
+int main(int argc, char **argv) {
+  size_t candidate_count = 300000;
+  size_t limit = 256;
+  size_t batch_cache_bytes = 64 * 1024 * 1024;
+  const char *query = "omega";
+  FirstQueryCorpus corpus = FirstQueryAscii;
+  if (argc > 6 ||
+      (argc > 1 && !bench_parse_size(argv[1], &candidate_count)) ||
+      (argc > 2 && !bench_parse_size(argv[2], &limit)) ||
+      (argc > 4 && !bench_parse_size(argv[4], &batch_cache_bytes)) ||
+      candidate_count == 0 || limit == 0) {
+    fprintf(stderr,
+            "usage: %s [candidates [limit [query [batch-cache-bytes "
+            "[ascii|arabic|korean]]]]]\n",
+            argv[0]);
+    return 2;
+  }
+  if (argc > 3) query = argv[3];
+  if (argc > 5) {
+    if (strcmp(argv[5], "arabic") == 0)
+      corpus = FirstQueryArabic;
+    else if (strcmp(argv[5], "korean") == 0)
+      corpus = FirstQueryKorean;
+    else if (strcmp(argv[5], "ascii") != 0) {
+      fprintf(stderr, "unknown corpus: %s\n", argv[5]);
+      return 2;
+    }
+  }
+  const char *corpus_name = corpus == FirstQueryArabic ? "arabic" :
+                            corpus == FirstQueryKorean ? "korean" : "ascii";
+
+  double setup_started = bench_now_ms();
+  AsyncSession *session = first_query_create_session(candidate_count, corpus);
+  double setup_ms = bench_now_ms() - setup_started;
+  if (!session) return 3;
+  session->batch_cache.max_bytes = batch_cache_bytes;
+  char *owned_query = strdup(query);
+  if (!owned_query) {
+    async_session_destroy(session);
+    return 3;
+  }
+
+  double started = bench_now_ms();
+  uint64_t request_id = async_submit_request_resolved_for_scheme(
+      session, owned_query, strlen(query), limit,
+      CaseSmart, true, false, true, FZF_SCORE_SCHEME_DEFAULT, 0, false);
+  bool complete = request_id &&
+      bench_wait_for_result(session, request_id, candidate_count);
+  double elapsed_ms = bench_now_ms() - started;
+
+  BenchSnapshot snapshot = {0};
+  bool valid = complete &&
+      bench_capture_snapshot(session, request_id, candidate_count, &snapshot) &&
+      bench_validate_snapshot(session, &snapshot, query, limit,
+                              CaseSmart, true, false, true,
+                              FZF_SCORE_SCHEME_DEFAULT);
+  printf("first_query_ms=%.3f setup_ms=%.3f candidates=%zu corpus=%s "
+         "query=%s matched=%zu top=%zu batch_cache_bytes=%zu "
+         "checksum=%016" PRIx64 " validation=%s\n",
+         elapsed_ms, setup_ms, candidate_count, corpus_name, query,
+         snapshot.matched_count, snapshot.top_count, batch_cache_bytes, snapshot.checksum,
+         valid ? "ok" : "failed");
+  free(snapshot.top);
+  async_session_destroy(session);
+  return valid ? 0 : 4;
+}

--- a/benchmarks/fzf-bench-driver-test.c
+++ b/benchmarks/fzf-bench-driver-test.c
@@ -80,7 +80,8 @@ static void test_fallback_and_duplicate_identity(void) {
     for (unsigned sorted = 0; sorted < 2; sorted++) {
       BenchPool pool;
       bool initialized = bench_pool_init(
-          &pool, threads, &corpus, pattern, sorted, false);
+          &pool, threads, &corpus, pattern, sorted,
+          FZF_SCORE_SCHEME_DEFAULT, false, false);
       CHECK(initialized);
       if (!initialized) continue;
       uint64_t expected = expected_checksum(5,
@@ -120,7 +121,9 @@ static void test_radix_passes(void) {
   enum { count = 512 };
   BenchCandidate candidates[count];
   BenchMatch values[count], expected[count], scratch[count];
+  BenchPool pool = {0};
   BenchWorker worker = {
+      .pool = &pool,
       .matches = {values, count, count},
       .sort_scratch = scratch,
       .sort_scratch_capacity = count,
@@ -153,6 +156,52 @@ static void test_radix_passes(void) {
   }
 }
 
+static void test_path_options_follow_fzf_last_option_wins(void) {
+  char *tiebreak_first[] = {
+      "fzf-bench", "--filter=alpha", "--dump-semantic",
+      "--tiebreak=index", "--scheme=path"};
+  char *scheme_first[] = {
+      "fzf-bench", "--filter=alpha", "--dump-semantic",
+      "--scheme=path", "--tiebreak=index"};
+  char *path_default[] = {
+      "fzf-bench", "--filter=alpha", "--dump-semantic", "--scheme=path"};
+  char *timed_pathname[] = {
+      "fzf-bench", "--filter=alpha", "--bench=1ms", "--scheme=path"};
+  char *timed_path_index[] = {
+      "fzf-bench", "--filter=alpha", "--bench=1ms", "--scheme=path",
+      "--tiebreak=index"};
+  BenchOptions first, second, default_path, timed;
+  CHECK(bench_parse_options(5, tiebreak_first, &first));
+  CHECK(bench_parse_options(5, scheme_first, &second));
+  CHECK(first.score_scheme == FZF_SCORE_SCHEME_PATH);
+  CHECK(second.score_scheme == FZF_SCORE_SCHEME_PATH);
+  CHECK(first.tiebreak_pathname && first.tiebreak_length);
+  CHECK(!second.tiebreak_pathname && !second.tiebreak_length);
+  CHECK(bench_parse_options(4, path_default, &default_path));
+  CHECK(default_path.tiebreak_pathname && default_path.tiebreak_length);
+  CHECK(!bench_parse_options(4, timed_pathname, &timed));
+  CHECK(bench_parse_options(5, timed_path_index, &timed));
+}
+
+static void test_path_comparison_and_merge(void) {
+  BenchCandidate short_candidate = {
+      .text = "beta alpha", .length = 10, .index = 0,
+      .input_is_ascii = true};
+  BenchCandidate long_candidate = {
+      .text = "long-directory/FOO alpha", .length = 24, .index = 1,
+      .input_is_ascii = true};
+  BenchMatch values[] = {
+      {.candidate = &short_candidate, .rank_pathname = 6,
+       .rank_score = 100, .rank_length = 10},
+      {.candidate = &long_candidate, .rank_pathname = 5,
+       .rank_score = 100, .rank_length = 24},
+  };
+  CHECK(bench_match_precedes(&values[1], &values[0], true, true));
+  CHECK(!bench_match_precedes(&values[1], &values[0], true, false));
+  qsort(values, 2, sizeof *values, bench_compare_path_matches);
+  CHECK(values[0].candidate == &long_candidate);
+}
+
 int main(void) {
   CHECK(sizeof(void *) != 8 || sizeof(BenchMatch) == 16);
   CHECK(bench_rank_score(INT64_MIN) == 0);
@@ -162,6 +211,8 @@ int main(void) {
   CHECK(bench_rank_score(UINT16_MAX) == UINT16_MAX);
   CHECK(bench_rank_score((int64_t)UINT16_MAX + 1) == UINT16_MAX);
   CHECK(bench_rank_score(INT64_MAX) == UINT16_MAX);
+  test_path_options_follow_fzf_last_option_wins();
+  test_path_comparison_and_merge();
   test_fallback_and_duplicate_identity();
   test_radix_passes();
   if (failures) return 1;

--- a/benchmarks/fzf-bench-driver-test.c
+++ b/benchmarks/fzf-bench-driver-test.c
@@ -1,0 +1,162 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Exercise the real driver without requiring an external fzf executable. */
+#define main fzf_bench_driver_main
+#include "fzf-bench-driver.c"
+#undef main
+
+static unsigned failures;
+#define CHECK(condition) do { \
+  if (!(condition)) { \
+    fprintf(stderr, "%s:%d: %s\n", __FILE__, __LINE__, #condition); \
+    failures++; \
+  } \
+} while (0)
+
+static uint64_t expected_checksum(size_t items, const uint32_t *indices,
+                                  const uint16_t *ranks, size_t count) {
+  static const char version[] = "fzf-native-bench-result-v1";
+  uint64_t hash = bench_hash_bytes(UINT64_C(14695981039346656037),
+                                   version, sizeof version - 1);
+  hash = bench_hash_u64(hash, items);
+  hash = bench_hash_u64(hash, count);
+  for (size_t i = 0; i < count; i++) {
+    hash = bench_hash_u64(hash, indices[i]);
+    hash = bench_hash_u64(hash, ranks[i]);
+  }
+  return hash;
+}
+
+static void test_fallback_and_duplicate_identity(void) {
+  /* Fixture: the 60000-byte gap forces v2 to use v1 with the default slab.
+     Pinned fzf 63e82a9 gives raw scores -59914 and 32 for query "ab c".
+     The public native membership scores are 37 and 32, respectively.
+     Duplicate text deliberately has distinct input identities. */
+  char *long_text = malloc(60005);
+  if (!long_text) { CHECK(long_text != NULL); return; }
+  long_text[0] = 'a';
+  memset(long_text + 1, 'x', 60000);
+  memcpy(long_text + 60001, "b c", 4);
+  char short_text[85];
+  memcpy(short_text, "za", 2);
+  memset(short_text + 2, 'x', 60);
+  short_text[62] = 'b';
+  memset(short_text + 63, 'x', 20);
+  memcpy(short_text + 83, "c", 2);
+  BenchCandidate candidates[] = {
+      {long_text, 60004, 0, true},
+      {short_text, 84, 1, true},
+      {short_text, 84, 2, true},
+      {long_text, 60004, 3, true},
+      {"no match", 8, 4, true},
+  };
+  BenchCorpus corpus = {.candidates = candidates, .count = 5};
+  char query[] = "ab c";
+  fzf_pattern_t *pattern = fzf_parse_pattern(CaseSmart, false, query, true);
+  if (!pattern) { CHECK(pattern != NULL); free(long_text); return; }
+  fzf_slab_t *slab = fzf_make_default_slab();
+  if (!slab) {
+    CHECK(slab != NULL); fzf_free_pattern(pattern); free(long_text); return;
+  }
+  for (size_t i = 0; i < 2; i++) {
+    fzf_score_bounds_t bounds;
+    int32_t membership = fzf_get_score_with_bounds_bytes_preclassified(
+        candidates[i].text, candidates[i].length, true, pattern, slab, &bounds);
+    CHECK(membership == (i == 0 ? 37 : 32));
+    CHECK(bounds.raw_score == (i == 0 ? -59914 : 32));
+    CHECK(bounds.valid && !fzf_allocation_failed());
+  }
+  fzf_free_slab(slab);
+
+  const uint32_t sorted_ids[] = {1, 2, 0, 3};
+  const uint16_t sorted_ranks[] = {32, 32, 0, 0};
+  const uint32_t unsorted_ids[] = {0, 1, 2, 3};
+  const uint16_t unsorted_ranks[] = {0, 32, 32, 0};
+  for (size_t threads = 1; threads <= 3; threads += 2) {
+    for (unsigned sorted = 0; sorted < 2; sorted++) {
+      BenchPool pool;
+      bool initialized = bench_pool_init(&pool, threads, &corpus, pattern, sorted);
+      CHECK(initialized);
+      if (!initialized) continue;
+      uint64_t expected = expected_checksum(5,
+          sorted ? sorted_ids : unsorted_ids,
+          sorted ? sorted_ranks : unsorted_ranks, 4);
+      for (unsigned round = 0; round < 12; round++) {
+        bench_pool_discard_results(&pool);
+        bool ran = bench_pool_run(&pool);
+        CHECK(ran);
+        if (!ran) break;
+        CHECK(bench_pool_result_length(&pool) == 4);
+        uint64_t actual = 0;
+        CHECK(bench_result_checksum(&pool, 4, &actual));
+        CHECK(actual == expected);
+        unsigned seen[5] = {0};
+        for (size_t w = 0; w < pool.worker_count; w++) {
+          for (size_t j = 0; j < pool.workers[w].matches.count; j++) {
+            const BenchMatch *match = &pool.workers[w].matches.values[j];
+            uint32_t id = match->candidate->index;
+            CHECK(id < 4);
+            if (id >= 4) continue;
+            seen[id]++;
+            CHECK(match->membership == ((id == 0 || id == 3) ? 37 : 32));
+            CHECK(match->rank_score == ((id == 0 || id == 3) ? 0 : 32));
+          }
+        }
+        for (size_t i = 0; i < 4; i++) CHECK(seen[i] == 1);
+      }
+      bench_pool_destroy(&pool);
+    }
+  }
+  fzf_free_pattern(pattern);
+  free(long_text);
+}
+
+static void test_radix_passes(void) {
+  enum { count = 512 };
+  BenchCandidate candidates[count];
+  BenchMatch values[count], expected[count], scratch[count];
+  BenchWorker worker = {
+      .matches = {values, count, count},
+      .sort_scratch = scratch,
+      .sort_scratch_capacity = count,
+  };
+  for (unsigned variant = 0; variant < 5; variant++) {
+    memset(scratch, 0xa5, sizeof scratch);
+    for (size_t i = 0; i < count; i++) {
+      candidates[i] = (BenchCandidate){"duplicate", 9, (uint32_t)i, true};
+      uint16_t rank = variant == 0 ? 32 :
+          variant == 1 ? (uint16_t)(i % 7) :
+          variant == 2 ? (uint16_t)((i % 7) * 256 + 7) :
+          variant == 3 ? (uint16_t)(i * 73) : UINT16_MAX;
+      values[i] = (BenchMatch){.candidate = &candidates[i],
+                               .membership = 1, .rank_score = rank};
+      expected[i] = values[i];
+    }
+    qsort(expected, count, sizeof *expected, bench_compare_matches);
+    bench_sort_matches(&worker);
+    for (size_t i = 0; i < count; i++) {
+      CHECK(values[i].candidate->index == expected[i].candidate->index);
+      CHECK(values[i].rank_score == expected[i].rank_score);
+    }
+    /* Uniform nonzero bytes must skip scattering, not only zero key bytes. */
+    if (variant == 0 || variant == 4) {
+      const unsigned char *bytes = (const unsigned char *)scratch;
+      for (size_t i = 0; i < sizeof scratch; i++) CHECK(bytes[i] == 0xa5);
+    }
+  }
+}
+
+int main(void) {
+  CHECK(sizeof(void *) != 8 || sizeof(BenchMatch) == 16);
+  CHECK(bench_rank_score(INT64_MIN) == 0);
+  CHECK(bench_rank_score(-1) == 0);
+  CHECK(bench_rank_score(0) == 0);
+  CHECK(bench_rank_score(32) == 32);
+  CHECK(bench_rank_score(UINT16_MAX) == UINT16_MAX);
+  CHECK(bench_rank_score((int64_t)UINT16_MAX + 1) == UINT16_MAX);
+  CHECK(bench_rank_score(INT64_MAX) == UINT16_MAX);
+  test_fallback_and_duplicate_identity();
+  test_radix_passes();
+  if (failures) return 1;
+  puts("benchmark driver raw-rank, duplicate-identity, and radix tests passed");
+  return 0;
+}

--- a/benchmarks/fzf-bench-driver-test.c
+++ b/benchmarks/fzf-bench-driver-test.c
@@ -43,11 +43,16 @@ static void test_fallback_and_duplicate_identity(void) {
   memset(short_text + 63, 'x', 20);
   memcpy(short_text + 83, "c", 2);
   BenchCandidate candidates[] = {
-      {long_text, 60004, 0, true},
-      {short_text, 84, 1, true},
-      {short_text, 84, 2, true},
-      {long_text, 60004, 3, true},
-      {"no match", 8, 4, true},
+      {.text = long_text, .length = 60004, .index = 0,
+       .input_is_ascii = true},
+      {.text = short_text, .length = 84, .index = 1,
+       .input_is_ascii = true},
+      {.text = short_text, .length = 84, .index = 2,
+       .input_is_ascii = true},
+      {.text = long_text, .length = 60004, .index = 3,
+       .input_is_ascii = true},
+      {.text = "no match", .length = 8, .index = 4,
+       .input_is_ascii = true},
   };
   BenchCorpus corpus = {.candidates = candidates, .count = 5};
   char query[] = "ab c";
@@ -74,7 +79,8 @@ static void test_fallback_and_duplicate_identity(void) {
   for (size_t threads = 1; threads <= 3; threads += 2) {
     for (unsigned sorted = 0; sorted < 2; sorted++) {
       BenchPool pool;
-      bool initialized = bench_pool_init(&pool, threads, &corpus, pattern, sorted);
+      bool initialized = bench_pool_init(
+          &pool, threads, &corpus, pattern, sorted, false);
       CHECK(initialized);
       if (!initialized) continue;
       uint64_t expected = expected_checksum(5,
@@ -122,7 +128,9 @@ static void test_radix_passes(void) {
   for (unsigned variant = 0; variant < 5; variant++) {
     memset(scratch, 0xa5, sizeof scratch);
     for (size_t i = 0; i < count; i++) {
-      candidates[i] = (BenchCandidate){"duplicate", 9, (uint32_t)i, true};
+      candidates[i] = (BenchCandidate){
+          .text = "duplicate", .length = 9, .index = (uint32_t)i,
+          .input_is_ascii = true};
       uint16_t rank = variant == 0 ? 32 :
           variant == 1 ? (uint16_t)(i % 7) :
           variant == 2 ? (uint16_t)((i % 7) * 256 + 7) :

--- a/benchmarks/fzf-bench-driver.c
+++ b/benchmarks/fzf-bench-driver.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 
 #include "fzf-private.h"
+#include "utf8proc-2.10.0/utf8proc.h"
 
 #ifndef FZF_BENCH_CHUNK_SIZE
 #define FZF_BENCH_CHUNK_SIZE 1024
@@ -46,6 +47,8 @@ typedef struct {
   const char *text;
   size_t length;
   uint32_t index;
+  uint16_t trim_length;
+  bool trim_length_known;
   bool input_is_ascii;
 } BenchCandidate;
 
@@ -61,7 +64,7 @@ typedef struct {
   const BenchCandidate *candidate;
   int32_t membership;
   uint16_t rank_score;
-  uint16_t reserved;
+  uint16_t rank_length;
 } BenchMatch;
 
 typedef struct {
@@ -106,10 +109,11 @@ typedef struct BenchPool {
   size_t active_count;
   uint64_t epoch;
   bool stop;
-  const BenchCorpus *corpus;
+  BenchCorpus *corpus;
   fzf_pattern_t *pattern;
   bool has_positive_term;
   bool sort_results;
+  bool tiebreak_length;
   BenchScanResult result;
   _Atomic size_t next_chunk;
   _Atomic bool failed;
@@ -121,7 +125,8 @@ typedef struct {
   unsigned threads;
   bool normalize;
   bool sort_results;
-  bool tiebreak_index;
+  bool tiebreak_set;
+  bool tiebreak_length;
   bool check_only;
   bool dump_results;
   bool dump_semantic;
@@ -140,7 +145,8 @@ static void bench_usage(FILE *stream, const char *program) {
           "usage: %s --filter QUERY "
           "(--bench DURATION | --check | --dump-results | --dump-semantic) "
           "[--threads N] [--literal] "
-          "[--sort | --no-sort] [--algo=v2] --tiebreak=index\n",
+          "[--sort | --no-sort] [--algo=v2] "
+          "--tiebreak=(length|index)\n",
           program);
 }
 
@@ -250,8 +256,14 @@ static bool bench_parse_options(int argc, char **argv,
       if (strcmp(value, "v2") != 0) return false;
     } else if (bench_option_value(
                    argc, argv, &i, "--tiebreak", &value)) {
-      if (strcmp(value, "index") != 0) return false;
-      options->tiebreak_index = true;
+      if (strcmp(value, "index") == 0) {
+        options->tiebreak_length = false;
+      } else if (strcmp(value, "length") == 0) {
+        options->tiebreak_length = true;
+      } else {
+        return false;
+      }
+      options->tiebreak_set = true;
     } else if (bench_option_value(
                    argc, argv, &i, "--scheme", &value)) {
       if (strcmp(value, "default") != 0) return false;
@@ -263,7 +275,7 @@ static bool bench_parse_options(int argc, char **argv,
   if (options->help) return true;
   unsigned modes = (options->duration_ns > 0) + options->check_only +
       options->dump_results + options->dump_semantic;
-  if (!options->query || !options->tiebreak_index || modes != 1)
+  if (!options->query || !options->tiebreak_set || modes != 1)
     return false;
   if (options->threads == 0) options->threads = bench_online_threads();
   return options->threads > 0;
@@ -306,6 +318,48 @@ static bool bench_read_all(FILE *stream, char **bytes, size_t *length) {
   *bytes = buffer;
   *length = used;
   return true;
+}
+
+static bool bench_unicode_is_space(utf8proc_int32_t codepoint) {
+  if ((codepoint >= 0x09 && codepoint <= 0x0d) || codepoint == 0x85)
+    return true;
+  utf8proc_category_t category = utf8proc_category(codepoint);
+  return category == UTF8PROC_CATEGORY_ZS ||
+      category == UTF8PROC_CATEGORY_ZL ||
+      category == UTF8PROC_CATEGORY_ZP;
+}
+
+/* Match fzf's rune-based, whitespace-trimmed length tiebreak. */
+static uint16_t bench_trim_length(const char *text, size_t length) {
+  size_t position = 0;
+  size_t rune_index = 0;
+  size_t first_nonspace = SIZE_MAX;
+  size_t last_nonspace = 0;
+  while (position < length) {
+    utf8proc_int32_t codepoint = 0xfffd;
+    utf8proc_ssize_t amount = utf8proc_iterate(
+        (const utf8proc_uint8_t *)text + position,
+        (utf8proc_ssize_t)(length - position), &codepoint);
+    if (amount <= 0) amount = 1;
+    if (!bench_unicode_is_space(codepoint)) {
+      if (first_nonspace == SIZE_MAX) first_nonspace = rune_index;
+      last_nonspace = rune_index;
+    }
+    position += (size_t)amount;
+    rune_index++;
+  }
+  if (first_nonspace == SIZE_MAX) return 0;
+  size_t trimmed = last_nonspace - first_nonspace + 1;
+  return trimmed > UINT16_MAX ? UINT16_MAX : (uint16_t)trimmed;
+}
+
+static uint16_t bench_candidate_trim_length(BenchCandidate *candidate) {
+  if (!candidate->trim_length_known) {
+    candidate->trim_length = bench_trim_length(
+        candidate->text, candidate->length);
+    candidate->trim_length_known = true;
+  }
+  return candidate->trim_length;
 }
 
 static bool bench_load_corpus(FILE *stream, BenchCorpus *corpus) {
@@ -373,6 +427,8 @@ static int bench_compare_matches(const void *left_value,
   const BenchMatch *right = right_value;
   if (left->rank_score != right->rank_score)
     return left->rank_score > right->rank_score ? -1 : 1;
+  if (left->rank_length != right->rank_length)
+    return left->rank_length < right->rank_length ? -1 : 1;
   if (left->candidate->index != right->candidate->index)
     return left->candidate->index < right->candidate->index ? -1 : 1;
   return 0;
@@ -393,9 +449,13 @@ static bool bench_match_list_append(BenchMatchList *list,
   return true;
 }
 
+static uint32_t bench_sort_key(const BenchMatch *match) {
+  return (uint32_t)match->rank_length |
+      (uint32_t)(UINT16_MAX - match->rank_score) << 16;
+}
+
 /* fzf uses comparison sort below 128 results and an LSD radix sort above it.
-   With --tiebreak=index, the only explicit key is the inverted 16-bit score;
-   stable input order supplies the final index tiebreak. */
+   Stable input order supplies the final index tiebreak. */
 static void bench_sort_matches(BenchWorker *worker) {
   BenchMatch *values = worker->matches.values;
   size_t count = worker->matches.count;
@@ -416,30 +476,29 @@ static void bench_sort_matches(BenchWorker *worker) {
     worker->sort_scratch_capacity = count;
   }
 
-  uint16_t key_or = 0;
+  uint32_t key_or = 0;
   for (size_t i = 0; i < count; i++)
-    key_or |= (uint16_t)(UINT16_MAX - values[i].rank_score);
+    key_or |= bench_sort_key(&values[i]);
 
   BenchMatch *source = values;
   BenchMatch *destination = worker->sort_scratch;
   unsigned scatters = 0;
-  for (unsigned pass = 0; pass < 2; pass++) {
+  for (unsigned pass = 0; pass < 4; pass++) {
     unsigned shift = pass * 8;
     if (((key_or >> shift) & 0xff) == 0) continue;
     size_t counts[256] = {0};
     for (size_t i = 0; i < count; i++) {
-      uint16_t key = (uint16_t)(UINT16_MAX - source[i].rank_score);
+      uint32_t key = bench_sort_key(&source[i]);
       counts[(key >> shift) & 0xff]++;
     }
-    uint16_t first_key = (uint16_t)(UINT16_MAX - source[0].rank_score);
+    uint32_t first_key = bench_sort_key(&source[0]);
     if (counts[(first_key >> shift) & 0xff] == count) continue;
-
     size_t offsets[256];
     offsets[0] = 0;
     for (size_t i = 1; i < 256; i++)
       offsets[i] = offsets[i - 1] + counts[i - 1];
     for (size_t i = 0; i < count; i++) {
-      uint16_t key = (uint16_t)(UINT16_MAX - source[i].rank_score);
+      uint32_t key = bench_sort_key(&source[i]);
       destination[offsets[(key >> shift) & 0xff]++] = source[i];
     }
     BenchMatch *swap = source;
@@ -473,7 +532,7 @@ static void bench_worker_scan(BenchWorker *worker) {
     size_t end = first + FZF_BENCH_CHUNK_SIZE;
     if (end > pool->corpus->count) end = pool->corpus->count;
     for (size_t i = first; i < end; i++) {
-      const BenchCandidate *candidate = &pool->corpus->candidates[i];
+      BenchCandidate *candidate = &pool->corpus->candidates[i];
       fzf_score_bounds_t bounds;
       int32_t membership = fzf_get_score_with_bounds_bytes_preclassified(
           candidate->text, candidate->length, candidate->input_is_ascii,
@@ -490,7 +549,10 @@ static void bench_worker_scan(BenchWorker *worker) {
                            (BenchMatch){
                                .candidate = candidate,
                                .membership = membership,
-                               .rank_score = bench_rank_score(bounds.raw_score),
+                               .rank_score = pool->has_positive_term
+                                   ? bench_rank_score(bounds.raw_score) : 0,
+                               .rank_length = pool->tiebreak_length
+                                   ? bench_candidate_trim_length(candidate) : 0,
                            })) {
         atomic_store_explicit(&pool->failed, true, memory_order_relaxed);
         return;
@@ -524,8 +586,9 @@ static void *bench_worker_main(void *data) {
 }
 
 static bool bench_pool_init(BenchPool *pool, size_t worker_count,
-                            const BenchCorpus *corpus,
-                            fzf_pattern_t *pattern, bool sort_results) {
+                            BenchCorpus *corpus,
+                            fzf_pattern_t *pattern, bool sort_results,
+                            bool tiebreak_length) {
   memset(pool, 0, sizeof *pool);
   if (pthread_mutex_init(&pool->mutex, NULL) != 0) return false;
   if (pthread_cond_init(&pool->start_cond, NULL) != 0) {
@@ -549,6 +612,7 @@ static bool bench_pool_init(BenchPool *pool, size_t worker_count,
   pool->pattern = pattern;
   pool->has_positive_term = pattern->has_positive_term;
   pool->sort_results = sort_results && pattern->has_positive_term;
+  pool->tiebreak_length = tiebreak_length;
   atomic_init(&pool->next_chunk, 0);
   atomic_init(&pool->failed, false);
 
@@ -732,6 +796,8 @@ static bool bench_match_precedes(const BenchMatch *left,
                                  bool sortable) {
   if (sortable && left->rank_score != right->rank_score)
     return left->rank_score > right->rank_score;
+  if (sortable && left->rank_length != right->rank_length)
+    return left->rank_length < right->rank_length;
   return left->candidate->index < right->candidate->index;
 }
 
@@ -774,6 +840,8 @@ static bool bench_result_checksum(BenchPool *pool, size_t match_count,
     if (!best) return false;
     hash = bench_hash_u64(hash, best->candidate->index);
     hash = bench_hash_u64(hash, best->rank_score);
+    if (pool->tiebreak_length)
+      hash = bench_hash_u64(hash, best->rank_length);
     merger->cursors[best_worker]++;
   }
   *checksum = hash;
@@ -934,7 +1002,8 @@ int main(int argc, char **argv) {
 
   BenchPool pool;
   if (!bench_pool_init(
-          &pool, worker_count, &corpus, pattern, options.sort_results)) {
+          &pool, worker_count, &corpus, pattern, options.sort_results,
+          options.tiebreak_length)) {
     fprintf(stderr, "fzf-native benchmark: could not start workers\n");
     fzf_free_pattern(pattern);
     bench_free_corpus(&corpus);
@@ -982,6 +1051,21 @@ int main(int argc, char **argv) {
     if (sample_count == 0) success = false;
   }
 
+  uint64_t total_ns = 0;
+  uint64_t minimum = sample_count ? samples[0] : 0;
+  uint64_t maximum = sample_count ? samples[0] : 0;
+  if (success && !options.check_only && !options.dump_results) {
+    for (size_t i = 0; i < sample_count; i++) {
+      if (UINT64_MAX - total_ns < samples[i]) {
+        success = false;
+        break;
+      }
+      total_ns += samples[i];
+      if (samples[i] < minimum) minimum = samples[i];
+      if (samples[i] > maximum) maximum = samples[i];
+    }
+  }
+
   uint64_t result_checksum = 0;
   if (success && options.dump_results)
     success = bench_dump_results(&pool, match_count);
@@ -998,23 +1082,25 @@ int main(int argc, char **argv) {
            " result_checksum=%016" PRIx64 "\n",
            corpus.count, match_count, input_checksum, result_checksum);
   } else {
-    long double total_ns = 0.0;
-    uint64_t minimum = samples[0];
-    uint64_t maximum = samples[0];
-    for (size_t i = 0; i < sample_count; i++) {
-      total_ns += samples[i];
-      if (samples[i] < minimum) minimum = samples[i];
-      if (samples[i] > maximum) maximum = samples[i];
+    const char *json = getenv("FZF_BENCH_JSON");
+    if (json && strcmp(json, "1") == 0) {
+      printf("benchmark-json {\"schema\":1,\"iterations\":%zu,"
+             "\"total_ns\":%" PRIu64 ",\"min_ns\":%" PRIu64 ","
+             "\"max_ns\":%" PRIu64 ",\"items\":%zu,"
+             "\"matches\":%zu,\"ingestion_ns\":%" PRIu64 "}\n",
+             sample_count, total_ns, minimum, maximum, corpus.count,
+             match_count, ingestion_ns);
+    } else {
+      double average_ms = (double)total_ns / (double)sample_count / 1e6;
+      double selectivity = corpus.count
+          ? (double)match_count / (double)corpus.count * 100.0 : 0.0;
+      printf("  %zu iterations  avg: %.2fms  min: %.2fms  max: %.2fms  "
+             "total: %.2fs  items: %zu  matches: %zu (%.2f%%)  "
+             "ingestion: %.2fms\n",
+             sample_count, average_ms, (double)minimum / 1e6,
+             (double)maximum / 1e6, (double)total_ns / 1e9, corpus.count,
+             match_count, selectivity, (double)ingestion_ns / 1e6);
     }
-    double average_ms = (double)(total_ns / sample_count / 1e6L);
-    double selectivity = corpus.count
-        ? (double)match_count / (double)corpus.count * 100.0 : 0.0;
-    printf("  %zu iterations  avg: %.2fms  min: %.2fms  max: %.2fms  "
-           "total: %.2Lfs  items: %zu  matches: %zu (%.2f%%)  "
-           "ingestion: %.2fms\n",
-           sample_count, average_ms, (double)minimum / 1e6,
-           (double)maximum / 1e6, total_ns / 1e9L, corpus.count,
-           match_count, selectivity, (double)ingestion_ns / 1e6);
     printf("semantic items=%zu matches=%zu input_checksum=%016" PRIx64
            " result_checksum=%016" PRIx64 "\n",
            corpus.count, match_count, input_checksum, result_checksum);

--- a/benchmarks/fzf-bench-driver.c
+++ b/benchmarks/fzf-bench-driver.c
@@ -29,6 +29,7 @@
 #include <pthread.h>
 #include <stdatomic.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -62,10 +63,27 @@ typedef struct {
 /* Keep the same 16-byte result footprint as fzf's Result on 64-bit hosts. */
 typedef struct {
   const BenchCandidate *candidate;
-  int32_t membership;
+  union {
+    int32_t membership;
+    struct {
+      uint16_t rank_pathname;
+      uint16_t rank_pathname_padding;
+    };
+  };
   uint16_t rank_score;
   uint16_t rank_length;
 } BenchMatch;
+
+#if UINTPTR_MAX == UINT64_MAX
+_Static_assert(sizeof(BenchMatch) == 16,
+               "benchmark results must match fzf's 16-byte Result");
+_Static_assert(offsetof(BenchMatch, membership) == 8,
+               "default membership layout must not change");
+_Static_assert(offsetof(BenchMatch, rank_score) == 12,
+               "default score-rank layout must not change");
+_Static_assert(offsetof(BenchMatch, rank_length) == 14,
+               "default length-rank layout must not change");
+#endif
 
 typedef struct {
   BenchMatch *values;
@@ -111,8 +129,10 @@ typedef struct BenchPool {
   bool stop;
   BenchCorpus *corpus;
   fzf_pattern_t *pattern;
+  fzf_score_scheme_t score_scheme;
   bool has_positive_term;
   bool sort_results;
+  bool tiebreak_pathname;
   bool tiebreak_length;
   BenchScanResult result;
   _Atomic size_t next_chunk;
@@ -125,6 +145,8 @@ typedef struct {
   unsigned threads;
   bool normalize;
   bool sort_results;
+  fzf_score_scheme_t score_scheme;
+  bool tiebreak_pathname;
   bool tiebreak_length;
   bool check_only;
   bool dump_results;
@@ -152,6 +174,7 @@ static void bench_usage(FILE *stream, const char *program) {
           "(--bench DURATION | --check | --dump-results | --dump-semantic) "
           "[--threads N] [--literal] "
           "[--sort | --no-sort] [--algo=v2] "
+          "[--scheme=(default|path)] "
           "[--tiebreak=(length|index)]\n",
           program);
 }
@@ -224,7 +247,9 @@ static unsigned bench_online_threads(void) {
 static bool bench_parse_options(int argc, char **argv,
                                 BenchOptions *options) {
   *options = (BenchOptions){
-      .normalize = true, .sort_results = true, .tiebreak_length = true};
+      .normalize = true, .sort_results = true,
+      .score_scheme = FZF_SCORE_SCHEME_DEFAULT,
+      .tiebreak_length = true};
   for (int i = 1; i < argc; i++) {
     const char *argument = argv[i];
     const char *value = NULL;
@@ -268,15 +293,27 @@ static bool bench_parse_options(int argc, char **argv,
     } else if (bench_option_value(
                    argc, argv, &i, "--tiebreak", &value)) {
       if (strcmp(value, "index") == 0) {
+        options->tiebreak_pathname = false;
         options->tiebreak_length = false;
       } else if (strcmp(value, "length") == 0) {
+        options->tiebreak_pathname = false;
         options->tiebreak_length = true;
       } else {
         return false;
       }
     } else if (bench_option_value(
                    argc, argv, &i, "--scheme", &value)) {
-      if (strcmp(value, "default") != 0) return false;
+      if (strcmp(value, "default") == 0) {
+        options->score_scheme = FZF_SCORE_SCHEME_DEFAULT;
+        options->tiebreak_pathname = false;
+        options->tiebreak_length = true;
+      } else if (strcmp(value, "path") == 0) {
+        options->score_scheme = FZF_SCORE_SCHEME_PATH;
+        options->tiebreak_pathname = true;
+        options->tiebreak_length = true;
+      } else {
+        return false;
+      }
     } else {
       return false;
     }
@@ -289,6 +326,10 @@ static bool bench_parse_options(int argc, char **argv,
   modes += options->check_trim_cache;
 #endif
   if (!options->query || modes != 1)
+    return false;
+  /* Pathname ranking currently uses comparison sort.  Do not present it as
+     the same timed sorting envelope as fzf's radix path. */
+  if (options->duration_ns > 0 && options->tiebreak_pathname)
     return false;
 #ifdef FZF_BENCH_TEST_HOOKS
   if (options->check_trim_cache && !options->tiebreak_length) return false;
@@ -459,6 +500,43 @@ static uint16_t bench_rank_length(BenchCandidate *candidate) {
   return candidate->rank_length;
 }
 
+static uint16_t bench_rank_pathname(
+    const BenchCandidate *candidate, const fzf_score_bounds_t *bounds) {
+  if (!bounds->valid || bounds->min_begin < 0) return UINT16_MAX;
+
+  ptrdiff_t last_delimiter = -1;
+  if (candidate->input_is_ascii) {
+    for (size_t index = candidate->length; index > 0; index--) {
+      if (candidate->text[index - 1] == '/' ||
+          candidate->text[index - 1] == '\\') {
+        last_delimiter = (ptrdiff_t)(index - 1);
+        break;
+      }
+    }
+  } else {
+    size_t offset = 0;
+    ptrdiff_t rune_index = 0;
+    while (offset < candidate->length) {
+      utf8proc_int32_t codepoint = 0;
+      utf8proc_ssize_t width = utf8proc_iterate(
+          (const utf8proc_uint8_t *)candidate->text + offset,
+          (utf8proc_ssize_t)(candidate->length - offset), &codepoint);
+      if (width <= 0) {
+        codepoint = (unsigned char)candidate->text[offset];
+        width = 1;
+      }
+      if (codepoint == '/' || codepoint == '\\')
+        last_delimiter = rune_index;
+      offset += (size_t)width;
+      rune_index++;
+    }
+  }
+
+  if (last_delimiter > bounds->min_begin) return UINT16_MAX;
+  size_t distance = (size_t)((ptrdiff_t)bounds->min_begin - last_delimiter);
+  return distance > UINT16_MAX ? UINT16_MAX : (uint16_t)distance;
+}
+
 #ifdef FZF_BENCH_TEST_HOOKS
 static size_t bench_known_trim_lengths(const BenchCorpus *corpus) {
   size_t count = 0;
@@ -474,6 +552,21 @@ static int bench_compare_matches(const void *left_value,
   const BenchMatch *right = right_value;
   if (left->rank_score != right->rank_score)
     return left->rank_score > right->rank_score ? -1 : 1;
+  if (left->rank_length != right->rank_length)
+    return left->rank_length < right->rank_length ? -1 : 1;
+  if (left->candidate->index != right->candidate->index)
+    return left->candidate->index < right->candidate->index ? -1 : 1;
+  return 0;
+}
+
+static int bench_compare_path_matches(const void *left_value,
+                                      const void *right_value) {
+  const BenchMatch *left = left_value;
+  const BenchMatch *right = right_value;
+  if (left->rank_score != right->rank_score)
+    return left->rank_score > right->rank_score ? -1 : 1;
+  if (left->rank_pathname != right->rank_pathname)
+    return left->rank_pathname < right->rank_pathname ? -1 : 1;
   if (left->rank_length != right->rank_length)
     return left->rank_length < right->rank_length ? -1 : 1;
   if (left->candidate->index != right->candidate->index)
@@ -509,6 +602,12 @@ static void bench_sort_matches(BenchWorker *worker) {
   BenchMatch *values = worker->matches.values;
   size_t count = worker->matches.count;
   if (count < 2) return;
+  /* Pathname ranking is an untimed semantic-oracle profile.  Keep the
+     benchmark's hot default score/length radix path unchanged. */
+  if (worker->pool->tiebreak_pathname) {
+    qsort(values, count, sizeof *values, bench_compare_path_matches);
+    return;
+  }
   if (count < 128) {
     qsort(values, count, sizeof *values, bench_compare_matches);
     return;
@@ -565,7 +664,7 @@ static void bench_worker_scan(BenchWorker *worker) {
   if (!worker->slab) {
     worker->slab = fzf_make_default_slab();
     if (!worker->slab || !fzf_slab_set_score_scheme(
-                             worker->slab, FZF_SCORE_SCHEME_DEFAULT)) {
+                             worker->slab, pool->score_scheme)) {
       atomic_store_explicit(&pool->failed, true, memory_order_relaxed);
       return;
     }
@@ -583,9 +682,15 @@ static void bench_worker_scan(BenchWorker *worker) {
     for (size_t i = first; i < end; i++) {
       BenchCandidate *candidate = &pool->corpus->candidates[i];
       fzf_score_bounds_t bounds;
-      int32_t membership = fzf_get_score_with_bounds_bytes_preclassified(
-          candidate->text, candidate->length, candidate->input_is_ascii,
-          pool->pattern, worker->slab, &bounds);
+      int32_t membership = pool->tiebreak_pathname
+          ? fzf_get_score_with_rank_bounds_bytes_preclassified(
+                candidate->text, candidate->length,
+                candidate->input_is_ascii, pool->pattern,
+                worker->slab, &bounds)
+          : fzf_get_score_with_bounds_bytes_preclassified(
+                candidate->text, candidate->length,
+                candidate->input_is_ascii, pool->pattern,
+                worker->slab, &bounds);
       if (fzf_allocation_failed()) {
         atomic_store_explicit(&pool->failed, true, memory_order_relaxed);
         return;
@@ -593,16 +698,31 @@ static void bench_worker_scan(BenchWorker *worker) {
       /* The public return preserves membership with a positive sentinel.
          A v1 fallback can have a negative raw score.  Rank the raw aggregate,
          as fzf does, rather than adding sentinel-adjusted term scores. */
-      if (membership > 0 && !bench_match_list_append(
-                           &worker->matches,
-                           (BenchMatch){
-                               .candidate = candidate,
-                               .membership = membership,
-                               .rank_score = pool->has_positive_term
-                                   ? bench_rank_score(bounds.raw_score) : 0,
-                               .rank_length = pool->tiebreak_length
-                                   ? bench_rank_length(candidate) : 0,
-                           })) {
+      bool appended = true;
+      if (pool->tiebreak_pathname && membership > 0) {
+        BenchMatch match = {
+          .candidate = candidate,
+          .membership = membership,
+          .rank_score = pool->has_positive_term
+              ? bench_rank_score(bounds.raw_score) : 0,
+          .rank_length = pool->tiebreak_length
+              ? bench_rank_length(candidate) : 0,
+        };
+        match.rank_pathname = bench_rank_pathname(candidate, &bounds);
+        appended = bench_match_list_append(&worker->matches, match);
+      } else if (!pool->tiebreak_pathname && membership > 0) {
+        appended = bench_match_list_append(
+            &worker->matches,
+            (BenchMatch){
+                .candidate = candidate,
+                .membership = membership,
+                .rank_score = pool->has_positive_term
+                    ? bench_rank_score(bounds.raw_score) : 0,
+                .rank_length = pool->tiebreak_length
+                    ? bench_rank_length(candidate) : 0,
+            });
+      }
+      if (!appended) {
         atomic_store_explicit(&pool->failed, true, memory_order_relaxed);
         return;
       }
@@ -637,7 +757,8 @@ static void *bench_worker_main(void *data) {
 static bool bench_pool_init(BenchPool *pool, size_t worker_count,
                             BenchCorpus *corpus,
                             fzf_pattern_t *pattern, bool sort_results,
-                            bool tiebreak_length) {
+                            fzf_score_scheme_t score_scheme,
+                            bool tiebreak_pathname, bool tiebreak_length) {
   memset(pool, 0, sizeof *pool);
   if (pthread_mutex_init(&pool->mutex, NULL) != 0) return false;
   if (pthread_cond_init(&pool->start_cond, NULL) != 0) {
@@ -659,8 +780,10 @@ static bool bench_pool_init(BenchPool *pool, size_t worker_count,
   pool->worker_count = worker_count;
   pool->corpus = corpus;
   pool->pattern = pattern;
+  pool->score_scheme = score_scheme;
   pool->has_positive_term = pattern->has_positive_term;
   pool->sort_results = sort_results && pattern->has_positive_term;
+  pool->tiebreak_pathname = tiebreak_pathname;
   pool->tiebreak_length = tiebreak_length;
   atomic_init(&pool->next_chunk, 0);
   atomic_init(&pool->failed, false);
@@ -842,9 +965,13 @@ static uint64_t bench_input_checksum(const BenchCorpus *corpus) {
 
 static bool bench_match_precedes(const BenchMatch *left,
                                  const BenchMatch *right,
-                                 bool sortable) {
+                                 bool sortable,
+                                 bool tiebreak_pathname) {
   if (sortable && left->rank_score != right->rank_score)
     return left->rank_score > right->rank_score;
+  if (sortable && tiebreak_pathname &&
+      left->rank_pathname != right->rank_pathname)
+    return left->rank_pathname < right->rank_pathname;
   if (sortable && left->rank_length != right->rank_length)
     return left->rank_length < right->rank_length;
   return left->candidate->index < right->candidate->index;
@@ -881,7 +1008,8 @@ static bool bench_result_checksum(BenchPool *pool, size_t match_count,
       const BenchMatch *candidate =
           &list->values[merger->cursors[worker]];
       if (!best || bench_match_precedes(
-                       candidate, best, merger->sorted)) {
+                       candidate, best, merger->sorted,
+                       pool->tiebreak_pathname)) {
         best = candidate;
         best_worker = worker;
       }
@@ -889,6 +1017,8 @@ static bool bench_result_checksum(BenchPool *pool, size_t match_count,
     if (!best) return false;
     hash = bench_hash_u64(hash, best->candidate->index);
     hash = bench_hash_u64(hash, best->rank_score);
+    if (pool->tiebreak_pathname)
+      hash = bench_hash_u64(hash, best->rank_pathname);
     if (pool->tiebreak_length)
       hash = bench_hash_u64(hash, best->rank_length);
     merger->cursors[best_worker]++;
@@ -929,7 +1059,8 @@ static bool bench_dump_results(BenchPool *pool, size_t match_count) {
       const BenchMatch *candidate =
           &list->values[merger->cursors[worker]];
       if (!best || bench_match_precedes(
-                       candidate, best, merger->sorted)) {
+                       candidate, best, merger->sorted,
+                       pool->tiebreak_pathname)) {
         best = candidate;
         best_worker = worker;
       }
@@ -955,7 +1086,7 @@ static bool bench_dump_semantic(BenchPool *pool, size_t match_count) {
 
   fzf_slab_t *slab = fzf_make_default_slab();
   if (!slab || !fzf_slab_set_score_scheme(
-                   slab, FZF_SCORE_SCHEME_DEFAULT)) {
+                   slab, pool->score_scheme)) {
     fzf_free_slab(slab);
     return false;
   }
@@ -969,7 +1100,9 @@ static bool bench_dump_semantic(BenchPool *pool, size_t match_count) {
       if (merger->cursors[worker] >= list->count) continue;
       const BenchMatch *candidate =
           &list->values[merger->cursors[worker]];
-      if (!best || bench_match_precedes(candidate, best, merger->sorted)) {
+      if (!best || bench_match_precedes(
+                       candidate, best, merger->sorted,
+                       pool->tiebreak_pathname)) {
         best = candidate;
         best_worker = worker;
       }
@@ -980,21 +1113,32 @@ static bool bench_dump_semantic(BenchPool *pool, size_t match_count) {
     }
 
     fzf_score_bounds_t bounds;
-    int32_t membership_score = fzf_get_score_with_bounds_bytes_preclassified(
-        best->candidate->text, best->candidate->length,
-        best->candidate->input_is_ascii, pool->pattern, slab, &bounds);
+    int32_t membership_score = pool->tiebreak_pathname
+        ? fzf_get_score_with_rank_bounds_bytes_preclassified(
+              best->candidate->text, best->candidate->length,
+              best->candidate->input_is_ascii, pool->pattern, slab, &bounds)
+        : fzf_get_score_with_bounds_bytes_preclassified(
+              best->candidate->text, best->candidate->length,
+              best->candidate->input_is_ascii, pool->pattern, slab, &bounds);
     uint16_t rank_score = pool->has_positive_term
         ? bench_rank_score(bounds.raw_score) : 0;
+    uint16_t rank_pathname = pool->tiebreak_pathname
+        ? bench_rank_pathname(best->candidate, &bounds) : 0;
     uint16_t rank_length = best->rank_length;
+    uint16_t point1 = pool->tiebreak_pathname ? rank_length : 0;
+    uint16_t point2 = pool->tiebreak_pathname
+        ? rank_pathname : rank_length;
     uint16_t point3 = (uint16_t)(UINT16_MAX - rank_score);
     if (membership_score <= 0 || fzf_allocation_failed() ||
         rank_score != best->rank_score ||
+        (pool->tiebreak_pathname &&
+         rank_pathname != best->rank_pathname) ||
         printf("%" PRIu32 "\t%" PRId64 "\t%d\t%d\t%d\t%d\t"
-               "%u\t0\t0\t%u\t%u\n",
+               "%u\t0\t%u\t%u\t%u\n",
                best->candidate->index, bounds.raw_score,
                bounds.min_begin, bounds.min_end, bounds.max_end,
                bounds.valid ? 1 : 0, (unsigned)rank_score,
-               (unsigned)rank_length,
+               (unsigned)point1, (unsigned)point2,
                (unsigned)point3) < 0) {
       success = false;
       break;
@@ -1035,8 +1179,9 @@ int main(int argc, char **argv) {
 
   char *query_copy = bench_duplicate(options.query);
   fzf_pattern_t *pattern = query_copy
-      ? fzf_parse_pattern(
-            CaseSmart, options.normalize, query_copy, true) : NULL;
+      ? fzf_parse_pattern_with_direction(
+            CaseSmart, options.normalize, query_copy, true,
+            !options.tiebreak_pathname) : NULL;
   free(query_copy);
   if (!pattern) {
     fprintf(stderr, "fzf-native benchmark: could not parse query\n");
@@ -1054,6 +1199,7 @@ int main(int argc, char **argv) {
   BenchPool pool;
   if (!bench_pool_init(
           &pool, worker_count, &corpus, pattern, options.sort_results,
+          options.score_scheme, options.tiebreak_pathname,
           options.tiebreak_length)) {
     fprintf(stderr, "fzf-native benchmark: could not start workers\n");
     fzf_free_pattern(pattern);

--- a/benchmarks/fzf-bench-driver.c
+++ b/benchmarks/fzf-bench-driver.c
@@ -1,0 +1,956 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Standalone fzf-native equivalent of junegunn/fzf's --bench scan boundary.
+ *
+ * fzf builds the pattern and ingests the input before timing.  Each timed
+ * matcher.scan call divides 1024-item chunks among workers, collects every
+ * match in a worker-local result list, sorts each list, constructs a lazy
+ * merger, and reads only Merger.Length().  It does not materialize the global
+ * order.  This driver follows that boundary: the final k-way merge is used
+ * only after timing to produce a deterministic semantic checksum.
+ *
+ * Persistent pthreads stand in for Go's persistent runtime threads and its
+ * per-scan goroutines.  Match buffers are discarded between samples outside
+ * the measured interval, while per-worker slabs and radix scratch persist as
+ * they do in fzf's Matcher.  Candidate length and ASCII classification are
+ * prepared during ingestion; fzf-native has no public retained-rune candidate
+ * representation, so non-ASCII scoring still decodes through its normal API.
+ * fzf also performs cold ChunkCache bookkeeping inside Pattern.Match after
+ * clearing that cache before each sample.  The native scorer has no analogous
+ * cache interface, so this driver does not add a synthetic cache cost.
+ * The --no-sort mode is a native diagnostic.  fzf filter mode forces sorting
+ * for sortable patterns, even when its command line contains --no-sort.
+ */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <math.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "fzf-private.h"
+
+#ifndef FZF_BENCH_CHUNK_SIZE
+#define FZF_BENCH_CHUNK_SIZE 1024
+#endif
+
+typedef struct {
+  const char *text;
+  size_t length;
+  uint32_t index;
+  bool input_is_ascii;
+} BenchCandidate;
+
+typedef struct {
+  char *bytes;
+  size_t byte_count;
+  BenchCandidate *candidates;
+  size_t count;
+} BenchCorpus;
+
+/* Keep the same 16-byte result footprint as fzf's Result on 64-bit hosts. */
+typedef struct {
+  const BenchCandidate *candidate;
+  int32_t score;
+  uint16_t rank_score;
+  uint16_t reserved;
+} BenchMatch;
+
+typedef struct {
+  BenchMatch *values;
+  size_t count;
+  size_t capacity;
+} BenchMatchList;
+
+typedef struct {
+  BenchMatchList *lists;
+  size_t list_count;
+  size_t *cursors;
+  size_t count;
+  bool sorted;
+  bool pass;
+} BenchMerger;
+
+typedef struct {
+  BenchMerger *merger;
+  BenchMerger *pass_merger;
+} BenchScanResult;
+
+struct BenchPool;
+
+typedef struct {
+  struct BenchPool *pool;
+  pthread_t thread;
+  fzf_slab_t *slab;
+  BenchMatchList matches;
+  BenchMatch *sort_scratch;
+  size_t sort_scratch_capacity;
+  uint64_t seen_epoch;
+} BenchWorker;
+
+typedef struct BenchPool {
+  pthread_mutex_t mutex;
+  pthread_cond_t start_cond;
+  pthread_cond_t done_cond;
+  BenchWorker *workers;
+  size_t worker_count;
+  size_t ready_count;
+  size_t active_count;
+  uint64_t epoch;
+  bool stop;
+  const BenchCorpus *corpus;
+  fzf_pattern_t *pattern;
+  bool has_positive_term;
+  bool sort_results;
+  BenchScanResult result;
+  _Atomic size_t next_chunk;
+  _Atomic bool failed;
+} BenchPool;
+
+typedef struct {
+  const char *query;
+  uint64_t duration_ns;
+  unsigned threads;
+  bool normalize;
+  bool sort_results;
+  bool tiebreak_index;
+  bool check_only;
+  bool dump_results;
+  bool help;
+} BenchOptions;
+
+static uint64_t bench_now_ns(void) {
+  struct timespec now;
+  if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) return 0;
+  return (uint64_t)now.tv_sec * UINT64_C(1000000000) +
+      (uint64_t)now.tv_nsec;
+}
+
+static void bench_usage(FILE *stream, const char *program) {
+  fprintf(stream,
+          "usage: %s --filter QUERY "
+          "(--bench DURATION | --check | --dump-results) "
+          "[--threads N] [--literal] "
+          "[--sort | --no-sort] [--algo=v2] --tiebreak=index\n",
+          program);
+}
+
+static bool bench_option_value(int argc, char **argv, int *index,
+                               const char *name, const char **value) {
+  size_t length = strlen(name);
+  const char *argument = argv[*index];
+  if (strcmp(argument, name) == 0) {
+    if (*index + 1 >= argc) return false;
+    *value = argv[++*index];
+    return true;
+  }
+  if (strncmp(argument, name, length) == 0 && argument[length] == '=') {
+    *value = argument + length + 1;
+    return true;
+  }
+  return false;
+}
+
+static bool bench_parse_duration(const char *text, uint64_t *duration_ns) {
+  errno = 0;
+  char *suffix = NULL;
+  long double value = strtold(text, &suffix);
+  if (errno != 0 || suffix == text || !isfinite(value) || value <= 0.0)
+    return false;
+
+  long double multiplier;
+  if (strcmp(suffix, "ns") == 0)
+    multiplier = 1.0L;
+  else if (strcmp(suffix, "us") == 0)
+    multiplier = 1e3L;
+  else if (strcmp(suffix, "ms") == 0)
+    multiplier = 1e6L;
+  else if (strcmp(suffix, "s") == 0)
+    multiplier = 1e9L;
+  else if (strcmp(suffix, "m") == 0)
+    multiplier = 60e9L;
+  else if (strcmp(suffix, "h") == 0)
+    multiplier = 3600e9L;
+  else
+    return false;
+
+  long double nanoseconds = value * multiplier;
+  /* 2^64 is exact even when long double has only double precision. */
+  if (!isfinite(nanoseconds) || nanoseconds < 1.0L ||
+      nanoseconds >= 0x1p64L)
+    return false;
+  *duration_ns = (uint64_t)nanoseconds;
+  return *duration_ns > 0;
+}
+
+static bool bench_parse_threads(const char *text, unsigned *threads) {
+  if (!text[0] || text[0] == '-') return false;
+  errno = 0;
+  char *end = NULL;
+  unsigned long value = strtoul(text, &end, 10);
+  if (errno != 0 || *end != '\0' || value > UINT_MAX) return false;
+  *threads = (unsigned)value;
+  return true;
+}
+
+static unsigned bench_online_threads(void) {
+  long value = sysconf(_SC_NPROCESSORS_ONLN);
+  if (value <= 0) return 1;
+  if ((unsigned long)value > UINT_MAX) return UINT_MAX;
+  return (unsigned)value;
+}
+
+static bool bench_parse_options(int argc, char **argv,
+                                BenchOptions *options) {
+  *options = (BenchOptions){.normalize = true, .sort_results = true};
+  for (int i = 1; i < argc; i++) {
+    const char *argument = argv[i];
+    const char *value = NULL;
+    if (strcmp(argument, "--help") == 0 || strcmp(argument, "-h") == 0) {
+      options->help = true;
+    } else if (strcmp(argument, "--check") == 0) {
+      options->check_only = true;
+    } else if (strcmp(argument, "--dump-results") == 0) {
+      options->dump_results = true;
+    } else if (strcmp(argument, "--literal") == 0) {
+      options->normalize = false;
+    } else if (strcmp(argument, "--no-literal") == 0) {
+      options->normalize = true;
+    } else if (strcmp(argument, "--no-sort") == 0 ||
+               strcmp(argument, "+s") == 0) {
+      options->sort_results = false;
+    } else if (strcmp(argument, "--sort") == 0 ||
+               strcmp(argument, "-s") == 0) {
+      options->sort_results = true;
+    } else if (strcmp(argument, "-f") == 0) {
+      if (++i >= argc) return false;
+      options->query = argv[i];
+    } else if (bench_option_value(
+                   argc, argv, &i, "--filter", &value)) {
+      options->query = value;
+    } else if (bench_option_value(
+                   argc, argv, &i, "--bench", &value)) {
+      if (!bench_parse_duration(value, &options->duration_ns)) return false;
+    } else if (bench_option_value(
+                   argc, argv, &i, "--threads", &value)) {
+      if (!bench_parse_threads(value, &options->threads)) return false;
+    } else if (bench_option_value(
+                   argc, argv, &i, "--algo", &value)) {
+      if (strcmp(value, "v2") != 0) return false;
+    } else if (bench_option_value(
+                   argc, argv, &i, "--tiebreak", &value)) {
+      if (strcmp(value, "index") != 0) return false;
+      options->tiebreak_index = true;
+    } else if (bench_option_value(
+                   argc, argv, &i, "--scheme", &value)) {
+      if (strcmp(value, "default") != 0) return false;
+    } else {
+      return false;
+    }
+  }
+
+  if (options->help) return true;
+  unsigned modes = (options->duration_ns > 0) + options->check_only +
+      options->dump_results;
+  if (!options->query || !options->tiebreak_index || modes != 1)
+    return false;
+  if (options->threads == 0) options->threads = bench_online_threads();
+  return options->threads > 0;
+}
+
+static bool bench_read_all(FILE *stream, char **bytes, size_t *length) {
+  char *buffer = NULL;
+  size_t used = 0;
+  size_t capacity = 0;
+  for (;;) {
+    if (capacity - used < 64 * 1024) {
+      size_t next = capacity ? capacity * 2 : 128 * 1024;
+      if (next < capacity || next > SIZE_MAX - 1) {
+        free(buffer);
+        return false;
+      }
+      char *grown = realloc(buffer, next + 1);
+      if (!grown) {
+        free(buffer);
+        return false;
+      }
+      buffer = grown;
+      capacity = next;
+    }
+    size_t amount = fread(buffer + used, 1, capacity - used, stream);
+    used += amount;
+    if (amount == 0) {
+      if (ferror(stream)) {
+        free(buffer);
+        return false;
+      }
+      break;
+    }
+  }
+  if (!buffer) {
+    buffer = malloc(1);
+    if (!buffer) return false;
+  }
+  buffer[used] = '\0';
+  *bytes = buffer;
+  *length = used;
+  return true;
+}
+
+static bool bench_load_corpus(FILE *stream, BenchCorpus *corpus) {
+  memset(corpus, 0, sizeof *corpus);
+  if (!bench_read_all(stream, &corpus->bytes, &corpus->byte_count))
+    return false;
+
+  size_t count = 0;
+  for (size_t i = 0; i < corpus->byte_count; i++)
+    if (corpus->bytes[i] == '\n') count++;
+  if (corpus->byte_count > 0 &&
+      corpus->bytes[corpus->byte_count - 1] != '\n')
+    count++;
+  if (count > INT32_MAX || count > SIZE_MAX / sizeof *corpus->candidates)
+    goto fail;
+
+  corpus->candidates = count
+      ? calloc(count, sizeof *corpus->candidates) : NULL;
+  if (count && !corpus->candidates) goto fail;
+
+  size_t start = 0;
+  size_t candidate_index = 0;
+  for (size_t i = 0; i <= corpus->byte_count; i++) {
+    bool delimiter = i < corpus->byte_count && corpus->bytes[i] == '\n';
+    bool final_line = i == corpus->byte_count && i > start;
+    if (!delimiter && !final_line) continue;
+    size_t length = i - start;
+#ifdef _WIN32
+    if (delimiter && length > 0 && corpus->bytes[i - 1] == '\r') length--;
+#endif
+    BenchCandidate *candidate = &corpus->candidates[candidate_index];
+    *candidate = (BenchCandidate){
+        .text = corpus->bytes + start,
+        .length = length,
+        .index = (uint32_t)candidate_index,
+        .input_is_ascii = is_ascii_utf8proc(corpus->bytes + start, length),
+    };
+    candidate_index++;
+    start = i + 1;
+  }
+  corpus->count = candidate_index;
+  if (candidate_index == count) return true;
+
+fail:
+  free(corpus->candidates);
+  free(corpus->bytes);
+  memset(corpus, 0, sizeof *corpus);
+  return false;
+}
+
+static void bench_free_corpus(BenchCorpus *corpus) {
+  free(corpus->candidates);
+  free(corpus->bytes);
+  memset(corpus, 0, sizeof *corpus);
+}
+
+static uint16_t bench_rank_score(int32_t score) {
+  if (score <= 0) return 0;
+  return score > UINT16_MAX ? UINT16_MAX : (uint16_t)score;
+}
+
+static int bench_compare_matches(const void *left_value,
+                                 const void *right_value) {
+  const BenchMatch *left = left_value;
+  const BenchMatch *right = right_value;
+  if (left->rank_score != right->rank_score)
+    return left->rank_score > right->rank_score ? -1 : 1;
+  if (left->candidate->index != right->candidate->index)
+    return left->candidate->index < right->candidate->index ? -1 : 1;
+  return 0;
+}
+
+static bool bench_match_list_append(BenchMatchList *list,
+                                    BenchMatch match) {
+  if (list->count == list->capacity) {
+    size_t next = list->capacity ? list->capacity * 2 : 128;
+    if (next < list->capacity || next > SIZE_MAX / sizeof *list->values)
+      return false;
+    BenchMatch *grown = realloc(list->values, next * sizeof *grown);
+    if (!grown) return false;
+    list->values = grown;
+    list->capacity = next;
+  }
+  list->values[list->count++] = match;
+  return true;
+}
+
+/* fzf uses comparison sort below 128 results and an LSD radix sort above it.
+   With --tiebreak=index, the only explicit key is the inverted 16-bit score;
+   stable input order supplies the final index tiebreak. */
+static void bench_sort_matches(BenchWorker *worker) {
+  BenchMatch *values = worker->matches.values;
+  size_t count = worker->matches.count;
+  if (count < 2) return;
+  if (count < 128) {
+    qsort(values, count, sizeof *values, bench_compare_matches);
+    return;
+  }
+
+  if (worker->sort_scratch_capacity < count) {
+    BenchMatch *grown = realloc(
+        worker->sort_scratch, count * sizeof *worker->sort_scratch);
+    if (!grown) {
+      qsort(values, count, sizeof *values, bench_compare_matches);
+      return;
+    }
+    worker->sort_scratch = grown;
+    worker->sort_scratch_capacity = count;
+  }
+
+  uint16_t key_or = 0;
+  for (size_t i = 0; i < count; i++)
+    key_or |= (uint16_t)(UINT16_MAX - values[i].rank_score);
+
+  BenchMatch *source = values;
+  BenchMatch *destination = worker->sort_scratch;
+  unsigned scatters = 0;
+  for (unsigned pass = 0; pass < 2; pass++) {
+    unsigned shift = pass * 8;
+    if (((key_or >> shift) & 0xff) == 0) continue;
+    size_t counts[256] = {0};
+    for (size_t i = 0; i < count; i++) {
+      uint16_t key = (uint16_t)(UINT16_MAX - source[i].rank_score);
+      counts[(key >> shift) & 0xff]++;
+    }
+    size_t offsets[256];
+    offsets[0] = 0;
+    for (size_t i = 1; i < 256; i++)
+      offsets[i] = offsets[i - 1] + counts[i - 1];
+    for (size_t i = 0; i < count; i++) {
+      uint16_t key = (uint16_t)(UINT16_MAX - source[i].rank_score);
+      destination[offsets[(key >> shift) & 0xff]++] = source[i];
+    }
+    BenchMatch *swap = source;
+    source = destination;
+    destination = swap;
+    scatters++;
+  }
+  if (scatters & 1)
+    memcpy(values, source, count * sizeof *values);
+}
+
+static void bench_worker_scan(BenchWorker *worker) {
+  BenchPool *pool = worker->pool;
+  worker->matches.count = 0;
+  if (!worker->slab) {
+    worker->slab = fzf_make_default_slab();
+    if (!worker->slab || !fzf_slab_set_score_scheme(
+                             worker->slab, FZF_SCORE_SCHEME_DEFAULT)) {
+      atomic_store_explicit(&pool->failed, true, memory_order_relaxed);
+      return;
+    }
+  }
+
+  size_t chunk_count = (pool->corpus->count + FZF_BENCH_CHUNK_SIZE - 1) /
+      FZF_BENCH_CHUNK_SIZE;
+  for (;;) {
+    size_t chunk = atomic_fetch_add_explicit(
+        &pool->next_chunk, 1, memory_order_relaxed);
+    if (chunk >= chunk_count) break;
+    size_t first = chunk * FZF_BENCH_CHUNK_SIZE;
+    size_t end = first + FZF_BENCH_CHUNK_SIZE;
+    if (end > pool->corpus->count) end = pool->corpus->count;
+    for (size_t i = first; i < end; i++) {
+      const BenchCandidate *candidate = &pool->corpus->candidates[i];
+      int32_t score = fzf_get_score_bytes_preclassified(
+          candidate->text, candidate->length, candidate->input_is_ascii,
+          pool->pattern, worker->slab);
+      if (fzf_allocation_failed()) {
+        atomic_store_explicit(&pool->failed, true, memory_order_relaxed);
+        return;
+      }
+      if (score > 0 && !bench_match_list_append(
+                           &worker->matches,
+                           (BenchMatch){
+                               .candidate = candidate,
+                               .score = score,
+                               .rank_score = pool->has_positive_term
+                                   ? bench_rank_score(score) : 0,
+                           })) {
+        atomic_store_explicit(&pool->failed, true, memory_order_relaxed);
+        return;
+      }
+    }
+  }
+  if (pool->sort_results) bench_sort_matches(worker);
+}
+
+static void *bench_worker_main(void *data) {
+  BenchWorker *worker = data;
+  BenchPool *pool = worker->pool;
+  pthread_mutex_lock(&pool->mutex);
+  pool->ready_count++;
+  pthread_cond_signal(&pool->done_cond);
+  while (!pool->stop) {
+    while (!pool->stop && worker->seen_epoch == pool->epoch)
+      pthread_cond_wait(&pool->start_cond, &pool->mutex);
+    if (pool->stop) break;
+    worker->seen_epoch = pool->epoch;
+    pthread_mutex_unlock(&pool->mutex);
+
+    bench_worker_scan(worker);
+
+    pthread_mutex_lock(&pool->mutex);
+    if (pool->active_count > 0 && --pool->active_count == 0)
+      pthread_cond_signal(&pool->done_cond);
+  }
+  pthread_mutex_unlock(&pool->mutex);
+  return NULL;
+}
+
+static bool bench_pool_init(BenchPool *pool, size_t worker_count,
+                            const BenchCorpus *corpus,
+                            fzf_pattern_t *pattern, bool sort_results) {
+  memset(pool, 0, sizeof *pool);
+  if (pthread_mutex_init(&pool->mutex, NULL) != 0) return false;
+  if (pthread_cond_init(&pool->start_cond, NULL) != 0) {
+    pthread_mutex_destroy(&pool->mutex);
+    return false;
+  }
+  if (pthread_cond_init(&pool->done_cond, NULL) != 0) {
+    pthread_cond_destroy(&pool->start_cond);
+    pthread_mutex_destroy(&pool->mutex);
+    return false;
+  }
+  pool->workers = calloc(worker_count, sizeof *pool->workers);
+  if (!pool->workers) {
+    pthread_cond_destroy(&pool->done_cond);
+    pthread_cond_destroy(&pool->start_cond);
+    pthread_mutex_destroy(&pool->mutex);
+    return false;
+  }
+  pool->worker_count = worker_count;
+  pool->corpus = corpus;
+  pool->pattern = pattern;
+  pool->has_positive_term = pattern->has_positive_term;
+  pool->sort_results = sort_results && pattern->has_positive_term;
+  atomic_init(&pool->next_chunk, 0);
+  atomic_init(&pool->failed, false);
+
+  size_t created = 0;
+  for (; created < worker_count; created++) {
+    pool->workers[created].pool = pool;
+    if (pthread_create(&pool->workers[created].thread, NULL,
+                       bench_worker_main, &pool->workers[created]) != 0)
+      break;
+  }
+  if (created != worker_count) {
+    pthread_mutex_lock(&pool->mutex);
+    pool->stop = true;
+    pthread_cond_broadcast(&pool->start_cond);
+    pthread_mutex_unlock(&pool->mutex);
+    for (size_t i = 0; i < created; i++)
+      pthread_join(pool->workers[i].thread, NULL);
+    free(pool->workers);
+    pthread_cond_destroy(&pool->done_cond);
+    pthread_cond_destroy(&pool->start_cond);
+    pthread_mutex_destroy(&pool->mutex);
+    memset(pool, 0, sizeof *pool);
+    return false;
+  }
+
+  pthread_mutex_lock(&pool->mutex);
+  while (pool->ready_count < pool->worker_count)
+    pthread_cond_wait(&pool->done_cond, &pool->mutex);
+  pthread_mutex_unlock(&pool->mutex);
+  return true;
+}
+
+static BenchMerger *bench_make_pass_merger(size_t count) {
+  BenchMerger *merger = calloc(1, sizeof *merger);
+  if (merger) {
+    merger->count = count;
+    merger->pass = true;
+  }
+  return merger;
+}
+
+static BenchMerger *bench_make_result_merger(BenchPool *pool,
+                                             size_t list_count) {
+  BenchMerger *merger = calloc(1, sizeof *merger);
+  if (!merger) return NULL;
+  merger->list_count = list_count;
+  merger->sorted = pool->sort_results;
+  if (list_count == 0) return merger;
+
+  merger->lists = calloc(list_count, sizeof *merger->lists);
+  merger->cursors = calloc(list_count, sizeof *merger->cursors);
+  if (!merger->lists || !merger->cursors) {
+    free(merger->cursors);
+    free(merger->lists);
+    free(merger);
+    return NULL;
+  }
+  for (size_t i = 0; i < list_count; i++) {
+    merger->lists[i] = pool->workers[i].matches;
+    if (merger->lists[i].count > SIZE_MAX - merger->count) {
+      free(merger->cursors);
+      free(merger->lists);
+      free(merger);
+      return NULL;
+    }
+    merger->count += merger->lists[i].count;
+  }
+  return merger;
+}
+
+static void bench_free_merger(BenchMerger *merger) {
+  if (!merger) return;
+  free(merger->cursors);
+  free(merger->lists);
+  free(merger);
+}
+
+static void bench_pool_discard_results(BenchPool *pool) {
+  if (pool->result.pass_merger != pool->result.merger)
+    bench_free_merger(pool->result.pass_merger);
+  bench_free_merger(pool->result.merger);
+  pool->result = (BenchScanResult){0};
+  for (size_t i = 0; i < pool->worker_count; i++) {
+    free(pool->workers[i].matches.values);
+    pool->workers[i].matches = (BenchMatchList){0};
+  }
+}
+
+static bool bench_pool_run(BenchPool *pool) {
+  /* PassMerger performs this chunk count at the start of matcher.scan. */
+  size_t chunk_count = (pool->corpus->count + FZF_BENCH_CHUNK_SIZE - 1) /
+      FZF_BENCH_CHUNK_SIZE;
+  if (chunk_count == 0) {
+    pool->result.merger = bench_make_result_merger(pool, 0);
+    return pool->result.merger != NULL;
+  }
+
+  size_t pass_count = 0;
+  for (size_t first = 0; first < pool->corpus->count;
+       first += FZF_BENCH_CHUNK_SIZE) {
+    size_t remaining = pool->corpus->count - first;
+    pass_count += remaining < FZF_BENCH_CHUNK_SIZE
+        ? remaining : FZF_BENCH_CHUNK_SIZE;
+  }
+  pool->result.pass_merger = bench_make_pass_merger(pass_count);
+  if (!pool->result.pass_merger) return false;
+  if (pool->pattern->ptr == NULL) {
+    pool->result.merger = pool->result.pass_merger;
+    return true;
+  }
+
+  atomic_store_explicit(&pool->next_chunk, 0, memory_order_relaxed);
+  atomic_store_explicit(&pool->failed, false, memory_order_relaxed);
+  pthread_mutex_lock(&pool->mutex);
+  pool->active_count = pool->worker_count;
+  pool->epoch++;
+  pthread_cond_broadcast(&pool->start_cond);
+  while (pool->active_count > 0)
+    pthread_cond_wait(&pool->done_cond, &pool->mutex);
+  pthread_mutex_unlock(&pool->mutex);
+
+  if (atomic_load_explicit(&pool->failed, memory_order_relaxed)) return false;
+  pool->result.merger = bench_make_result_merger(pool, pool->worker_count);
+  return pool->result.merger != NULL;
+}
+
+static size_t bench_pool_result_length(const BenchPool *pool) {
+  return pool->result.merger ? pool->result.merger->count : 0;
+}
+
+static void bench_pool_destroy(BenchPool *pool) {
+  pthread_mutex_lock(&pool->mutex);
+  pool->stop = true;
+  pthread_cond_broadcast(&pool->start_cond);
+  pthread_mutex_unlock(&pool->mutex);
+  for (size_t i = 0; i < pool->worker_count; i++) {
+    pthread_join(pool->workers[i].thread, NULL);
+    fzf_free_slab(pool->workers[i].slab);
+    free(pool->workers[i].sort_scratch);
+  }
+  bench_pool_discard_results(pool);
+  free(pool->workers);
+  pthread_cond_destroy(&pool->done_cond);
+  pthread_cond_destroy(&pool->start_cond);
+  pthread_mutex_destroy(&pool->mutex);
+  memset(pool, 0, sizeof *pool);
+}
+
+static uint64_t bench_hash_bytes(uint64_t hash, const void *data,
+                                 size_t length) {
+  const unsigned char *bytes = data;
+  for (size_t i = 0; i < length; i++) {
+    hash ^= bytes[i];
+    hash *= UINT64_C(1099511628211);
+  }
+  return hash;
+}
+
+static uint64_t bench_hash_u64(uint64_t hash, uint64_t value) {
+  unsigned char encoded[8];
+  for (unsigned i = 0; i < 8; i++)
+    encoded[i] = (unsigned char)(value >> (i * 8));
+  return bench_hash_bytes(hash, encoded, sizeof encoded);
+}
+
+static uint64_t bench_input_checksum(const BenchCorpus *corpus) {
+  static const char version[] = "fzf-native-bench-input-v1";
+  uint64_t hash = bench_hash_bytes(
+      UINT64_C(14695981039346656037), version, sizeof version - 1);
+  hash = bench_hash_u64(hash, corpus->count);
+  for (size_t i = 0; i < corpus->count; i++) {
+    const BenchCandidate *candidate = &corpus->candidates[i];
+    hash = bench_hash_u64(hash, candidate->length);
+    hash = bench_hash_bytes(hash, candidate->text, candidate->length);
+  }
+  return hash;
+}
+
+static bool bench_match_precedes(const BenchMatch *left,
+                                 const BenchMatch *right,
+                                 bool sortable) {
+  if (sortable && left->rank_score != right->rank_score)
+    return left->rank_score > right->rank_score;
+  return left->candidate->index < right->candidate->index;
+}
+
+static bool bench_result_checksum(BenchPool *pool, size_t match_count,
+                                  uint64_t *checksum) {
+  static const char version[] = "fzf-native-bench-result-v1";
+  uint64_t hash = bench_hash_bytes(
+      UINT64_C(14695981039346656037), version, sizeof version - 1);
+  hash = bench_hash_u64(hash, pool->corpus->count);
+  hash = bench_hash_u64(hash, match_count);
+
+  if (pool->pattern->ptr == NULL) {
+    for (size_t i = 0; i < pool->corpus->count; i++) {
+      hash = bench_hash_u64(hash, pool->corpus->candidates[i].index);
+      hash = bench_hash_u64(hash, 0);
+    }
+    *checksum = hash;
+    return true;
+  }
+
+  BenchMerger *merger = pool->result.merger;
+  if (!merger || merger->pass || merger->count != match_count) return false;
+  if (merger->list_count > 0)
+    memset(merger->cursors, 0,
+           merger->list_count * sizeof *merger->cursors);
+  for (size_t emitted = 0; emitted < match_count; emitted++) {
+    const BenchMatch *best = NULL;
+    size_t best_worker = 0;
+    for (size_t worker = 0; worker < merger->list_count; worker++) {
+      const BenchMatchList *list = &merger->lists[worker];
+      if (merger->cursors[worker] >= list->count) continue;
+      const BenchMatch *candidate =
+          &list->values[merger->cursors[worker]];
+      if (!best || bench_match_precedes(
+                       candidate, best, merger->sorted)) {
+        best = candidate;
+        best_worker = worker;
+      }
+    }
+    if (!best) return false;
+    hash = bench_hash_u64(hash, best->candidate->index);
+    hash = bench_hash_u64(hash, best->rank_score);
+    merger->cursors[best_worker]++;
+  }
+  *checksum = hash;
+  return true;
+}
+
+static bool bench_write_candidate(const BenchCandidate *candidate) {
+  return fwrite(candidate->text, 1, candidate->length, stdout) ==
+             candidate->length &&
+      fputc('\n', stdout) != EOF;
+}
+
+/* Materialize the lazy merge only in this untimed correctness mode.
+   The native library preserves malformed bytes.  fzf replaces them with
+   U+FFFD during ingestion, so byte-for-byte fzf comparisons require valid
+   UTF-8 input. */
+static bool bench_dump_results(BenchPool *pool, size_t match_count) {
+  if (pool->pattern->ptr == NULL) {
+    for (size_t i = 0; i < pool->corpus->count; i++)
+      if (!bench_write_candidate(&pool->corpus->candidates[i])) return false;
+    return fflush(stdout) == 0;
+  }
+
+  BenchMerger *merger = pool->result.merger;
+  if (!merger || merger->pass || merger->count != match_count) return false;
+  if (merger->list_count > 0)
+    memset(merger->cursors, 0,
+           merger->list_count * sizeof *merger->cursors);
+  bool success = true;
+  for (size_t emitted = 0; emitted < match_count; emitted++) {
+    const BenchMatch *best = NULL;
+    size_t best_worker = 0;
+    for (size_t worker = 0; worker < merger->list_count; worker++) {
+      const BenchMatchList *list = &merger->lists[worker];
+      if (merger->cursors[worker] >= list->count) continue;
+      const BenchMatch *candidate =
+          &list->values[merger->cursors[worker]];
+      if (!best || bench_match_precedes(
+                       candidate, best, merger->sorted)) {
+        best = candidate;
+        best_worker = worker;
+      }
+    }
+    if (!best || !bench_write_candidate(best->candidate)) {
+      success = false;
+      break;
+    }
+    merger->cursors[best_worker]++;
+  }
+  return success && fflush(stdout) == 0;
+}
+
+static char *bench_duplicate(const char *text) {
+  size_t length = strlen(text) + 1;
+  char *copy = malloc(length);
+  if (copy) memcpy(copy, text, length);
+  return copy;
+}
+
+int main(int argc, char **argv) {
+  BenchOptions options;
+  if (!bench_parse_options(argc, argv, &options)) {
+    bench_usage(stderr, argv[0]);
+    return 2;
+  }
+  if (options.help) {
+    bench_usage(stdout, argv[0]);
+    return 0;
+  }
+
+  uint64_t ingestion_started = bench_now_ns();
+  BenchCorpus corpus;
+  if (!bench_load_corpus(stdin, &corpus)) {
+    fprintf(stderr, "fzf-native benchmark: could not ingest stdin\n");
+    return 1;
+  }
+  uint64_t ingestion_ns = bench_now_ns() - ingestion_started;
+  uint64_t input_checksum = bench_input_checksum(&corpus);
+
+  char *query_copy = bench_duplicate(options.query);
+  fzf_pattern_t *pattern = query_copy
+      ? fzf_parse_pattern(
+            CaseSmart, options.normalize, query_copy, true) : NULL;
+  free(query_copy);
+  if (!pattern) {
+    fprintf(stderr, "fzf-native benchmark: could not parse query\n");
+    bench_free_corpus(&corpus);
+    return 1;
+  }
+
+  size_t chunk_count = (corpus.count + FZF_BENCH_CHUNK_SIZE - 1) /
+      FZF_BENCH_CHUNK_SIZE;
+  size_t worker_count = options.threads;
+  if (chunk_count > 0 && worker_count > chunk_count)
+    worker_count = chunk_count;
+  if (worker_count == 0) worker_count = 1;
+
+  BenchPool pool;
+  if (!bench_pool_init(
+          &pool, worker_count, &corpus, pattern, options.sort_results)) {
+    fprintf(stderr, "fzf-native benchmark: could not start workers\n");
+    fzf_free_pattern(pattern);
+    bench_free_corpus(&corpus);
+    return 1;
+  }
+
+  size_t match_count = 0;
+  uint64_t *samples = NULL;
+  size_t sample_count = 0;
+  size_t sample_capacity = 0;
+  bool success = true;
+  if (options.check_only || options.dump_results) {
+    bench_pool_discard_results(&pool);
+    success = bench_pool_run(&pool);
+    if (success) match_count = bench_pool_result_length(&pool);
+  } else {
+    uint64_t started = bench_now_ns();
+    uint64_t deadline = UINT64_MAX - started < options.duration_ns
+        ? UINT64_MAX : started + options.duration_ns;
+    while (bench_now_ns() < deadline) {
+      bench_pool_discard_results(&pool);
+      uint64_t scan_started = bench_now_ns();
+      if (!bench_pool_run(&pool)) {
+        success = false;
+        break;
+      }
+      uint64_t elapsed = bench_now_ns() - scan_started;
+      match_count = bench_pool_result_length(&pool);
+      if (sample_count == sample_capacity) {
+        size_t next = sample_capacity ? sample_capacity * 2 : 128;
+        if (next < sample_capacity || next > SIZE_MAX / sizeof *samples) {
+          success = false;
+          break;
+        }
+        uint64_t *grown = realloc(samples, next * sizeof *grown);
+        if (!grown) {
+          success = false;
+          break;
+        }
+        samples = grown;
+        sample_capacity = next;
+      }
+      samples[sample_count++] = elapsed;
+    }
+    if (sample_count == 0) success = false;
+  }
+
+  uint64_t result_checksum = 0;
+  if (success && options.dump_results)
+    success = bench_dump_results(&pool, match_count);
+  else if (success)
+    success = bench_result_checksum(&pool, match_count, &result_checksum);
+  if (!success) {
+    fprintf(stderr, "fzf-native benchmark: scan or output failed\n");
+  } else if (options.dump_results) {
+    /* bench_dump_results has already written the intentionally plain output. */
+  } else if (options.check_only) {
+    printf("semantic items=%zu matches=%zu input_checksum=%016" PRIx64
+           " result_checksum=%016" PRIx64 "\n",
+           corpus.count, match_count, input_checksum, result_checksum);
+  } else {
+    long double total_ns = 0.0;
+    uint64_t minimum = samples[0];
+    uint64_t maximum = samples[0];
+    for (size_t i = 0; i < sample_count; i++) {
+      total_ns += samples[i];
+      if (samples[i] < minimum) minimum = samples[i];
+      if (samples[i] > maximum) maximum = samples[i];
+    }
+    double average_ms = (double)(total_ns / sample_count / 1e6L);
+    double selectivity = corpus.count
+        ? (double)match_count / (double)corpus.count * 100.0 : 0.0;
+    printf("  %zu iterations  avg: %.2fms  min: %.2fms  max: %.2fms  "
+           "total: %.2Lfs  items: %zu  matches: %zu (%.2f%%)  "
+           "ingestion: %.2fms\n",
+           sample_count, average_ms, (double)minimum / 1e6,
+           (double)maximum / 1e6, total_ns / 1e9L, corpus.count,
+           match_count, selectivity, (double)ingestion_ns / 1e6);
+    printf("semantic items=%zu matches=%zu input_checksum=%016" PRIx64
+           " result_checksum=%016" PRIx64 "\n",
+           corpus.count, match_count, input_checksum, result_checksum);
+  }
+
+  free(samples);
+  bench_pool_destroy(&pool);
+  fzf_free_pattern(pattern);
+  bench_free_corpus(&corpus);
+  return success ? 0 : 1;
+}

--- a/benchmarks/fzf-bench-driver.c
+++ b/benchmarks/fzf-bench-driver.c
@@ -18,8 +18,8 @@
  * fzf also performs cold ChunkCache bookkeeping inside Pattern.Match after
  * clearing that cache before each sample.  The native scorer has no analogous
  * cache interface, so this driver does not add a synthetic cache cost.
- * The --no-sort mode is a native diagnostic.  fzf filter mode forces sorting
- * for sortable patterns, even when its command line contains --no-sort.
+ * The --no-sort mode is an unmeasured diagnostic.  Every parity-campaign lane
+ * explicitly enables sorting in both this driver and fzf.
  */
 
 #include <errno.h>

--- a/benchmarks/fzf-bench-driver.c
+++ b/benchmarks/fzf-bench-driver.c
@@ -124,6 +124,7 @@ typedef struct {
   bool tiebreak_index;
   bool check_only;
   bool dump_results;
+  bool dump_semantic;
   bool help;
 } BenchOptions;
 
@@ -137,7 +138,7 @@ static uint64_t bench_now_ns(void) {
 static void bench_usage(FILE *stream, const char *program) {
   fprintf(stream,
           "usage: %s --filter QUERY "
-          "(--bench DURATION | --check | --dump-results) "
+          "(--bench DURATION | --check | --dump-results | --dump-semantic) "
           "[--threads N] [--literal] "
           "[--sort | --no-sort] [--algo=v2] --tiebreak=index\n",
           program);
@@ -220,6 +221,8 @@ static bool bench_parse_options(int argc, char **argv,
       options->check_only = true;
     } else if (strcmp(argument, "--dump-results") == 0) {
       options->dump_results = true;
+    } else if (strcmp(argument, "--dump-semantic") == 0) {
+      options->dump_semantic = true;
     } else if (strcmp(argument, "--literal") == 0) {
       options->normalize = false;
     } else if (strcmp(argument, "--no-literal") == 0) {
@@ -259,7 +262,7 @@ static bool bench_parse_options(int argc, char **argv,
 
   if (options->help) return true;
   unsigned modes = (options->duration_ns > 0) + options->check_only +
-      options->dump_results;
+      options->dump_results + options->dump_semantic;
   if (!options->query || !options->tiebreak_index || modes != 1)
     return false;
   if (options->threads == 0) options->threads = bench_online_threads();
@@ -823,6 +826,67 @@ static bool bench_dump_results(BenchPool *pool, size_t match_count) {
   return success && fflush(stdout) == 0;
 }
 
+/* Emit the exact identity and rank inputs used by the adapter.  This mode is
+   intentionally untimed.  A pinned helper inside the upstream fzf package
+   consumes the same candidates for the parity checker. */
+static bool bench_dump_semantic(BenchPool *pool, size_t match_count) {
+  BenchMerger *merger = pool->result.merger;
+  if (!merger || merger->pass || merger->count != match_count) return false;
+  if (merger->list_count > 0)
+    memset(merger->cursors, 0,
+           merger->list_count * sizeof *merger->cursors);
+
+  fzf_slab_t *slab = fzf_make_default_slab();
+  if (!slab || !fzf_slab_set_score_scheme(
+                   slab, FZF_SCORE_SCHEME_DEFAULT)) {
+    fzf_free_slab(slab);
+    return false;
+  }
+
+  bool success = true;
+  for (size_t emitted = 0; emitted < match_count; emitted++) {
+    const BenchMatch *best = NULL;
+    size_t best_worker = 0;
+    for (size_t worker = 0; worker < merger->list_count; worker++) {
+      const BenchMatchList *list = &merger->lists[worker];
+      if (merger->cursors[worker] >= list->count) continue;
+      const BenchMatch *candidate =
+          &list->values[merger->cursors[worker]];
+      if (!best || bench_match_precedes(candidate, best, merger->sorted)) {
+        best = candidate;
+        best_worker = worker;
+      }
+    }
+    if (!best) {
+      success = false;
+      break;
+    }
+
+    fzf_score_bounds_t bounds;
+    int32_t membership_score = fzf_get_score_with_bounds_bytes_preclassified(
+        best->candidate->text, best->candidate->length,
+        best->candidate->input_is_ascii, pool->pattern, slab, &bounds);
+    uint16_t rank_score = pool->has_positive_term
+        ? bench_rank_score(bounds.raw_score) : 0;
+    uint16_t point3 = (uint16_t)(UINT16_MAX - rank_score);
+    if (membership_score <= 0 || fzf_allocation_failed() ||
+        rank_score != best->rank_score ||
+        printf("%" PRIu32 "\t%" PRId64 "\t%d\t%d\t%d\t%d\t"
+               "%u\t0\t0\t0\t%u\n",
+               best->candidate->index, bounds.raw_score,
+               bounds.min_begin, bounds.min_end, bounds.max_end,
+               bounds.valid ? 1 : 0, (unsigned)rank_score,
+               (unsigned)point3) < 0) {
+      success = false;
+      break;
+    }
+    merger->cursors[best_worker]++;
+  }
+
+  fzf_free_slab(slab);
+  return success && fflush(stdout) == 0;
+}
+
 static char *bench_duplicate(const char *text) {
   size_t length = strlen(text) + 1;
   char *copy = malloc(length);
@@ -882,7 +946,7 @@ int main(int argc, char **argv) {
   size_t sample_count = 0;
   size_t sample_capacity = 0;
   bool success = true;
-  if (options.check_only || options.dump_results) {
+  if (options.check_only || options.dump_results || options.dump_semantic) {
     bench_pool_discard_results(&pool);
     success = bench_pool_run(&pool);
     if (success) match_count = bench_pool_result_length(&pool);
@@ -921,12 +985,14 @@ int main(int argc, char **argv) {
   uint64_t result_checksum = 0;
   if (success && options.dump_results)
     success = bench_dump_results(&pool, match_count);
+  else if (success && options.dump_semantic)
+    success = bench_dump_semantic(&pool, match_count);
   else if (success)
     success = bench_result_checksum(&pool, match_count, &result_checksum);
   if (!success) {
     fprintf(stderr, "fzf-native benchmark: scan or output failed\n");
-  } else if (options.dump_results) {
-    /* bench_dump_results has already written the intentionally plain output. */
+  } else if (options.dump_results || options.dump_semantic) {
+    /* The selected dump mode has already written its output. */
   } else if (options.check_only) {
     printf("semantic items=%zu matches=%zu input_checksum=%016" PRIx64
            " result_checksum=%016" PRIx64 "\n",

--- a/benchmarks/fzf-bench-driver.c
+++ b/benchmarks/fzf-bench-driver.c
@@ -37,7 +37,7 @@
 #include <unistd.h>
 
 #include "fzf-private.h"
-#include "utf8proc-2.10.0/utf8proc.h"
+#include "utf8proc.h"
 
 #ifndef FZF_BENCH_CHUNK_SIZE
 #define FZF_BENCH_CHUNK_SIZE 1024
@@ -47,9 +47,9 @@ typedef struct {
   const char *text;
   size_t length;
   uint32_t index;
-  uint16_t trim_length;
-  bool trim_length_known;
+  uint16_t rank_length;
   bool input_is_ascii;
+  bool rank_length_known;
 } BenchCandidate;
 
 typedef struct {
@@ -320,48 +320,6 @@ static bool bench_read_all(FILE *stream, char **bytes, size_t *length) {
   return true;
 }
 
-static bool bench_unicode_is_space(utf8proc_int32_t codepoint) {
-  if ((codepoint >= 0x09 && codepoint <= 0x0d) || codepoint == 0x85)
-    return true;
-  utf8proc_category_t category = utf8proc_category(codepoint);
-  return category == UTF8PROC_CATEGORY_ZS ||
-      category == UTF8PROC_CATEGORY_ZL ||
-      category == UTF8PROC_CATEGORY_ZP;
-}
-
-/* Match fzf's rune-based, whitespace-trimmed length tiebreak. */
-static uint16_t bench_trim_length(const char *text, size_t length) {
-  size_t position = 0;
-  size_t rune_index = 0;
-  size_t first_nonspace = SIZE_MAX;
-  size_t last_nonspace = 0;
-  while (position < length) {
-    utf8proc_int32_t codepoint = 0xfffd;
-    utf8proc_ssize_t amount = utf8proc_iterate(
-        (const utf8proc_uint8_t *)text + position,
-        (utf8proc_ssize_t)(length - position), &codepoint);
-    if (amount <= 0) amount = 1;
-    if (!bench_unicode_is_space(codepoint)) {
-      if (first_nonspace == SIZE_MAX) first_nonspace = rune_index;
-      last_nonspace = rune_index;
-    }
-    position += (size_t)amount;
-    rune_index++;
-  }
-  if (first_nonspace == SIZE_MAX) return 0;
-  size_t trimmed = last_nonspace - first_nonspace + 1;
-  return trimmed > UINT16_MAX ? UINT16_MAX : (uint16_t)trimmed;
-}
-
-static uint16_t bench_candidate_trim_length(BenchCandidate *candidate) {
-  if (!candidate->trim_length_known) {
-    candidate->trim_length = bench_trim_length(
-        candidate->text, candidate->length);
-    candidate->trim_length_known = true;
-  }
-  return candidate->trim_length;
-}
-
 static bool bench_load_corpus(FILE *stream, BenchCorpus *corpus) {
   memset(corpus, 0, sizeof *corpus);
   if (!bench_read_all(stream, &corpus->bytes, &corpus->byte_count))
@@ -421,6 +379,66 @@ static uint16_t bench_rank_score(int64_t score) {
   return score > UINT16_MAX ? UINT16_MAX : (uint16_t)score;
 }
 
+static bool bench_rank_is_space(utf8proc_int32_t codepoint) {
+  return (codepoint >= 0x09 && codepoint <= 0x0d) ||
+      codepoint == 0x20 || codepoint == 0x85 || codepoint == 0xa0 ||
+      codepoint == 0x1680 ||
+      (codepoint >= 0x2000 && codepoint <= 0x200a) ||
+      codepoint == 0x2028 || codepoint == 0x2029 ||
+      codepoint == 0x202f || codepoint == 0x205f ||
+      codepoint == 0x3000;
+}
+
+/* fzf computes Item.TrimLength lazily on the first matching scan and caches
+   it on the item.  Each candidate belongs to one worker per scan, and scans
+   do not overlap, so the equivalent per-candidate cache needs no lock. */
+static uint16_t bench_rank_length(BenchCandidate *candidate) {
+  if (candidate->rank_length_known) return candidate->rank_length;
+
+  if (candidate->input_is_ascii) {
+    size_t first = 0;
+    size_t end = candidate->length;
+    while (first < end &&
+           bench_rank_is_space((unsigned char)candidate->text[first]))
+      first++;
+    while (end > first &&
+           bench_rank_is_space((unsigned char)candidate->text[end - 1]))
+      end--;
+    size_t length = end - first;
+    candidate->rank_length = length > UINT16_MAX
+        ? UINT16_MAX : (uint16_t)length;
+    candidate->rank_length_known = true;
+    return candidate->rank_length;
+  }
+
+  size_t first_nonspace = SIZE_MAX;
+  size_t last_nonspace = 0;
+  size_t rune_index = 0;
+  size_t offset = 0;
+  while (offset < candidate->length) {
+    utf8proc_int32_t codepoint = 0;
+    utf8proc_ssize_t width = utf8proc_iterate(
+        (const utf8proc_uint8_t *)candidate->text + offset,
+        (utf8proc_ssize_t)(candidate->length - offset), &codepoint);
+    if (width <= 0) {
+      codepoint = (unsigned char)candidate->text[offset];
+      width = 1;
+    }
+    if (!bench_rank_is_space(codepoint)) {
+      if (first_nonspace == SIZE_MAX) first_nonspace = rune_index;
+      last_nonspace = rune_index;
+    }
+    offset += (size_t)width;
+    rune_index++;
+  }
+  size_t length = first_nonspace == SIZE_MAX
+      ? 0 : last_nonspace - first_nonspace + 1;
+  candidate->rank_length = length > UINT16_MAX
+      ? UINT16_MAX : (uint16_t)length;
+  candidate->rank_length_known = true;
+  return candidate->rank_length;
+}
+
 static int bench_compare_matches(const void *left_value,
                                  const void *right_value) {
   const BenchMatch *left = left_value;
@@ -455,7 +473,9 @@ static uint32_t bench_sort_key(const BenchMatch *match) {
 }
 
 /* fzf uses comparison sort below 128 results and an LSD radix sort above it.
-   Stable input order supplies the final index tiebreak. */
+   The default key is inverted score followed by trimmed rune length.  With
+   --tiebreak=index, the length half is zero and stable input order supplies
+   the final index tiebreak. */
 static void bench_sort_matches(BenchWorker *worker) {
   BenchMatch *values = worker->matches.values;
   size_t count = worker->matches.count;
@@ -552,7 +572,7 @@ static void bench_worker_scan(BenchWorker *worker) {
                                .rank_score = pool->has_positive_term
                                    ? bench_rank_score(bounds.raw_score) : 0,
                                .rank_length = pool->tiebreak_length
-                                   ? bench_candidate_trim_length(candidate) : 0,
+                                   ? bench_rank_length(candidate) : 0,
                            })) {
         atomic_store_explicit(&pool->failed, true, memory_order_relaxed);
         return;
@@ -936,14 +956,16 @@ static bool bench_dump_semantic(BenchPool *pool, size_t match_count) {
         best->candidate->input_is_ascii, pool->pattern, slab, &bounds);
     uint16_t rank_score = pool->has_positive_term
         ? bench_rank_score(bounds.raw_score) : 0;
+    uint16_t rank_length = best->rank_length;
     uint16_t point3 = (uint16_t)(UINT16_MAX - rank_score);
     if (membership_score <= 0 || fzf_allocation_failed() ||
         rank_score != best->rank_score ||
         printf("%" PRIu32 "\t%" PRId64 "\t%d\t%d\t%d\t%d\t"
-               "%u\t0\t0\t0\t%u\n",
+               "%u\t0\t0\t%u\t%u\n",
                best->candidate->index, bounds.raw_score,
                bounds.min_begin, bounds.min_end, bounds.max_end,
                bounds.valid ? 1 : 0, (unsigned)rank_score,
+               (unsigned)rank_length,
                (unsigned)point3) < 0) {
       success = false;
       break;

--- a/benchmarks/fzf-bench-driver.c
+++ b/benchmarks/fzf-bench-driver.c
@@ -59,7 +59,7 @@ typedef struct {
 /* Keep the same 16-byte result footprint as fzf's Result on 64-bit hosts. */
 typedef struct {
   const BenchCandidate *candidate;
-  int32_t score;
+  int32_t membership;
   uint16_t rank_score;
   uint16_t reserved;
 } BenchMatch;
@@ -359,7 +359,7 @@ static void bench_free_corpus(BenchCorpus *corpus) {
   memset(corpus, 0, sizeof *corpus);
 }
 
-static uint16_t bench_rank_score(int32_t score) {
+static uint16_t bench_rank_score(int64_t score) {
   if (score <= 0) return 0;
   return score > UINT16_MAX ? UINT16_MAX : (uint16_t)score;
 }
@@ -428,6 +428,9 @@ static void bench_sort_matches(BenchWorker *worker) {
       uint16_t key = (uint16_t)(UINT16_MAX - source[i].rank_score);
       counts[(key >> shift) & 0xff]++;
     }
+    uint16_t first_key = (uint16_t)(UINT16_MAX - source[0].rank_score);
+    if (counts[(first_key >> shift) & 0xff] == count) continue;
+
     size_t offsets[256];
     offsets[0] = 0;
     for (size_t i = 1; i < 256; i++)
@@ -468,20 +471,23 @@ static void bench_worker_scan(BenchWorker *worker) {
     if (end > pool->corpus->count) end = pool->corpus->count;
     for (size_t i = first; i < end; i++) {
       const BenchCandidate *candidate = &pool->corpus->candidates[i];
-      int32_t score = fzf_get_score_bytes_preclassified(
+      fzf_score_bounds_t bounds;
+      int32_t membership = fzf_get_score_with_bounds_bytes_preclassified(
           candidate->text, candidate->length, candidate->input_is_ascii,
-          pool->pattern, worker->slab);
+          pool->pattern, worker->slab, &bounds);
       if (fzf_allocation_failed()) {
         atomic_store_explicit(&pool->failed, true, memory_order_relaxed);
         return;
       }
-      if (score > 0 && !bench_match_list_append(
+      /* The public return preserves membership with a positive sentinel.
+         A v1 fallback can have a negative raw score.  Rank the raw aggregate,
+         as fzf does, rather than adding sentinel-adjusted term scores. */
+      if (membership > 0 && !bench_match_list_append(
                            &worker->matches,
                            (BenchMatch){
                                .candidate = candidate,
-                               .score = score,
-                               .rank_score = pool->has_positive_term
-                                   ? bench_rank_score(score) : 0,
+                               .membership = membership,
+                               .rank_score = bench_rank_score(bounds.raw_score),
                            })) {
         atomic_store_explicit(&pool->failed, true, memory_order_relaxed);
         return;

--- a/benchmarks/fzf-bench-driver.c
+++ b/benchmarks/fzf-bench-driver.c
@@ -129,8 +129,15 @@ typedef struct {
   bool check_only;
   bool dump_results;
   bool dump_semantic;
+#ifdef FZF_BENCH_TEST_HOOKS
+  bool check_trim_cache;
+#endif
   bool help;
 } BenchOptions;
+
+#ifdef FZF_BENCH_TEST_HOOKS
+static _Atomic size_t bench_trim_length_computations;
+#endif
 
 static uint64_t bench_now_ns(void) {
   struct timespec now;
@@ -229,6 +236,10 @@ static bool bench_parse_options(int argc, char **argv,
       options->dump_results = true;
     } else if (strcmp(argument, "--dump-semantic") == 0) {
       options->dump_semantic = true;
+#ifdef FZF_BENCH_TEST_HOOKS
+    } else if (strcmp(argument, "--check-trim-cache") == 0) {
+      options->check_trim_cache = true;
+#endif
     } else if (strcmp(argument, "--literal") == 0) {
       options->normalize = false;
     } else if (strcmp(argument, "--no-literal") == 0) {
@@ -274,8 +285,14 @@ static bool bench_parse_options(int argc, char **argv,
   if (options->help) return true;
   unsigned modes = (options->duration_ns > 0) + options->check_only +
       options->dump_results + options->dump_semantic;
+#ifdef FZF_BENCH_TEST_HOOKS
+  modes += options->check_trim_cache;
+#endif
   if (!options->query || modes != 1)
     return false;
+#ifdef FZF_BENCH_TEST_HOOKS
+  if (options->check_trim_cache && !options->tiebreak_length) return false;
+#endif
   if (options->threads == 0) options->threads = bench_online_threads();
   return options->threads > 0;
 }
@@ -393,6 +410,10 @@ static bool bench_rank_is_space(utf8proc_int32_t codepoint) {
    do not overlap, so the equivalent per-candidate cache needs no lock. */
 static uint16_t bench_rank_length(BenchCandidate *candidate) {
   if (candidate->rank_length_known) return candidate->rank_length;
+#ifdef FZF_BENCH_TEST_HOOKS
+  atomic_fetch_add_explicit(
+      &bench_trim_length_computations, 1, memory_order_relaxed);
+#endif
 
   if (candidate->input_is_ascii) {
     size_t first = 0;
@@ -437,6 +458,15 @@ static uint16_t bench_rank_length(BenchCandidate *candidate) {
   candidate->rank_length_known = true;
   return candidate->rank_length;
 }
+
+#ifdef FZF_BENCH_TEST_HOOKS
+static size_t bench_known_trim_lengths(const BenchCorpus *corpus) {
+  size_t count = 0;
+  for (size_t i = 0; i < corpus->count; i++)
+    count += corpus->candidates[i].rank_length_known;
+  return count;
+}
+#endif
 
 static int bench_compare_matches(const void *left_value,
                                  const void *right_value) {
@@ -1036,10 +1066,49 @@ int main(int argc, char **argv) {
   size_t sample_count = 0;
   size_t sample_capacity = 0;
   bool success = true;
-  if (options.check_only || options.dump_results || options.dump_semantic) {
+#ifdef FZF_BENCH_TEST_HOOKS
+  size_t trim_before_known = 0;
+  size_t trim_before_computed = 0;
+  size_t trim_first_matches = 0;
+  size_t trim_first_known = 0;
+  size_t trim_first_computed = 0;
+  size_t trim_second_known = 0;
+  size_t trim_second_computed = 0;
+  if (options.check_trim_cache) {
+    trim_before_known = bench_known_trim_lengths(&corpus);
+    trim_before_computed = atomic_load_explicit(
+        &bench_trim_length_computations, memory_order_relaxed);
+  }
+#endif
+  bool single_scan = options.check_only || options.dump_results ||
+      options.dump_semantic;
+#ifdef FZF_BENCH_TEST_HOOKS
+  single_scan = single_scan || options.check_trim_cache;
+#endif
+  if (single_scan) {
     bench_pool_discard_results(&pool);
     success = bench_pool_run(&pool);
     if (success) match_count = bench_pool_result_length(&pool);
+#ifdef FZF_BENCH_TEST_HOOKS
+    if (success && options.check_trim_cache) {
+      trim_first_matches = match_count;
+      trim_first_known = bench_known_trim_lengths(&corpus);
+      trim_first_computed = atomic_load_explicit(
+          &bench_trim_length_computations, memory_order_relaxed);
+      bench_pool_discard_results(&pool);
+      success = bench_pool_run(&pool);
+      if (success) match_count = bench_pool_result_length(&pool);
+      trim_second_known = bench_known_trim_lengths(&corpus);
+      trim_second_computed = atomic_load_explicit(
+          &bench_trim_length_computations, memory_order_relaxed);
+      success = success && trim_before_known == 0 &&
+          trim_before_computed == 0 && trim_first_matches == match_count &&
+          trim_first_known == trim_first_matches &&
+          trim_first_computed == trim_first_matches &&
+          trim_second_known == trim_first_known &&
+          trim_second_computed == trim_first_computed;
+    }
+#endif
   } else {
     uint64_t started = bench_now_ns();
     uint64_t deadline = UINT64_MAX - started < options.duration_ns
@@ -1075,7 +1144,12 @@ int main(int argc, char **argv) {
   uint64_t total_ns = 0;
   uint64_t minimum = sample_count ? samples[0] : 0;
   uint64_t maximum = sample_count ? samples[0] : 0;
-  if (success && !options.check_only && !options.dump_results) {
+  if (success && !options.check_only && !options.dump_results &&
+      !options.dump_semantic
+#ifdef FZF_BENCH_TEST_HOOKS
+      && !options.check_trim_cache
+#endif
+      ) {
     for (size_t i = 0; i < sample_count; i++) {
       if (UINT64_MAX - total_ns < samples[i]) {
         success = false;
@@ -1092,12 +1166,26 @@ int main(int argc, char **argv) {
     success = bench_dump_results(&pool, match_count);
   else if (success && options.dump_semantic)
     success = bench_dump_semantic(&pool, match_count);
+#ifdef FZF_BENCH_TEST_HOOKS
+  else if (success && options.check_trim_cache) {
+    /* The cache assertions above are the complete result for this mode. */
+  }
+#endif
   else if (success)
     success = bench_result_checksum(&pool, match_count, &result_checksum);
   if (!success) {
     fprintf(stderr, "fzf-native benchmark: scan or output failed\n");
   } else if (options.dump_results || options.dump_semantic) {
     /* The selected dump mode has already written its output. */
+#ifdef FZF_BENCH_TEST_HOOKS
+  } else if (options.check_trim_cache) {
+    printf("trim-cache items=%zu before_known=%zu before_computed=%zu "
+           "first_matches=%zu first_known=%zu first_computed=%zu "
+           "second_matches=%zu second_known=%zu second_computed=%zu\n",
+           corpus.count, trim_before_known, trim_before_computed,
+           trim_first_matches, trim_first_known, trim_first_computed,
+           match_count, trim_second_known, trim_second_computed);
+#endif
   } else if (options.check_only) {
     printf("semantic items=%zu matches=%zu input_checksum=%016" PRIx64
            " result_checksum=%016" PRIx64 "\n",

--- a/benchmarks/fzf-bench-driver.c
+++ b/benchmarks/fzf-bench-driver.c
@@ -125,7 +125,6 @@ typedef struct {
   unsigned threads;
   bool normalize;
   bool sort_results;
-  bool tiebreak_set;
   bool tiebreak_length;
   bool check_only;
   bool dump_results;
@@ -146,7 +145,7 @@ static void bench_usage(FILE *stream, const char *program) {
           "(--bench DURATION | --check | --dump-results | --dump-semantic) "
           "[--threads N] [--literal] "
           "[--sort | --no-sort] [--algo=v2] "
-          "--tiebreak=(length|index)\n",
+          "[--tiebreak=(length|index)]\n",
           program);
 }
 
@@ -217,7 +216,8 @@ static unsigned bench_online_threads(void) {
 
 static bool bench_parse_options(int argc, char **argv,
                                 BenchOptions *options) {
-  *options = (BenchOptions){.normalize = true, .sort_results = true};
+  *options = (BenchOptions){
+      .normalize = true, .sort_results = true, .tiebreak_length = true};
   for (int i = 1; i < argc; i++) {
     const char *argument = argv[i];
     const char *value = NULL;
@@ -263,7 +263,6 @@ static bool bench_parse_options(int argc, char **argv,
       } else {
         return false;
       }
-      options->tiebreak_set = true;
     } else if (bench_option_value(
                    argc, argv, &i, "--scheme", &value)) {
       if (strcmp(value, "default") != 0) return false;
@@ -275,7 +274,7 @@ static bool bench_parse_options(int argc, char **argv,
   if (options->help) return true;
   unsigned modes = (options->duration_ns > 0) + options->check_only +
       options->dump_results + options->dump_semantic;
-  if (!options->query || !options->tiebreak_set || modes != 1)
+  if (!options->query || modes != 1)
     return false;
   if (options->threads == 0) options->threads = bench_online_threads();
   return options->threads > 0;

--- a/benchmarks/fzf-bench-fixture.txt
+++ b/benchmarks/fzf-bench-fixture.txt
@@ -1,0 +1,12 @@
+a_b_c
+nomatch
+abc
+ABC
+zabxc
+xxabcyy
+ab-c
+cab
+
+abc
+إنabc
+abc니다

--- a/benchmarks/fzf-bench-json.patch
+++ b/benchmarks/fzf-bench-json.patch
@@ -1,0 +1,34 @@
+diff --git a/src/core.go b/src/core.go
+index 2883488..930f669 100644
+--- a/src/core.go
++++ b/src/core.go
+@@ -326,14 +326,21 @@ func Run(opts *Options) (int, error) {
+ 				}
+ 				avg := total / time.Duration(len(times))
+ 				selectivity := float64(matchCount) / float64(totalItems) * 100
+-				fmt.Printf("  %d iterations  avg: %.2fms  min: %.2fms  max: %.2fms  total: %.2fs  items: %d  matches: %d (%.2f%%)  ingestion: %.2fms\n",
+-					len(times),
+-					float64(avg.Microseconds())/1000,
+-					float64(minD.Microseconds())/1000,
+-					float64(maxD.Microseconds())/1000,
+-					total.Seconds(),
+-					totalItems, matchCount, selectivity,
+-					float64(ingestionTime.Microseconds())/1000)
++				if os.Getenv("FZF_BENCH_JSON") == "1" {
++					fmt.Printf("benchmark-json {\"schema\":1,\"iterations\":%d,\"total_ns\":%d,\"min_ns\":%d,\"max_ns\":%d,\"items\":%d,\"matches\":%d,\"ingestion_ns\":%d}\n",
++						len(times), total.Nanoseconds(), minD.Nanoseconds(),
++						maxD.Nanoseconds(), totalItems, matchCount,
++						ingestionTime.Nanoseconds())
++				} else {
++					fmt.Printf("  %d iterations  avg: %.2fms  min: %.2fms  max: %.2fms  total: %.2fs  items: %d  matches: %d (%.2f%%)  ingestion: %.2fms\n",
++						len(times),
++						float64(avg.Microseconds())/1000,
++						float64(minD.Microseconds())/1000,
++						float64(maxD.Microseconds())/1000,
++						total.Seconds(),
++						totalItems, matchCount, selectivity,
++						float64(ingestionTime.Microseconds())/1000)
++				}
+ 				return ExitOk, nil
+ 			}
+ 

--- a/benchmarks/fzf-upstream-semantic-oracle_test.go
+++ b/benchmarks/fzf-upstream-semantic-oracle_test.go
@@ -79,7 +79,7 @@ func semanticOracleMatch(pattern *Pattern, item *Item, slab *util.Slab) (semanti
 		term := pattern.directTerm
 		matched, _ := pattern.directAlgo(
 			term.caseSensitive, term.normalize, pattern.forward,
-			&item.text, term.text, false, slab)
+			&item.text, term.text, pattern.withPos, slab)
 		if matched.Start < 0 {
 			return semanticOracleRecord{}, false
 		}
@@ -89,7 +89,7 @@ func semanticOracleMatch(pattern *Pattern, item *Item, slab *util.Slab) (semanti
 		result = buildResultFromBounds(
 			item, rawScore, minBegin, minEnd, maxEnd, boundsValid)
 	} else {
-		offsets, score, _ := pattern.extendedMatch(item, false, slab)
+		offsets, score, _ := pattern.extendedMatch(item, pattern.withPos, slab)
 		if len(offsets) != len(pattern.termSets) {
 			return semanticOracleRecord{}, false
 		}
@@ -130,12 +130,11 @@ func TestFzfNativeSemanticOracle(t *testing.T) {
 
 	previousCriteria := sortCriteria
 	defer func() { sortCriteria = previousCriteria }()
-	if !algo.Init("default") {
-		t.Fatal("could not initialize the default fzf scoring scheme")
-	}
-
 	output := semanticOracleOutput{Cases: make([]semanticOracleCaseOutput, 0, len(input.Cases))}
 	for _, oracleCase := range input.Cases {
+		scheme := "default"
+		forward := true
+		withPos := false
 		switch oracleCase.Profile {
 		case "literal-score-index":
 			if oracleCase.Normalize {
@@ -150,12 +149,25 @@ func TestFzfNativeSemanticOracle(t *testing.T) {
 			}
 			// parseScheme("default") ranks by score and trimmed rune length.
 			sortCriteria = []criterion{byScore, byLength}
+		case "path-score-pathname-length":
+			if !oracleCase.Normalize {
+				t.Fatalf("%s: path profile disables normalization", oracleCase.ID)
+			}
+			// core.go requests positions and searches backward whenever pathname
+			// is one of the active rank criteria.
+			scheme = "path"
+			forward = false
+			withPos = true
+			sortCriteria = []criterion{byScore, byPathname, byLength}
 		default:
 			t.Fatalf("%s: unknown profile %q", oracleCase.ID, oracleCase.Profile)
 		}
+		if !algo.Init(scheme) {
+			t.Fatalf("%s: could not initialize fzf scheme %q", oracleCase.ID, scheme)
+		}
 		pattern := BuildPattern(
 			NewChunkCache(), map[string]*Pattern{}, true, algo.FuzzyMatchV2,
-			true, CaseSmart, oracleCase.Normalize, true, false, false,
+			true, CaseSmart, oracleCase.Normalize, forward, withPos, false,
 			nil, Delimiter{}, revision{}, []rune(oracleCase.Query), nil, 0)
 		slab := util.MakeSlab(slab16Size, slab32Size)
 		records := make([]semanticOracleRecord, 0, len(oracleCase.Candidates))

--- a/benchmarks/fzf-upstream-semantic-oracle_test.go
+++ b/benchmarks/fzf-upstream-semantic-oracle_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+
+// This file is injected into the pinned upstream fzf/src package with the Go
+// overlay mechanism.  Package membership gives the oracle access to the exact
+// Pattern and Result rank data without maintaining a second Go matcher.
+package fzf
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/junegunn/fzf/src/algo"
+	"github.com/junegunn/fzf/src/util"
+)
+
+type semanticOracleInput struct {
+	Cases []semanticOracleCase `json:"cases"`
+}
+
+type semanticOracleCase struct {
+	ID         string   `json:"id"`
+	Query      string   `json:"query"`
+	Normalize  bool     `json:"normalize"`
+	Candidates []string `json:"candidates"`
+}
+
+type semanticOracleRecord struct {
+	Index       int32     `json:"index"`
+	RawScore    int64     `json:"raw_score"`
+	MinBegin    int       `json:"min_begin"`
+	MinEnd      int       `json:"min_end"`
+	MaxEnd      int       `json:"max_end"`
+	BoundsValid bool      `json:"bounds_valid"`
+	RankScore   uint16    `json:"rank_score"`
+	Points      [4]uint16 `json:"points"`
+	result      Result
+}
+
+type semanticOracleOutput struct {
+	Cases []semanticOracleCaseOutput `json:"cases"`
+}
+
+type semanticOracleCaseOutput struct {
+	ID      string                 `json:"id"`
+	Records []semanticOracleRecord `json:"records"`
+}
+
+func semanticOracleBounds(offsets []Offset) (int, int, int, bool) {
+	minBegin := math.MaxInt
+	minEnd := math.MaxInt
+	maxEnd := 0
+	valid := false
+	for _, offset := range offsets {
+		begin, end := int(offset[0]), int(offset[1])
+		if begin < end {
+			minBegin = min(minBegin, begin)
+			minEnd = min(minEnd, end)
+			maxEnd = max(maxEnd, end)
+			valid = true
+		}
+	}
+	if !valid {
+		return 0, 0, 0, false
+	}
+	return minBegin, minEnd, maxEnd, true
+}
+
+func semanticOracleMatch(pattern *Pattern, item *Item, slab *util.Slab) (semanticOracleRecord, bool) {
+	var rawScore int
+	var minBegin, minEnd, maxEnd int
+	var boundsValid bool
+	var result Result
+
+	if pattern.directAlgo != nil && len(pattern.denylist) == 0 {
+		term := pattern.directTerm
+		matched, _ := pattern.directAlgo(
+			term.caseSensitive, term.normalize, pattern.forward,
+			&item.text, term.text, false, slab)
+		if matched.Start < 0 {
+			return semanticOracleRecord{}, false
+		}
+		rawScore = matched.Score
+		minBegin, minEnd, maxEnd, boundsValid =
+			matched.Start, matched.End, matched.End, true
+		result = buildResultFromBounds(
+			item, rawScore, minBegin, minEnd, maxEnd, boundsValid)
+	} else {
+		offsets, score, _ := pattern.extendedMatch(item, false, slab)
+		if len(offsets) != len(pattern.termSets) {
+			return semanticOracleRecord{}, false
+		}
+		rawScore = score
+		minBegin, minEnd, maxEnd, boundsValid = semanticOracleBounds(offsets)
+		result = buildResult(item, offsets, rawScore)
+	}
+
+	rankScore := util.AsUint16(rawScore)
+	return semanticOracleRecord{
+		Index:       item.Index(),
+		RawScore:    int64(rawScore),
+		MinBegin:    minBegin,
+		MinEnd:      minEnd,
+		MaxEnd:      maxEnd,
+		BoundsValid: boundsValid,
+		RankScore:   rankScore,
+		Points:      result.points,
+		result:      result,
+	}, true
+}
+
+func TestFzfNativeSemanticOracle(t *testing.T) {
+	inputPath := os.Getenv("FZF_SEMANTIC_ORACLE_INPUT")
+	outputPath := os.Getenv("FZF_SEMANTIC_ORACLE_OUTPUT")
+	if inputPath == "" || outputPath == "" {
+		t.Fatal("FZF_SEMANTIC_ORACLE_INPUT and FZF_SEMANTIC_ORACLE_OUTPUT are required")
+	}
+
+	inputBytes, err := os.ReadFile(inputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var input semanticOracleInput
+	if err := json.Unmarshal(inputBytes, &input); err != nil {
+		t.Fatal(err)
+	}
+
+	// The benchmark command uses --tiebreak=index. parseTiebreak("index")
+	// leaves score as the sole rank point; input index is the final comparator.
+	previousCriteria := sortCriteria
+	sortCriteria = []criterion{byScore}
+	defer func() { sortCriteria = previousCriteria }()
+	if !algo.Init("default") {
+		t.Fatal("could not initialize the default fzf scoring scheme")
+	}
+
+	output := semanticOracleOutput{Cases: make([]semanticOracleCaseOutput, 0, len(input.Cases))}
+	for _, oracleCase := range input.Cases {
+		pattern := BuildPattern(
+			NewChunkCache(), map[string]*Pattern{}, true, algo.FuzzyMatchV2,
+			true, CaseSmart, oracleCase.Normalize, true, false, false,
+			nil, Delimiter{}, revision{}, []rune(oracleCase.Query), nil, 0)
+		slab := util.MakeSlab(slab16Size, slab32Size)
+		records := make([]semanticOracleRecord, 0, len(oracleCase.Candidates))
+		for index, candidate := range oracleCase.Candidates {
+			chars := util.ToChars([]byte(candidate))
+			chars.Index = int32(index)
+			item := Item{text: chars}
+			if record, matched := semanticOracleMatch(pattern, &item, slab); matched {
+				records = append(records, record)
+			}
+		}
+		if pattern.sortable {
+			sort.SliceStable(records, func(i, j int) bool {
+				return compareRanks(records[i].result, records[j].result, false)
+			})
+		}
+		for index := range records {
+			records[index].result = Result{}
+		}
+		output.Cases = append(output.Cases, semanticOracleCaseOutput{
+			ID: oracleCase.ID, Records: records,
+		})
+	}
+
+	encoded, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded = append(encoded, '\n')
+	if err := os.WriteFile(outputPath, encoded, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/benchmarks/fzf-upstream-semantic-oracle_test.go
+++ b/benchmarks/fzf-upstream-semantic-oracle_test.go
@@ -22,6 +22,7 @@ type semanticOracleInput struct {
 
 type semanticOracleCase struct {
 	ID         string   `json:"id"`
+	Profile    string   `json:"profile"`
 	Query      string   `json:"query"`
 	Normalize  bool     `json:"normalize"`
 	Candidates []string `json:"candidates"`
@@ -127,10 +128,7 @@ func TestFzfNativeSemanticOracle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The benchmark command uses --tiebreak=index. parseTiebreak("index")
-	// leaves score as the sole rank point; input index is the final comparator.
 	previousCriteria := sortCriteria
-	sortCriteria = []criterion{byScore}
 	defer func() { sortCriteria = previousCriteria }()
 	if !algo.Init("default") {
 		t.Fatal("could not initialize the default fzf scoring scheme")
@@ -138,6 +136,23 @@ func TestFzfNativeSemanticOracle(t *testing.T) {
 
 	output := semanticOracleOutput{Cases: make([]semanticOracleCaseOutput, 0, len(input.Cases))}
 	for _, oracleCase := range input.Cases {
+		switch oracleCase.Profile {
+		case "literal-score-index":
+			if oracleCase.Normalize {
+				t.Fatalf("%s: literal profile enables normalization", oracleCase.ID)
+			}
+			// parseTiebreak("index") leaves score as the sole rank point;
+			// input index is the final comparator.
+			sortCriteria = []criterion{byScore}
+		case "default-score-length":
+			if !oracleCase.Normalize {
+				t.Fatalf("%s: default profile disables normalization", oracleCase.ID)
+			}
+			// parseScheme("default") ranks by score and trimmed rune length.
+			sortCriteria = []criterion{byScore, byLength}
+		default:
+			t.Fatalf("%s: unknown profile %q", oracleCase.ID, oracleCase.Profile)
+		}
 		pattern := BuildPattern(
 			NewChunkCache(), map[string]*Pattern{}, true, algo.FuzzyMatchV2,
 			true, CaseSmart, oracleCase.Normalize, true, false, false,

--- a/benchmarks/rejection-hotpath-probe.c
+++ b/benchmarks/rejection-hotpath-probe.c
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: MIT
+/*
+ * Deterministic microbenchmark for rejection-heavy ASCII score calls.
+ *
+ * This intentionally uses synthetic candidates rather than either external
+ * benchmark suite.  It isolates the scorer's mandatory-subsequence reject,
+ * exact-substring reject, and their match-heavy counterweights.
+ *
+ * Build from the repository root:
+ *
+ *   cc -std=gnu11 -O3 -DNDEBUG -I. -Iutf8proc-2.10.0 \
+ *      -o build/rejection-hotpath-probe \
+ *      benchmarks/rejection-hotpath-probe.c fzf.c \
+ *      utf8proc-2.10.0/utf8proc.c
+ */
+
+#include "fzf.h"
+#include "fzf-private.h"
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define ITEM_COUNT 32768u
+#ifndef PROBE_SAMPLES
+#define PROBE_SAMPLES 15u
+#endif
+
+typedef enum {
+  SHAPE_EARLY_MISS,
+  SHAPE_TERMINAL_MISS,
+  SHAPE_RARE_MISS,
+  SHAPE_GUARD_PRESENT_MISS,
+  SHAPE_PARTIAL_MIX,
+  SHAPE_ALL_MATCH,
+} candidate_shape_t;
+
+typedef enum {
+  API_PRECLASSIFIED,
+  API_BOUNDED,
+  API_C_STRING,
+} score_api_t;
+
+typedef struct {
+  char *bytes;
+  size_t length;
+} candidate_t;
+
+typedef struct {
+  uint64_t scores;
+  uint64_t membership;
+} fingerprint_t;
+
+static volatile uint64_t benchmark_sink;
+
+static uint64_t now_ns(void) {
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) abort();
+  return (uint64_t)ts.tv_sec * UINT64_C(1000000000) +
+         (uint64_t)ts.tv_nsec;
+}
+
+static int compare_u64(const void *left, const void *right) {
+  uint64_t a = *(const uint64_t *)left;
+  uint64_t b = *(const uint64_t *)right;
+  return (a > b) - (a < b);
+}
+
+static uint64_t mix64(uint64_t value) {
+  value ^= value >> 30;
+  value *= UINT64_C(0xbf58476d1ce4e5b9);
+  value ^= value >> 27;
+  value *= UINT64_C(0x94d049bb133111eb);
+  return value ^ (value >> 31);
+}
+
+static void place_spaced(char *bytes, size_t length,
+                         const char *sequence, size_t sequence_length) {
+  for (size_t i = 0; i < sequence_length; i++) {
+    size_t at = sequence_length == 1
+                    ? 0
+                    : i * (length - 1) / (sequence_length - 1);
+    bytes[at] = sequence[i];
+  }
+}
+
+static void apply_shape(char *bytes, size_t length, size_t item_index,
+                        candidate_shape_t shape) {
+  static const char query[] = "deadbeef";
+  if (shape == SHAPE_PARTIAL_MIX) {
+    size_t kind = item_index % 20;
+    shape = kind == 0 ? SHAPE_ALL_MATCH
+                      : (kind < 5 ? SHAPE_TERMINAL_MISS
+                                  : SHAPE_EARLY_MISS);
+  }
+  if (shape == SHAPE_EARLY_MISS) {
+    /* The terminal guard succeeds, then the first required d is absent. */
+    bytes[length - 1] = 'f';
+  } else if (shape == SHAPE_TERMINAL_MISS) {
+    /* Seven ordered query bytes followed by a guaranteed missing f. */
+    place_spaced(bytes, length, "deadbee", 7);
+  } else if (shape == SHAPE_RARE_MISS) {
+    /* The generic-frequency rarest query byte, b, is absent; f is present. */
+    place_spaced(bytes, length, "deadeef", 7);
+  } else if (shape == SHAPE_GUARD_PRESENT_MISS) {
+    /* Every distinct query byte is present, but order rejects the match. */
+    place_spaced(bytes, length, "feebdaed", 8);
+  } else {
+    size_t at = (item_index * 7) % (length - (sizeof query - 1) + 1);
+    memcpy(bytes + at, query, sizeof query - 1);
+  }
+}
+
+static candidate_t *make_candidates(size_t length, candidate_shape_t shape) {
+  static const char filler[] = "acghijklmnopqstuvwxyz0123456789_/-";
+  candidate_t *items = calloc(ITEM_COUNT, sizeof *items);
+  if (!items) abort();
+  for (size_t i = 0; i < ITEM_COUNT; i++) {
+    char *bytes = malloc(length + 1);
+    if (!bytes) abort();
+    for (size_t j = 0; j < length; j++)
+      bytes[j] = filler[(i * 13 + j * 17) % (sizeof filler - 1)];
+
+    apply_shape(bytes, length, i, shape);
+    bytes[length] = '\0';
+    items[i] = (candidate_t){bytes, length};
+  }
+  return items;
+}
+
+static candidate_t *make_repeated_candidates(size_t length, bool matches) {
+  static const char filler[] = "cghijklmnopqstuvwxyz0123456789_/-";
+  candidate_t *items = calloc(ITEM_COUNT, sizeof *items);
+  if (!items) abort();
+  for (size_t i = 0; i < ITEM_COUNT; i++) {
+    char *bytes = malloc(length + 1);
+    if (!bytes) abort();
+    for (size_t j = 0; j < length; j++)
+      bytes[j] = filler[(i * 13 + j * 17) % (sizeof filler - 1)];
+    if (matches) place_spaced(bytes, length, "aAaAaAaA", 8);
+    bytes[length] = '\0';
+    items[i] = (candidate_t){bytes, length};
+  }
+  return items;
+}
+
+static void free_candidates(candidate_t *items) {
+  for (size_t i = 0; i < ITEM_COUNT; i++) free(items[i].bytes);
+  free(items);
+}
+
+static int32_t score_item(const candidate_t *item, fzf_pattern_t *pattern,
+                          fzf_slab_t *slab, score_api_t api) {
+  if (api == API_PRECLASSIFIED)
+    return fzf_get_score_bytes_preclassified(
+        item->bytes, item->length, true, pattern, slab);
+  if (api == API_BOUNDED)
+    return fzf_get_score_bytes(item->bytes, item->length, pattern, slab);
+  return fzf_get_score(item->bytes, pattern, slab);
+}
+
+static fingerprint_t fingerprint(const candidate_t *items,
+                                 fzf_pattern_t *pattern,
+                                 fzf_slab_t *slab, score_api_t api) {
+  fingerprint_t result = {
+      UINT64_C(0x243f6a8885a308d3), UINT64_C(0x13198a2e03707344)};
+  for (size_t i = 0; i < ITEM_COUNT; i++) {
+    int32_t score = score_item(&items[i], pattern, slab, api);
+    if (fzf_allocation_failed()) abort();
+    result.scores = mix64(result.scores ^ (uint32_t)score ^ mix64(i));
+    result.membership = mix64(result.membership +
+                              (score > 0 ? UINT64_C(0x9e3779b97f4a7c15)
+                                         : UINT64_C(0xd1b54a32d192ed03)) +
+                              i);
+  }
+  return result;
+}
+
+static uint64_t time_once(const candidate_t *items, fzf_pattern_t *pattern,
+                          fzf_slab_t *slab, score_api_t api) {
+  uint64_t checksum = 0;
+  uint64_t start = now_ns();
+  for (size_t i = 0; i < ITEM_COUNT; i++) {
+    checksum += (uint32_t)score_item(&items[i], pattern, slab, api);
+    if (fzf_allocation_failed()) abort();
+  }
+  uint64_t elapsed = now_ns() - start;
+  benchmark_sink += checksum;
+  return elapsed;
+}
+
+static double median_ns_per_item(const candidate_t *items,
+                                 fzf_pattern_t *pattern,
+                                 fzf_slab_t *slab, score_api_t api) {
+  for (size_t i = 0; i < 3; i++) (void)time_once(items, pattern, slab, api);
+  uint64_t samples[PROBE_SAMPLES];
+  for (size_t i = 0; i < PROBE_SAMPLES; i++)
+    samples[i] = time_once(items, pattern, slab, api);
+  qsort(samples, PROBE_SAMPLES, sizeof samples[0], compare_u64);
+  return (double)samples[PROBE_SAMPLES / 2] / ITEM_COUNT;
+}
+
+static void measure_case(candidate_t *items, size_t length,
+                         const char *shape_name, char *query, bool fuzzy,
+                         fzf_case_types case_mode) {
+  fzf_pattern_t *pattern = fzf_parse_pattern(
+      case_mode, false, query, fuzzy);
+  fzf_slab_t *slab = fzf_make_default_slab();
+  if (!pattern || !slab) abort();
+
+  fingerprint_t identity = fingerprint(
+      items, pattern, slab, API_PRECLASSIFIED);
+  fingerprint_t bounded = fingerprint(items, pattern, slab, API_BOUNDED);
+  fingerprint_t c_string = fingerprint(items, pattern, slab, API_C_STRING);
+  if (identity.scores != bounded.scores ||
+      identity.membership != bounded.membership ||
+      identity.scores != c_string.scores ||
+      identity.membership != c_string.membership) {
+    fprintf(stderr, "score API fingerprints differ\n");
+    abort();
+  }
+  double preclassified = median_ns_per_item(
+      items, pattern, slab, API_PRECLASSIFIED);
+  double bounded_ns = median_ns_per_item(
+      items, pattern, slab, API_BOUNDED);
+  double c_string_ns = median_ns_per_item(
+      items, pattern, slab, API_C_STRING);
+  printf("%-5s %-7s len=%-3zu %-14s pre=%7.3f bounded=%7.3f "
+         "cstr=%7.3f ns/item fp=%016" PRIx64
+         "%016" PRIx64 "\n",
+         fuzzy ? "fuzzy" : "exact",
+         case_mode == CaseRespect ? "respect" : "ignore", length,
+         shape_name, preclassified, bounded_ns, c_string_ns,
+         identity.scores, identity.membership);
+
+  fzf_free_slab(slab);
+  fzf_free_pattern(pattern);
+  free_candidates(items);
+}
+
+static void run_case(size_t length, candidate_shape_t shape, bool fuzzy,
+                     fzf_case_types case_mode) {
+  static const char *shape_names[] = {
+      "early-miss", "terminal-miss", "rare-miss", "all-bytes-miss",
+      "partial-mix", "all-match"};
+  char query[] = "deadbeef";
+  measure_case(make_candidates(length, shape), length, shape_names[shape],
+               query, fuzzy, case_mode);
+}
+
+static void run_repeated_case(size_t length, bool matches) {
+  char query[] = "aaaaaaaa";
+  measure_case(make_repeated_candidates(length, matches), length,
+               matches ? "repeat-match" : "repeat-miss", query, true,
+               CaseIgnore);
+}
+
+int main(void) {
+  static const size_t lengths[] = {16, 32, 64, 128};
+  for (size_t fuzzy = 0; fuzzy < 2; fuzzy++)
+    for (size_t shape = 0; shape < 6; shape++)
+      for (size_t li = 0; li < sizeof lengths / sizeof lengths[0]; li++)
+        run_case(lengths[li], (candidate_shape_t)shape, fuzzy != 0,
+                 CaseIgnore);
+  run_case(32, SHAPE_TERMINAL_MISS, true, CaseRespect);
+  run_case(128, SHAPE_TERMINAL_MISS, true, CaseRespect);
+  run_case(32, SHAPE_ALL_MATCH, true, CaseRespect);
+  run_case(128, SHAPE_ALL_MATCH, true, CaseRespect);
+  for (size_t matches = 0; matches < 2; matches++)
+    for (size_t li = 0; li < sizeof lengths / sizeof lengths[0]; li++)
+      run_repeated_case(lengths[li], matches != 0);
+  printf("sink=%" PRIu64 "\n", benchmark_sink);
+  return 0;
+}

--- a/benchmarks/run-fzf-envelope.py
+++ b/benchmarks/run-fzf-envelope.py
@@ -76,6 +76,78 @@ def sha256(path: pathlib.Path) -> str:
     return digest.hexdigest()
 
 
+def host_details() -> dict[str, object]:
+    details: dict[str, object] = {
+        "platform": platform.platform(),
+        "uname": platform.uname()._asdict(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "logical_cpu_count": os.cpu_count(),
+    }
+    if platform.system() == "Darwin":
+        sysctl = {}
+        for key in (
+            "hw.model", "hw.physicalcpu", "hw.logicalcpu", "hw.memsize",
+            "machdep.cpu.brand_string",
+        ):
+            completed = subprocess.run(
+                ["sysctl", "-n", key], capture_output=True, text=True,
+            )
+            if completed.returncode == 0:
+                sysctl[key] = completed.stdout.strip()
+        if sysctl:
+            details["sysctl"] = sysctl
+        profiler = pathlib.Path("/usr/sbin/system_profiler")
+        if profiler.is_file():
+            completed = subprocess.run(
+                [str(profiler), "SPHardwareDataType", "-json"],
+                capture_output=True, text=True,
+            )
+            if completed.returncode == 0:
+                records = json.loads(completed.stdout).get(
+                    "SPHardwareDataType", []
+                )
+                if records:
+                    safe_keys = (
+                        "chip_type", "machine_model", "machine_name",
+                        "number_processors", "physical_memory",
+                    )
+                    details["hardware"] = {
+                        key: records[0][key]
+                        for key in safe_keys if key in records[0]
+                    }
+    return details
+
+
+def load_native_build(
+    name: str, path: pathlib.Path, binary_hash: str, driver_hash: str
+) -> dict[str, object]:
+    provenance = json.loads(path.read_text(encoding="utf-8"))
+    if provenance.get("schema") != 1 or provenance.get(
+        "kind"
+    ) != "fzf-native-scan-benchmark-build":
+        raise RuntimeError(f"unsupported {name} native build provenance")
+    if provenance.get("binary_sha256") != binary_hash:
+        raise RuntimeError(f"{name} binary does not match its build provenance")
+    if provenance.get("driver_source_sha256") != driver_hash:
+        raise RuntimeError(f"{name} build does not use this benchmark driver")
+    if provenance.get("source_status") != "clean":
+        raise RuntimeError(f"{name} product source was not clean")
+    for field in (
+        "source_commit", "source_tree", "compiler", "compiler_sha256",
+        "compiler_version_stdout",
+    ):
+        if not isinstance(provenance.get(field), str) or not provenance[field]:
+            raise RuntimeError(f"{name} provenance lacks {field}")
+    for field in (
+        "product_source_sha256", "build_options", "build_argv",
+        "build_environment",
+    ):
+        if not provenance.get(field):
+            raise RuntimeError(f"{name} provenance lacks {field}")
+    return provenance
+
+
 def cells(corpus_root: pathlib.Path) -> dict[str, dict[str, object]]:
     result: dict[str, dict[str, object]] = {
         "chromium": {
@@ -174,6 +246,12 @@ def main() -> None:
     parser.add_argument("--corpus-root", type=pathlib.Path, required=True)
     parser.add_argument("--candidate", type=pathlib.Path, required=True)
     parser.add_argument("--base", type=pathlib.Path, required=True)
+    parser.add_argument(
+        "--candidate-build-provenance", type=pathlib.Path, required=True
+    )
+    parser.add_argument(
+        "--base-build-provenance", type=pathlib.Path, required=True
+    )
     parser.add_argument("--fzf", type=pathlib.Path, required=True)
     parser.add_argument(
         "--fzf-build-provenance", type=pathlib.Path, required=True
@@ -194,6 +272,8 @@ def main() -> None:
     }
     runner_path = pathlib.Path(__file__).resolve()
     runner_sha256 = sha256(runner_path)
+    driver_path = runner_path.with_name("fzf-bench-driver.c")
+    driver_sha256 = sha256(driver_path)
     fzf_provenance_path = arguments.fzf_build_provenance.resolve()
     selected_lanes = arguments.lane or list(LANES)
     if len(selected_lanes) != len(set(selected_lanes)):
@@ -207,6 +287,30 @@ def main() -> None:
         raise RuntimeError(f"unknown cells: {', '.join(unknown_cells)}")
     workload_cells = {name: all_cells[name] for name in selected_cells}
     subject_hashes = {name: sha256(path) for name, path in subjects.items()}
+    native_provenance_paths = {
+        "candidate": arguments.candidate_build_provenance.resolve(),
+        "base": arguments.base_build_provenance.resolve(),
+    }
+    native_provenance_hashes = {
+        name: sha256(path) for name, path in native_provenance_paths.items()
+    }
+    native_builds = {
+        name: load_native_build(
+            name, native_provenance_paths[name], subject_hashes[name],
+            driver_sha256,
+        )
+        for name in ("candidate", "base")
+    }
+    comparable_native_fields = (
+        "driver_commit", "driver_tree", "driver_source_sha256", "compiler",
+        "compiler_sha256",
+        "compiler_version_stdout", "compiler_version_stderr", "build_options",
+        "build_environment",
+    )
+    for field in comparable_native_fields:
+        if native_builds["candidate"].get(field) != native_builds["base"].get(field):
+            raise RuntimeError(f"native builds differ in {field}")
+    fzf_provenance_sha256 = sha256(fzf_provenance_path)
     fzf_provenance = json.loads(
         fzf_provenance_path.read_text(encoding="utf-8")
     )
@@ -281,35 +385,21 @@ def main() -> None:
                 )
                 schedule.append((round_number, cell, lane_name, order))
 
-    profiles: dict[str, dict[str, object]] = {}
-    for lane_name in selected_lanes:
-        lane = LANES[lane_name]
-        profile_name = str(lane["profile"])
-        profile = profiles.setdefault(
-            profile_name,
-            {
-                "arguments": list(lane["arguments"]),
-                "threads": lane["threads"],
-            },
-        )
-        if profile["arguments"] != lane["arguments"]:
-            raise RuntimeError(f"inconsistent lane arguments for {profile_name}")
-        profile["threads"] = min(int(profile["threads"]), int(lane["threads"]))
-
     started = utc_now()
     ordered_records = []
     for cell_name, cell in workload_cells.items():
-        for profile_name, profile in profiles.items():
+        for lane_name in selected_lanes:
+            lane = LANES[lane_name]
             output_hashes = set()
             for subject, binary in subjects.items():
                 command = [
                     str(binary), f"--filter={cell['query']}",
-                    f"--threads={profile['threads']}", "--algo=v2",
-                    "--scheme=default", "--sort", *profile["arguments"],
+                    f"--threads={lane['threads']}", "--algo=v2",
+                    "--scheme=default", "--sort", *lane["arguments"],
                 ]
                 if subject != "fzf":
                     command.append("--dump-results")
-                stem = f"{profile_name}-{cell_name}-{subject}"
+                stem = f"{lane_name}-{cell_name}-{subject}"
                 stdout_path = ordered_output_root / f"{stem}.stdout"
                 stderr_path = ordered_output_root / f"{stem}.stderr"
                 command_started = utc_now()
@@ -337,9 +427,10 @@ def main() -> None:
                 output_hash = sha256(stdout_path)
                 output_hashes.add(output_hash)
                 ordered_records.append({
-                    "profile": profile_name,
-                    "threads": profile["threads"],
-                    "arguments": profile["arguments"],
+                    "lane": lane_name,
+                    "profile": lane["profile"],
+                    "threads": lane["threads"],
+                    "arguments": lane["arguments"],
                     "cell": cell_name,
                     "query": cell["query"],
                     "corpus": str(cell["path"]),
@@ -356,7 +447,7 @@ def main() -> None:
                 })
             if len(output_hashes) != 1:
                 raise RuntimeError(
-                    f"ordered output differs: {cell_name} {profile_name}"
+                    f"ordered output differs: {cell_name} {lane_name}"
                 )
     ordered_output_path = root / "ordered-output.json"
     ordered_output_path.write_text(
@@ -441,6 +532,14 @@ def main() -> None:
         raise RuntimeError("corpus changed during the campaign")
     if sha256(runner_path) != runner_sha256:
         raise RuntimeError("benchmark runner changed during the campaign")
+    if sha256(driver_path) != driver_sha256:
+        raise RuntimeError("benchmark driver changed during the campaign")
+    if {
+        name: sha256(path) for name, path in native_provenance_paths.items()
+    } != native_provenance_hashes:
+        raise RuntimeError("native build provenance changed during the campaign")
+    if sha256(fzf_provenance_path) != fzf_provenance_sha256:
+        raise RuntimeError("fzf build provenance changed during the campaign")
 
     result = {
         "schema": 1,
@@ -455,16 +554,20 @@ def main() -> None:
         "runner_argv": sys.argv,
         "runner_cwd": str(pathlib.Path.cwd()),
         "python": sys.version,
-        "host": {
-            "platform": platform.platform(),
-            "machine": platform.machine(),
-        },
+        "host": host_details(),
         "lanes": {name: LANES[name] for name in selected_lanes},
         "environment": environment,
         "subjects": {name: str(path) for name, path in subjects.items()},
         "subject_sha256": subject_hashes,
+        "driver": str(driver_path),
+        "driver_sha256": driver_sha256,
+        "native_build_provenance": {
+            name: str(path) for name, path in native_provenance_paths.items()
+        },
+        "native_build_provenance_sha256": native_provenance_hashes,
+        "native_builds": native_builds,
         "fzf_build_provenance": str(fzf_provenance_path),
-        "fzf_build_provenance_sha256": sha256(fzf_provenance_path),
+        "fzf_build_provenance_sha256": fzf_provenance_sha256,
         "fzf_build": fzf_provenance,
         "cells": {
             name: {

--- a/benchmarks/run-fzf-envelope.py
+++ b/benchmarks/run-fzf-envelope.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""Run paired fzf and fzf-native scan-envelope benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import pathlib
+import platform
+import random
+import subprocess
+import sys
+
+
+DEFAULT_SEED = 0xF2F20260909
+PINNED_FZF_COMMIT = "63e82a9e3dd52cc67a46db842b8a29e0c1f83229"
+BENCH_PREFIX = "benchmark-json "
+SEMANTIC_PREFIX = "semantic "
+
+LANES = {
+    "default-length-w1": {
+        "profile": "default-length", "threads": 1, "primary": True,
+        "arguments": ["--tiebreak=length"],
+    },
+    "default-length-w8": {
+        "profile": "default-length", "threads": 8, "primary": True,
+        "arguments": ["--tiebreak=length"],
+    },
+    "literal-index-w1": {
+        "profile": "literal-index", "threads": 1, "primary": False,
+        "arguments": ["--literal", "--tiebreak=index"],
+    },
+    "literal-index-w8": {
+        "profile": "literal-index", "threads": 8, "primary": False,
+        "arguments": ["--literal", "--tiebreak=index"],
+    },
+}
+
+CORPUS_SHA256 = {
+    "chromium": "46163ffa59aa350386dfa8447a898660a5ff02054cbcae7d1d3d96943582bbc3",
+    "arabic": "e107f84c8c5d7cf468c3e33b5fa894056fadce8da4232f71a04aa4b4e4fefbbc",
+    "korean": "9a3042337b54d83281ed51d347dd6817912a71723c392529dbb21def73c10296",
+    "partial-16": "0e61944de50783c147e12b073ba18358d6a45bf4d46132c6194f04c325ff6800",
+    "partial-32": "aec093c49d3e54447e46c83956b095246758c0f1693e6d9d63097ff617606960",
+    "partial-64": "3f7097d05461de95c1e0634a1dfd4a5b36560538f5a4e73d09382f4b73c8fb4d",
+    "partial-128": "6227f21670c010b61f57f553ddd8044921ff471a167776265dccf99721006ce1",
+    "all-16": "c6a8f7ea821806906a21cb0f614696c62b1d9e4fa62e1f06d77c645f7a98afdd",
+    "all-32": "e0fd4573b92412754df8c63a930a2d147d9d3d5ae9573ec0b407d1eff7f191b7",
+    "all-64": "fa319758f69d2c9ee41307cb5f9c44dff9e9b25980c7383117cb24ce16aa9da1",
+    "all-128": "3fdf3aaa864508d87738ea1dc36c294cf6075714ca4fc41935cd8e478bb6b416",
+    "partial-miss-16": "a59bda342eba5478a3b905b29224ca081d767adcc5329959c43d04329ed3ce29",
+    "partial-miss-32": "2f2aa8282a071e62e69f3d77131b64e82ac25820298530d7d4a25fab4e97faf4",
+    "partial-miss-64": "efe7f1ac9c62921b31de27a4432c9700c708ccff3077b5c8168456ff2761160d",
+    "partial-miss-128": "e67861a7b4cb5b41717154b8f8723c85386799fb9e84b50344430328b088816a",
+    "none-16": "5705157daafba71e6b409fcbd44d2ddfd30eac249457195526dcc56a6a20ee16",
+    "none-32": "d40b5466270e6c90a733744597a3004cdef4ed8985b097a549bd84b9496abe3f",
+    "none-64": "cb0682a57e35f5542f2f024c9d1280b6b1c7e8f26338087a5fa0f68fd0b60781",
+    "none-128": "9b9c06b5560975f727e75b5d870f479927134ad1b275a72e4bee541a51e56558",
+}
+
+
+def utc_now() -> str:
+    return datetime.datetime.now(
+        datetime.timezone.utc
+    ).isoformat().replace("+00:00", "Z")
+
+
+def sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def cells(corpus_root: pathlib.Path) -> dict[str, dict[str, object]]:
+    result: dict[str, dict[str, object]] = {
+        "chromium": {
+            "path": corpus_root / "chromium.txt", "items": 1_406_940,
+            "matches": 179_966, "query": "linux",
+        },
+        "arabic": {
+            "path": corpus_root / "arabic_unicode.txt", "items": 285_587,
+            "matches": 22_659, "query": "إن",
+        },
+        "korean": {
+            "path": corpus_root / "korean_unicode.txt", "items": 281_471,
+            "matches": 23_696, "query": "니다",
+        },
+    }
+    for family in ("partial", "all", "partial-miss", "none"):
+        for length in (16, 32, 64, 128):
+            name = f"{family}-{length}"
+            result[name] = {
+                "path": corpus_root / "synthetic" / f"{name}.txt",
+                "items": 100_000,
+                "matches": 4_977 if family == "partial" else (
+                    100_000 if family == "all" else 0
+                ),
+                "query": "deadbeef",
+            }
+    return result
+
+
+def parse_machine_output(
+    subject: str, output: str, expected: dict[str, object]
+) -> dict[str, object]:
+    lines = [line for line in output.splitlines() if line]
+    machine = [line for line in lines if line.startswith(BENCH_PREFIX)]
+    semantic = [line for line in lines if line.startswith(SEMANTIC_PREFIX)]
+    if len(machine) != 1:
+        raise RuntimeError(f"missing machine statistics for {subject}: {output!r}")
+    required_lines = 2 if subject != "fzf" else 1
+    if len(lines) != required_lines:
+        raise RuntimeError(f"unexpected output for {subject}: {output!r}")
+    if (subject == "fzf" and semantic) or (
+        subject != "fzf" and len(semantic) != 1
+    ):
+        raise RuntimeError(f"unexpected semantic output for {subject}")
+
+    stats = json.loads(machine[0][len(BENCH_PREFIX):])
+    required = {
+        "schema", "iterations", "total_ns", "min_ns", "max_ns",
+        "items", "matches", "ingestion_ns",
+    }
+    if set(stats) != required or any(
+        type(stats[field]) is not int for field in required
+    ) or stats["schema"] != 1:
+        raise RuntimeError(f"unexpected statistics schema: {stats!r}")
+    nonnegative = required - {"schema", "iterations", "total_ns"}
+    if any(stats[field] < 0 for field in nonnegative):
+        raise RuntimeError(f"negative statistics: {stats!r}")
+    if stats["iterations"] < 1 or stats["total_ns"] < 1:
+        raise RuntimeError(f"invalid iteration statistics: {stats!r}")
+    if stats["min_ns"] > stats["max_ns"]:
+        raise RuntimeError(f"invalid range: {stats!r}")
+    if not (
+        stats["min_ns"] * stats["iterations"] <= stats["total_ns"]
+        <= stats["max_ns"] * stats["iterations"]
+    ):
+        raise RuntimeError(f"total outside sample bounds: {stats!r}")
+    average_ns = stats["total_ns"] / stats["iterations"]
+    if (stats["items"], stats["matches"]) != (
+        expected["items"], expected["matches"]
+    ):
+        raise RuntimeError(f"count mismatch: {stats!r}")
+
+    result: dict[str, object] = {**stats, "average_ns": average_ns}
+    if semantic:
+        fields = dict(part.split("=", 1) for part in semantic[0].split()[1:])
+        if set(fields) != {
+            "items", "matches", "input_checksum", "result_checksum"
+        }:
+            raise RuntimeError(f"unexpected semantic schema: {semantic[0]!r}")
+        result["semantic"] = {
+            "items": int(fields["items"]),
+            "matches": int(fields["matches"]),
+            "input_checksum": fields["input_checksum"],
+            "result_checksum": fields["result_checksum"],
+        }
+        if (
+            result["semantic"]["items"], result["semantic"]["matches"]
+        ) != (stats["items"], stats["matches"]):
+            raise RuntimeError("native semantic counts differ from statistics")
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifact-root", type=pathlib.Path, required=True)
+    parser.add_argument("--corpus-root", type=pathlib.Path, required=True)
+    parser.add_argument("--candidate", type=pathlib.Path, required=True)
+    parser.add_argument("--base", type=pathlib.Path, required=True)
+    parser.add_argument("--fzf", type=pathlib.Path, required=True)
+    parser.add_argument(
+        "--fzf-build-provenance", type=pathlib.Path, required=True
+    )
+    parser.add_argument("--rounds", type=int, default=10)
+    parser.add_argument("--duration", default="1s")
+    parser.add_argument("--seed", type=lambda value: int(value, 0), default=DEFAULT_SEED)
+    parser.add_argument("--lane", action="append", choices=sorted(LANES))
+    parser.add_argument("--cell", action="append")
+    arguments = parser.parse_args()
+    if arguments.rounds < 2 or arguments.rounds % 2:
+        raise RuntimeError("--rounds must be a positive even number of at least 2")
+
+    subjects = {
+        "candidate": arguments.candidate.resolve(),
+        "base": arguments.base.resolve(),
+        "fzf": arguments.fzf.resolve(),
+    }
+    fzf_provenance_path = arguments.fzf_build_provenance.resolve()
+    selected_lanes = arguments.lane or list(LANES)
+    if len(selected_lanes) != len(set(selected_lanes)):
+        raise RuntimeError("--lane values must be unique")
+    all_cells = cells(arguments.corpus_root.resolve())
+    selected_cells = arguments.cell or list(all_cells)
+    if len(selected_cells) != len(set(selected_cells)):
+        raise RuntimeError("--cell values must be unique")
+    unknown_cells = sorted(set(selected_cells) - set(all_cells))
+    if unknown_cells:
+        raise RuntimeError(f"unknown cells: {', '.join(unknown_cells)}")
+    workload_cells = {name: all_cells[name] for name in selected_cells}
+    subject_hashes = {name: sha256(path) for name, path in subjects.items()}
+    fzf_provenance = json.loads(
+        fzf_provenance_path.read_text(encoding="utf-8")
+    )
+    if fzf_provenance.get("schema") != 1:
+        raise RuntimeError("unsupported fzf build provenance schema")
+    if fzf_provenance.get("fzf_commit") != PINNED_FZF_COMMIT:
+        raise RuntimeError("fzf build provenance does not name the pinned commit")
+    expected_patch = pathlib.Path(__file__).with_name(
+        "fzf-bench-json.patch"
+    ).resolve()
+    if fzf_provenance.get("patch_sha256") != sha256(expected_patch):
+        raise RuntimeError("fzf build provenance does not use this benchmark patch")
+    if fzf_provenance.get("binary_sha256") != subject_hashes["fzf"]:
+        raise RuntimeError("fzf binary does not match its build provenance")
+    if not isinstance(fzf_provenance.get("build_argv"), list) or not isinstance(
+        fzf_provenance.get("build_environment"), dict
+    ):
+        raise RuntimeError("fzf build provenance lacks build argv or environment")
+    corpus_hashes = {
+        name: sha256(cell["path"]) for name, cell in workload_cells.items()
+    }
+    if corpus_hashes != {
+        name: CORPUS_SHA256[name] for name in workload_cells
+    }:
+        raise RuntimeError("one or more corpora do not match the frozen hashes")
+
+    root = arguments.artifact_root.resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    for path in (
+        root / "campaign.json", root / "commands.jsonl",
+        root / "ordered-output.json", root / "ordered-output",
+        root / "timings",
+    ):
+        if path.exists():
+            raise RuntimeError(f"refusing to replace campaign artifact: {path}")
+    ordered_output_root = root / "ordered-output"
+    ordered_output_root.mkdir()
+    logs = root / "timings"
+    logs.mkdir()
+
+    environment = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", ""),
+        "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
+        "LC_ALL": "C",
+        "LANG": "C",
+        "TZ": "UTC",
+        "FZF_BENCH_JSON": "1",
+    }
+
+    schedule = []
+    schedule_randomizer = random.Random(arguments.seed)
+    subject_orders = {
+        (pair, cell, lane): list(subjects)
+        for pair in range(1, arguments.rounds // 2 + 1)
+        for cell in workload_cells
+        for lane in selected_lanes
+    }
+    for key, order in subject_orders.items():
+        random.Random(f"{arguments.seed}:{key}").shuffle(order)
+    for round_number in range(1, arguments.rounds + 1):
+        names = list(workload_cells)
+        schedule_randomizer.shuffle(names)
+        for cell in names:
+            lane_names = selected_lanes.copy()
+            schedule_randomizer.shuffle(lane_names)
+            for lane_name in lane_names:
+                pair = (round_number + 1) // 2
+                base_order = subject_orders[(pair, cell, lane_name)]
+                order = base_order.copy() if round_number % 2 else list(
+                    reversed(base_order)
+                )
+                schedule.append((round_number, cell, lane_name, order))
+
+    profiles: dict[str, dict[str, object]] = {}
+    for lane_name in selected_lanes:
+        lane = LANES[lane_name]
+        profile_name = str(lane["profile"])
+        profile = profiles.setdefault(
+            profile_name,
+            {
+                "arguments": list(lane["arguments"]),
+                "threads": lane["threads"],
+            },
+        )
+        if profile["arguments"] != lane["arguments"]:
+            raise RuntimeError(f"inconsistent lane arguments for {profile_name}")
+        profile["threads"] = min(int(profile["threads"]), int(lane["threads"]))
+
+    started = utc_now()
+    ordered_records = []
+    for cell_name, cell in workload_cells.items():
+        for profile_name, profile in profiles.items():
+            output_hashes = set()
+            for subject, binary in subjects.items():
+                command = [
+                    str(binary), f"--filter={cell['query']}",
+                    f"--threads={profile['threads']}", "--algo=v2",
+                    "--scheme=default", "--sort", *profile["arguments"],
+                ]
+                if subject != "fzf":
+                    command.append("--dump-results")
+                stem = f"{profile_name}-{cell_name}-{subject}"
+                stdout_path = ordered_output_root / f"{stem}.stdout"
+                stderr_path = ordered_output_root / f"{stem}.stderr"
+                command_started = utc_now()
+                with cell["path"].open("rb") as source:
+                    completed = subprocess.run(
+                        command, stdin=source, capture_output=True,
+                        env=environment,
+                    )
+                stdout_path.write_bytes(completed.stdout)
+                stderr_path.write_bytes(completed.stderr)
+                expected_returncode = (
+                    1 if subject == "fzf" and cell["matches"] == 0 else 0
+                )
+                if completed.returncode != expected_returncode or completed.stderr:
+                    raise RuntimeError(
+                        f"ordered-output process failed: {stem} "
+                        f"rc={completed.returncode} stderr={completed.stderr!r}"
+                    )
+                line_count = len(completed.stdout.splitlines())
+                if line_count != cell["matches"]:
+                    raise RuntimeError(
+                        f"ordered-output count mismatch: {stem} "
+                        f"got={line_count} expected={cell['matches']}"
+                    )
+                output_hash = sha256(stdout_path)
+                output_hashes.add(output_hash)
+                ordered_records.append({
+                    "profile": profile_name,
+                    "threads": profile["threads"],
+                    "arguments": profile["arguments"],
+                    "cell": cell_name,
+                    "query": cell["query"],
+                    "corpus": str(cell["path"]),
+                    "subject": subject,
+                    "argv": command,
+                    "started_utc": command_started,
+                    "completed_utc": utc_now(),
+                    "returncode": completed.returncode,
+                    "line_count": line_count,
+                    "stdout": str(stdout_path),
+                    "stderr": str(stderr_path),
+                    "stdout_sha256": output_hash,
+                    "stderr_sha256": sha256(stderr_path),
+                })
+            if len(output_hashes) != 1:
+                raise RuntimeError(
+                    f"ordered output differs: {cell_name} {profile_name}"
+                )
+    ordered_output_path = root / "ordered-output.json"
+    ordered_output_path.write_text(
+        json.dumps(ordered_records, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    # Compare each native process with the first native signature for its
+    # workload and profile. The full-corpus gate above compares with fzf.
+    native_signatures: dict[tuple[str, str], dict[str, object]] = {}
+    records = []
+    commands_path = root / "commands.jsonl"
+    with commands_path.open("x", encoding="utf-8") as command_log:
+        for round_number, cell_name, lane_name, subject_order in schedule:
+            lane = LANES[lane_name]
+            cell = workload_cells[cell_name]
+            for subject in subject_order:
+                binary = subjects[subject]
+                command = [
+                    str(binary), f"--filter={cell['query']}",
+                    f"--bench={arguments.duration}",
+                    f"--threads={lane['threads']}", "--algo=v2",
+                    "--scheme=default", "--sort", *lane["arguments"],
+                ]
+                stem = (
+                    f"r{round_number:02d}-{lane_name}-{cell_name}-{subject}"
+                )
+                stdout_path = logs / f"{stem}.stdout"
+                stderr_path = logs / f"{stem}.stderr"
+                command_started = utc_now()
+                with cell["path"].open("rb") as source:
+                    completed = subprocess.run(
+                        command, stdin=source, capture_output=True,
+                        env=environment,
+                    )
+                stdout_path.write_bytes(completed.stdout)
+                stderr_path.write_bytes(completed.stderr)
+                if completed.returncode != 0 or completed.stderr:
+                    raise RuntimeError(
+                        f"process failed: {stem} rc={completed.returncode} "
+                        f"stderr={completed.stderr!r}"
+                    )
+                parsed = parse_machine_output(
+                    subject, completed.stdout.decode("utf-8"), cell
+                )
+                if subject != "fzf":
+                    key = (cell_name, str(lane["profile"]))
+                    signature = parsed["semantic"]
+                    previous = native_signatures.setdefault(key, signature)
+                    if signature != previous:
+                        raise RuntimeError(
+                            f"native semantic mismatch: {stem}"
+                        )
+                record = {
+                    "round": round_number,
+                    "lane": lane_name,
+                    **lane,
+                    "cell": cell_name,
+                    "query": cell["query"],
+                    "corpus": str(cell["path"]),
+                    "subject": subject,
+                    "argv": command,
+                    "started_utc": command_started,
+                    "completed_utc": utc_now(),
+                    "stdout": str(stdout_path),
+                    "stderr": str(stderr_path),
+                    "stdout_sha256": sha256(stdout_path),
+                    "stderr_sha256": sha256(stderr_path),
+                    **parsed,
+                }
+                records.append(record)
+                command_log.write(
+                    json.dumps(record, ensure_ascii=False) + "\n"
+                )
+                command_log.flush()
+
+    if {name: sha256(path) for name, path in subjects.items()} != subject_hashes:
+        raise RuntimeError("subject binary changed during the campaign")
+    if {
+        name: sha256(cell["path"]) for name, cell in workload_cells.items()
+    } != corpus_hashes:
+        raise RuntimeError("corpus changed during the campaign")
+
+    result = {
+        "schema": 1,
+        "status": "ordered-output-and-timings-complete",
+        "started_utc": started,
+        "completed_utc": utc_now(),
+        "rounds": arguments.rounds,
+        "duration": arguments.duration,
+        "seed": arguments.seed,
+        "runner": str(pathlib.Path(__file__).resolve()),
+        "runner_sha256": sha256(pathlib.Path(__file__).resolve()),
+        "runner_argv": sys.argv,
+        "runner_cwd": str(pathlib.Path.cwd()),
+        "python": sys.version,
+        "host": {
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+        },
+        "lanes": {name: LANES[name] for name in selected_lanes},
+        "environment": environment,
+        "subjects": {name: str(path) for name, path in subjects.items()},
+        "subject_sha256": subject_hashes,
+        "fzf_build_provenance": str(fzf_provenance_path),
+        "fzf_build_provenance_sha256": sha256(fzf_provenance_path),
+        "fzf_build": fzf_provenance,
+        "cells": {
+            name: {
+                "path": str(cell["path"]),
+                "items": cell["items"],
+                "matches": cell["matches"],
+                "query": cell["query"],
+            }
+            for name, cell in workload_cells.items()
+        },
+        "corpus_sha256": corpus_hashes,
+        "ordered_output_checks": ordered_records,
+        "ordered_output_sha256": sha256(ordered_output_path),
+        "record_count": len(records),
+        "records": records,
+    }
+    (root / "campaign.json").write_text(
+        json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(f"fzf envelope campaign: FAIL: {error}", file=sys.stderr)
+        raise

--- a/benchmarks/run-fzf-envelope.py
+++ b/benchmarks/run-fzf-envelope.py
@@ -192,6 +192,8 @@ def main() -> None:
         "base": arguments.base.resolve(),
         "fzf": arguments.fzf.resolve(),
     }
+    runner_path = pathlib.Path(__file__).resolve()
+    runner_sha256 = sha256(runner_path)
     fzf_provenance_path = arguments.fzf_build_provenance.resolve()
     selected_lanes = arguments.lane or list(LANES)
     if len(selected_lanes) != len(set(selected_lanes)):
@@ -437,6 +439,8 @@ def main() -> None:
         name: sha256(cell["path"]) for name, cell in workload_cells.items()
     } != corpus_hashes:
         raise RuntimeError("corpus changed during the campaign")
+    if sha256(runner_path) != runner_sha256:
+        raise RuntimeError("benchmark runner changed during the campaign")
 
     result = {
         "schema": 1,
@@ -446,8 +450,8 @@ def main() -> None:
         "rounds": arguments.rounds,
         "duration": arguments.duration,
         "seed": arguments.seed,
-        "runner": str(pathlib.Path(__file__).resolve()),
-        "runner_sha256": sha256(pathlib.Path(__file__).resolve()),
+        "runner": str(runner_path),
+        "runner_sha256": runner_sha256,
         "runner_argv": sys.argv,
         "runner_cwd": str(pathlib.Path.cwd()),
         "python": sys.version,

--- a/benchmarks/test_analyze_fzf_envelope.py
+++ b/benchmarks/test_analyze_fzf_envelope.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Regression tests for analyze-fzf-envelope.py."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import math
+import pathlib
+import tempfile
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).with_name("analyze-fzf-envelope.py")
+SPEC = importlib.util.spec_from_file_location("analyze_fzf_envelope", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+ANALYZER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ANALYZER)
+
+
+LANES = {
+    "default-length-w1": {
+        "profile": "default-length", "threads": 1, "primary": True,
+        "arguments": ["--tiebreak=length"],
+    },
+    "default-length-w8": {
+        "profile": "default-length", "threads": 8, "primary": True,
+        "arguments": ["--tiebreak=length"],
+    },
+    "literal-index-w1": {
+        "profile": "literal-index", "threads": 1, "primary": False,
+        "arguments": ["--literal", "--tiebreak=index"],
+    },
+    "literal-index-w8": {
+        "profile": "literal-index", "threads": 8, "primary": False,
+        "arguments": ["--literal", "--tiebreak=index"],
+    },
+}
+CELLS = ("chromium", "partial-16", "all-16", "partial-miss-16", "none-16")
+
+
+def make_campaign() -> dict[str, object]:
+    records = []
+    # These pairs prove that the analyzer uses same-round ratios.  For
+    # base/candidate, median([2 / 1, 300 / 100]) is 2.5.  Dividing the two
+    # subject medians instead would give 151 / 50.5, about 2.99.
+    values = {
+        1: {"candidate": 1, "base": 2, "fzf": 8},
+        2: {"candidate": 100, "base": 300, "fzf": 400},
+    }
+    for lane in LANES:
+        for cell in CELLS:
+            for round_number in (1, 2):
+                for subject, total_ns in values[round_number].items():
+                    records.append({
+                        "lane": lane,
+                        "cell": cell,
+                        "round": round_number,
+                        "subject": subject,
+                        "iterations": 1,
+                        "total_ns": total_ns,
+                        "average_ns": float(total_ns),
+                    })
+    return {
+        "schema": 1,
+        "status": "ordered-output-and-timings-complete",
+        "started_utc": "2026-09-09T00:00:00Z",
+        "completed_utc": "2026-09-09T01:00:00Z",
+        "rounds": 2,
+        "lanes": LANES,
+        "cells": {
+            cell: {"items": 100, "matches": 10, "query": "q"}
+            for cell in CELLS
+        },
+        "record_count": len(records),
+        "records": records,
+    }
+
+
+class AnalyzerTest(unittest.TestCase):
+    def analyze(self, campaign: dict[str, object]) -> dict[str, object]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "campaign.json"
+            path.write_text(json.dumps(campaign), encoding="utf-8")
+            return ANALYZER.analyze_campaign(
+                campaign,
+                path,
+                bootstrap_samples=101,
+                bootstrap_seed=12345,
+                analyzer_path=SCRIPT,
+            )
+
+    def test_same_round_ratios_categories_and_all_lanes(self) -> None:
+        analysis = self.analyze(make_campaign())
+        self.assertEqual(len(analysis["lanes"]), 4)
+        for lane in analysis["lanes"]:
+            ratios = lane["aggregate"]["ratios"]
+            self.assertTrue(math.isclose(
+                ratios["base/candidate"]["estimate"], 2.5
+            ))
+            self.assertTrue(math.isclose(
+                ratios["fzf/candidate"]["estimate"], 6.0
+            ))
+            self.assertTrue(math.isclose(
+                ratios["fzf/base"]["estimate"], 8.0 / 3.0
+            ))
+            self.assertEqual(list(lane["categories"]), list(ANALYZER.CATEGORY_ORDER))
+            self.assertTrue(all(
+                details["cell_count"] == 1
+                for details in lane["categories"].values()
+            ))
+
+    def test_bootstrap_is_deterministic(self) -> None:
+        campaign = make_campaign()
+        first = self.analyze(campaign)
+        second = self.analyze(campaign)
+        self.assertEqual(first["lanes"], second["lanes"])
+
+    def test_missing_same_round_subject_is_rejected(self) -> None:
+        campaign = make_campaign()
+        campaign["records"].pop()
+        campaign["record_count"] -= 1
+        with self.assertRaisesRegex(ValueError, "expected"):
+            self.analyze(campaign)
+
+    def test_rounded_average_is_rejected(self) -> None:
+        campaign = copy.deepcopy(make_campaign())
+        campaign["records"][0]["iterations"] = 3
+        campaign["records"][0]["total_ns"] = 10
+        campaign["records"][0]["average_ns"] = 3.33
+        with self.assertRaisesRegex(ValueError, "differs"):
+            self.analyze(campaign)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/etc/session-growth-benchmark.c
+++ b/etc/session-growth-benchmark.c
@@ -105,6 +105,12 @@ static AsyncSession *bench_session_create(unsigned workers) {
   cache_init_limits(&session->cache, 40, 64 * 1024 * 1024);
   batch_cache_init(&session->batch_cache, 64 * 1024 * 1024);
 
+  /* A zero worker count leaves the session unpooled.  Cold-start probes use
+     this mode so their first request performs the process's first worker
+     creation, matching production startup rather than warming pthread state
+     with a throwaway private pool. */
+  if (workers == 0) return session;
+
   struct AsyncWorkerPool *pool = async_worker_pool_create(workers);
   if (!pool) {
     async_session_destroy(session);

--- a/fuzz/fzf-native-session-fuzz.c
+++ b/fuzz/fzf-native-session-fuzz.c
@@ -743,6 +743,7 @@ static void session_fuzz_check_reference(FuzzSession *fuzz) {
   for (size_t i = 0; i < pool; i++) {
     const char *candidate =
         s->cands_top[i >> CANDS_BLOCK_SHIFT][i & CANDS_BLOCK_MASK];
+    size_t candidate_len = strlen(candidate);
     int score;
     fzf_score_bounds_t bounds = {0};
     if (!pattern)
@@ -750,12 +751,18 @@ static void session_fuzz_check_reference(FuzzSession *fuzz) {
     else if (filter_only)
       score = fzf_has_match(candidate, pattern, slab) ? 1 : 0;
     else
-      score = fzf_get_score_with_bounds(candidate, pattern, slab, &bounds);
+      score = score_scheme == FZF_SCORE_SCHEME_PATH
+                  ? fzf_get_score_with_rank_bounds_bytes_preclassified(
+                        candidate, candidate_len,
+                        is_ascii_utf8proc(candidate, candidate_len),
+                        pattern, slab, &bounds)
+                  : fzf_get_score_with_bounds(
+                        candidate, pattern, slab, &bounds);
     if (score > 0) {
       reference[matched++] = (ScoredStr){
           .str = (char *)candidate, .score = score, .idx = (uint32_t)i,
           .rank = fzf_rank_keys_preclassified(
-              candidate, strlen(candidate), false, &bounds, score_scheme)};
+              candidate, candidate_len, false, &bounds, score_scheme)};
     }
   }
   pthread_mutex_unlock(&s->mu);
@@ -764,10 +771,16 @@ static void session_fuzz_check_reference(FuzzSession *fuzz) {
   if (filter_only && sortable && emit > 1) {
     for (size_t i = 0; i < emit; i++) {
       fzf_score_bounds_t bounds = {0};
-      reference[i].score = fzf_get_score_with_bounds(
-          reference[i].str, pattern, slab, &bounds);
+      size_t candidate_len = strlen(reference[i].str);
+      reference[i].score = score_scheme == FZF_SCORE_SCHEME_PATH
+          ? fzf_get_score_with_rank_bounds_bytes_preclassified(
+                reference[i].str, candidate_len,
+                is_ascii_utf8proc(reference[i].str, candidate_len),
+                pattern, slab, &bounds)
+          : fzf_get_score_with_bounds(
+                reference[i].str, pattern, slab, &bounds);
       reference[i].rank = fzf_rank_keys_preclassified(
-          reference[i].str, strlen(reference[i].str), false, &bounds,
+          reference[i].str, candidate_len, false, &bounds,
           score_scheme);
     }
     qsort(reference, emit, sizeof *reference, cmp_scored_desc);

--- a/fuzz/fzf-native-upstream-test.el
+++ b/fuzz/fzf-native-upstream-test.el
@@ -1208,6 +1208,67 @@ Each specification has the form (KEY VALUES)."
       (dolist (candidate candidates)
         (insert (fzf-native-differential-candidate-text candidate) "\n")))))
 
+(ert-deftest fzf-native-fuzz-upstream-path-ranking-backtracks-begin ()
+  "Path ranking uses the backtracked match begin in batch and session APIs."
+  (let* ((fzf (or (getenv "FZF_REFERENCE") (executable-find "fzf")))
+         (cat (executable-find "cat"))
+         (candidates
+          (cl-loop for text in '("beta alpha" "FOO alpha")
+                   for id from 0
+                   collect (make-fzf-native-differential-candidate
+                            :id id :text text :role 'path-rank)))
+         (round '(:name path-backtrace :query "alpha" :case-mode smart
+                  :fuzzy t :score-scheme path :direction auto))
+         (case (fzf-native-upstream--session-case
+                12648430 0 round candidates))
+         (input (make-temp-file "fzf-native-upstream-path-rank-" nil ".txt"))
+         handle)
+    (skip-unless (and fzf cat
+                      (fboundp 'fzf-native-score-all)
+                      (fboundp 'fzf-native-async-start)
+                      (fboundp 'fzf-native-async-submit)
+                      (fboundp 'fzf-native-async-snapshot)))
+    (fzf-native-upstream--verify-reference fzf)
+    (unwind-protect
+        (let ((fzf-native-score-scheme 'path)
+              (fzf-native-search-direction 'auto)
+              (fzf-native-case-mode 'smart)
+              (fzf-native-fuzzy t)
+              (fzf-native-normalize t)
+              (fzf-native-batch-highlight nil)
+              (fzf-native-async-highlight nil)
+              (fzf-native-filter-only-min-pool nil)
+              (fzf-native-filter-only-length nil))
+          (let ((upstream
+                 (fzf-native-upstream--identities
+                  case (fzf-native-upstream--fzf fzf case) t))
+                (batch
+                 (fzf-native-upstream--identities
+                  case (fzf-native-score-all
+                        (vconcat (fzf-native-upstream--candidate-texts case))
+                        "alpha"))))
+            (should (equal upstream '(1 0)))
+            (should (equal batch upstream))
+            (fzf-native-upstream--write-session-input input candidates)
+            (setq handle
+                  (fzf-native-async-start
+                   (format "exec %s -- %s"
+                           (shell-quote-argument cat)
+                           (shell-quote-argument input))))
+            (fzf-native-upstream--wait-for-producer-eof handle)
+            (let* ((request-id (fzf-native-async-submit handle "alpha" 0))
+                   (snapshot
+                    (fzf-native-upstream--wait-for-session-request
+                     handle request-id))
+                   (session
+                    (fzf-native-upstream--identities
+                     case (plist-get snapshot :candidates))))
+              (should (equal session upstream)))))
+      (when handle
+        (fzf-native-async-stop handle))
+      (when (file-exists-p input)
+        (delete-file input)))))
+
 (ert-deftest fzf-native-fuzz-upstream-session-rounds ()
   "Compare identity sets from one native session with fresh fzf processes."
   (let* ((fzf (or (getenv "FZF_REFERENCE") (executable-find "fzf")))

--- a/fzf-additions-test.c
+++ b/fzf-additions-test.c
@@ -154,6 +154,156 @@ static void test_ascii_v2_single_byte_path(void) {
                        -1, -1, 0, -1);
 }
 
+static uint32_t short_v2_test_rng = UINT32_C(0x91e10da5);
+
+static uint32_t short_v2_test_random(void) {
+  short_v2_test_rng ^= short_v2_test_rng << 13;
+  short_v2_test_rng ^= short_v2_test_rng >> 17;
+  short_v2_test_rng ^= short_v2_test_rng << 5;
+  return short_v2_test_rng;
+}
+
+/* The parsed scorer has specialized one- and two-byte paths, while the
+   public algorithm entry point deliberately retains the general recurrence.
+   Compare those independent implementations across matching settings and
+   ranking schemes. */
+static void test_parsed_ascii_v2_short_paths_match_general(void) {
+  static const char *queries[] = {
+      "a", "A", "_", "aa", "ab", "aA", "Aa", "__", "09"};
+  static const char alphabet[] = "abABxyXY09_-/ :";
+
+  for (size_t q = 0; q < sizeof queries / sizeof queries[0]; q++) {
+    size_t query_len = strlen(queries[q]);
+    for (int mode = CaseSmart; mode <= CaseRespect; mode++) {
+      for (int normalize = 0; normalize < 2; normalize++) {
+        for (int forward = 0; forward < 2; forward++) {
+          char query[3];
+          memcpy(query, queries[q], query_len + 1);
+          fzf_pattern_t *parsed = fzf_parse_pattern_with_direction(
+              (fzf_case_types)mode, normalize, query, true, forward);
+          CHECK(parsed != NULL);
+          if (!parsed) return;
+          CHECK(parsed->size == 1 && parsed->ptr[0]->size == 1);
+          if (parsed->size != 1 || parsed->ptr[0]->size != 1) {
+            fzf_free_pattern(parsed);
+            return;
+          }
+          fzf_term_t *term = &parsed->ptr[0]->ptr[0];
+          fzf_string_t *pattern = term->text;
+
+          for (int scheme = FZF_SCORE_SCHEME_DEFAULT;
+               scheme <= FZF_SCORE_SCHEME_HISTORY; scheme++) {
+            for (int use_slab = 0; use_slab < 4; use_slab++) {
+              fzf_slab_t *slab =
+                  use_slab == 0
+                      ? NULL
+                      : use_slab == 1
+                            ? fzf_make_default_slab()
+                            : use_slab == 2
+                                  ? fzf_make_slab((fzf_slab_config_t){1, 1})
+                                  : fzf_make_slab((fzf_slab_config_t){7, 3});
+              CHECK(!use_slab || slab != NULL);
+              if (use_slab && !slab) {
+                fzf_free_pattern(parsed);
+                return;
+              }
+              if (slab)
+                CHECK(fzf_slab_set_score_scheme(
+                    slab, (fzf_score_scheme_t)scheme));
+
+              for (size_t sample = 0; sample < 256; sample++) {
+                char text[66];
+                size_t text_len = short_v2_test_random() % 65;
+                for (size_t i = 0; i < text_len; i++)
+                  text[i] = alphabet[short_v2_test_random() %
+                                     (sizeof alphabet - 1)];
+                if ((sample & 15) == 0 && text_len >= query_len) {
+                  size_t at = short_v2_test_random() %
+                              (text_len - query_len + 1);
+                  memcpy(text + at, queries[q], query_len);
+                }
+                text[text_len] = '\0';
+
+                fzf_string_t input = {.data = text, .size = text_len};
+                fzf_result_t expected =
+                    fzf_fuzzy_match_v2_with_direction(
+                        term->case_sensitive, term->normalize, forward,
+                        &input, pattern, NULL, slab);
+                int32_t expected_score =
+                    expected.start < 0
+                        ? 0
+                        : expected.score > 0 ? expected.score : 1;
+                fzf_score_bounds_t bounds = {0};
+                int32_t actual =
+                    fzf_get_score_with_bounds_bytes_preclassified(
+                        text, text_len, true, parsed, slab, &bounds);
+                bool same = actual == expected_score &&
+                            bounds.valid == (expected.start >= 0);
+                if (bounds.valid)
+                  same = same && bounds.raw_score == expected.score &&
+                         bounds.min_begin == expected.start &&
+                         bounds.min_end == expected.end &&
+                         bounds.max_end == expected.end;
+                if (!same) {
+                  fprintf(stderr,
+                          "  short-v2 mismatch query=%s mode=%d normalize=%d "
+                          "forward=%d scheme=%d text=%s expected=(%d,%d,%d) "
+                          "actual=%d bounds=(%d,%d,%d,%lld,%d)\n",
+                          queries[q], mode, normalize, forward, scheme, text,
+                          expected.start, expected.end, expected.score, actual,
+                          bounds.min_begin, bounds.min_end, bounds.max_end,
+                          (long long)bounds.raw_score, bounds.valid);
+                  failed++;
+                  fzf_free_slab(slab);
+                  fzf_free_pattern(parsed);
+                  return;
+                }
+
+                if ((sample & 63) == 0) {
+                  fzf_position_t expected_positions = {0};
+                  expected = fzf_fuzzy_match_v2_with_direction(
+                      term->case_sensitive, term->normalize, forward, &input,
+                      pattern, &expected_positions, slab);
+                  fzf_position_t *actual_positions = NULL;
+                  actual = fzf_get_score_positions(
+                      text, parsed, slab, &actual_positions);
+                  expected_score = expected.start < 0
+                                       ? 0
+                                       : expected.score > 0
+                                             ? expected.score
+                                             : 1;
+                  same = actual == expected_score &&
+                         (!!actual_positions == (expected.start >= 0));
+                  if (actual_positions)
+                    same = same &&
+                           actual_positions->size == expected_positions.size &&
+                           memcmp(actual_positions->data,
+                                  expected_positions.data,
+                                  expected_positions.size * sizeof(uint32_t)) ==
+                               0;
+                  free(expected_positions.data);
+                  fzf_free_positions(actual_positions);
+                  if (!same) {
+                    fprintf(stderr,
+                            "  short-v2 position mismatch query=%s text=%s\n",
+                            queries[q], text);
+                    failed++;
+                    fzf_free_slab(slab);
+                    fzf_free_pattern(parsed);
+                    return;
+                  }
+                }
+              }
+              fzf_free_slab(slab);
+            }
+          }
+          fzf_free_pattern(parsed);
+        }
+      }
+    }
+  }
+}
+
 static void test_exact_match(void) {
   check_agreement("exact 'pat", "foobarbaz", "'bar",
                   CaseIgnore, true, true);
@@ -1236,6 +1386,7 @@ int main(void) {
   RUN(test_fuzzy_empty_pattern);
   RUN(test_fuzzy_pattern_longer_than_text);
   RUN(test_ascii_v2_single_byte_path);
+  RUN(test_parsed_ascii_v2_short_paths_match_general);
   RUN(test_exact_match);
   RUN(test_exact_no_match);
   RUN(test_pinned_fzf_exact_boundary);

--- a/fzf-additions-test.c
+++ b/fzf-additions-test.c
@@ -304,6 +304,163 @@ static void test_parsed_ascii_v2_short_paths_match_general(void) {
   }
 }
 
+/* The compact rune scorer relies on the Unicode invariant that an uppercase
+   rune's simple lowercase mapping is not an Other_Letter rune.  Audit the
+   exact vendored table so a future utf8proc update cannot silently weaken the
+   parser guard. */
+static void test_unicode_other_letter_guard_is_sound(void) {
+  size_t violations = 0;
+  for (utf8proc_int32_t codepoint = 0; codepoint < 0x110000; codepoint++) {
+    if (utf8proc_category(codepoint) != UTF8PROC_CATEGORY_LU) continue;
+    utf8proc_int32_t lower = utf8proc_tolower(codepoint);
+    if (lower != codepoint &&
+        utf8proc_category(lower) == UTF8PROC_CATEGORY_LO)
+      violations++;
+  }
+  CHECK(violations == 0);
+}
+
+static bool append_utf8_test_piece(char *text, size_t cap, size_t *length,
+                                   const char *piece) {
+  size_t piece_length = strlen(piece);
+  if (piece_length >= cap - *length) return false;
+  memcpy(text + *length, piece, piece_length);
+  *length += piece_length;
+  text[*length] = '\0';
+  return true;
+}
+
+/* Compare the parsed Other_Letter fast path with the public general UTF-8 v2
+   algorithm.  The generated candidates mix all boundary classes, cased
+   Latin runes, uncased scripts, repeated query runes, forward/backward ties,
+   every score scheme, and slabs both above and below the v2 cutoff. */
+static void test_parsed_unicode_v2_rune_rows_match_general(void) {
+  static const char *queries[] = {
+      "界", "إن", "니다", "组件", "漢字語", "界界界",
+      "한글검사", "العربية",
+      "界界界界界界界界界界界界界界界界",
+      "界界界界界界界界界界界界界界界界界"};
+  static const char *unicode_pieces[] = {
+      "界", "組", "件", "漢", "字", "語", "니", "다", "한", "글",
+      "검", "사", "إ", "ن", "ا", "ل", "ع", "ر", "ب", "ي", "ة"};
+  static const char *pieces[] = {
+      "a", "A", "z", "Z", "0", "9", "_", "-", "/", " ", ":",
+      "界", "組", "件", "漢", "字", "語", "니", "다", "한", "글",
+      "검", "사", "إ", "ن", "ا", "ل", "ع", "ر", "ب", "ي", "ة",
+      "é", "É", "ß", "ẞ"};
+
+  for (size_t q = 0; q < sizeof queries / sizeof queries[0]; q++) {
+    for (int mode = CaseSmart; mode <= CaseRespect; mode++) {
+      for (int normalize = 0; normalize < 2; normalize++) {
+        for (int forward = 0; forward < 2; forward++) {
+          char query[64];
+          size_t query_length = strlen(queries[q]);
+          CHECK(query_length < sizeof query);
+          memcpy(query, queries[q], query_length + 1);
+          fzf_pattern_t *parsed = fzf_parse_pattern_with_direction(
+              (fzf_case_types)mode, normalize, query, true, forward);
+          CHECK(parsed != NULL);
+          if (!parsed) return;
+          CHECK(parsed->size == 1 && parsed->ptr[0]->size == 1);
+          if (parsed->size != 1 || parsed->ptr[0]->size != 1) {
+            fzf_free_pattern(parsed);
+            return;
+          }
+          fzf_term_t *term = &parsed->ptr[0]->ptr[0];
+          fzf_string_t *pattern = term->text;
+          for (size_t i = 0; i < pattern->codepoint_count; i++)
+            CHECK(utf8proc_category(pattern->codepoints[i]) ==
+                  UTF8PROC_CATEGORY_LO);
+
+          for (int scheme = FZF_SCORE_SCHEME_DEFAULT;
+               scheme <= FZF_SCORE_SCHEME_HISTORY; scheme++) {
+            for (int use_slab = 0; use_slab < 4; use_slab++) {
+              fzf_slab_t *slab =
+                  use_slab == 0
+                      ? NULL
+                      : use_slab == 1
+                            ? fzf_make_default_slab()
+                            : use_slab == 2
+                                  ? fzf_make_slab((fzf_slab_config_t){1, 1})
+                                  : fzf_make_slab(
+                                        (fzf_slab_config_t){128, 64});
+              CHECK(!use_slab || slab != NULL);
+              if (use_slab && !slab) {
+                fzf_free_pattern(parsed);
+                return;
+              }
+              if (slab)
+                CHECK(fzf_slab_set_score_scheme(
+                    slab, (fzf_score_scheme_t)scheme));
+
+              for (size_t sample = 0; sample < 256; sample++) {
+                char text[256] = {0};
+                size_t text_length = 0;
+                CHECK(append_utf8_test_piece(
+                    text, sizeof text, &text_length,
+                    unicode_pieces[short_v2_test_random() %
+                                   (sizeof unicode_pieces /
+                                    sizeof unicode_pieces[0])]));
+                size_t piece_count = short_v2_test_random() % 32;
+                for (size_t i = 0; i < piece_count; i++)
+                  if (!append_utf8_test_piece(
+                          text, sizeof text, &text_length,
+                          pieces[short_v2_test_random() %
+                                 (sizeof pieces / sizeof pieces[0])]))
+                    break;
+                if ((sample & 7) == 0)
+                  CHECK(append_utf8_test_piece(
+                      text, sizeof text, &text_length, queries[q]));
+
+                fzf_string_t input = {
+                    .data = text,
+                    .size = text_length,
+                };
+                fzf_result_t expected =
+                    fzf_fuzzy_match_v2_utf8_with_direction(
+                        term->case_sensitive, term->normalize, forward,
+                        &input, pattern, NULL, slab);
+                CHECK(!fzf_allocation_failed());
+                int32_t expected_score =
+                    expected.start < 0
+                        ? 0
+                        : expected.score > 0 ? expected.score : 1;
+                fzf_score_bounds_t bounds = {0};
+                int32_t actual =
+                    fzf_get_score_with_bounds_bytes_preclassified(
+                        text, text_length, false, parsed, slab, &bounds);
+                bool same = actual == expected_score &&
+                            bounds.valid == (expected.start >= 0);
+                if (bounds.valid)
+                  same = same && bounds.raw_score == expected.score &&
+                         bounds.min_begin == expected.start &&
+                         bounds.min_end == expected.end &&
+                         bounds.max_end == expected.end;
+                if (!same) {
+                  fprintf(stderr,
+                          "  rune-row mismatch query=%s mode=%d normalize=%d "
+                          "forward=%d scheme=%d text=%s expected=(%d,%d,%d) "
+                          "actual=%d bounds=(%d,%d,%d,%lld,%d)\n",
+                          queries[q], mode, normalize, forward, scheme, text,
+                          expected.start, expected.end, expected.score, actual,
+                          bounds.min_begin, bounds.min_end, bounds.max_end,
+                          (long long)bounds.raw_score, bounds.valid);
+                  failed++;
+                  fzf_free_slab(slab);
+                  fzf_free_pattern(parsed);
+                  return;
+                }
+              }
+              fzf_free_slab(slab);
+            }
+          }
+          fzf_free_pattern(parsed);
+        }
+      }
+    }
+  }
+}
+
 static void test_exact_match(void) {
   check_agreement("exact 'pat", "foobarbaz", "'bar",
                   CaseIgnore, true, true);
@@ -712,6 +869,10 @@ static void test_utf8_terms(void) {
      those that don't (the false-positive direction of the deferral bug). */
   check_agreement("utf8 inverted excludes", "αβγ", "!α", CaseIgnore, true, false);
   check_agreement("utf8 inverted keeps",    "xyz", "!α", CaseIgnore, true, true);
+  check_agreement("utf8 Lo compound match", "路径/组件-123",
+                  "组件 | 없는 !禁止", CaseIgnore, true, true);
+  check_agreement("utf8 Lo compound inverse", "路径/组件-123",
+                  "组件 | 없는 !路径", CaseIgnore, true, false);
 }
 
 static void check_bounded_range(const char *text, size_t text_len,
@@ -1073,8 +1234,9 @@ static void test_utf8_char_map_scratch_reuse_and_cap(void) {
   free(scratch.map.byte_to_char);
 
   /* Parsed patterns fuse immutable decoded codepoints with the term object.
-     Two real scorer calls reuse one slab-owned map; the slab destructor owns
-     that retained allocation and sanitizer builds check the final free. */
+     Two position calls reuse one slab-owned map; score-only paths can avoid
+     the map entirely.  The slab destructor owns the retained allocation and
+     sanitizer builds check the final free. */
   char query[] = "组件";
   fzf_pattern_t *pattern = fzf_parse_pattern(
       CaseSmart, false, query, true);
@@ -1087,12 +1249,18 @@ static void test_utf8_char_map_scratch_reuse_and_cap(void) {
     CHECK(parsed->codepoints ==
           (const utf8proc_int32_t *)(parsed + 1));
     CHECK(parsed->codepoints_case_folded);
-    CHECK(fzf_get_score("路径/组件-123", pattern, slab) > 0);
+    fzf_position_t *first_positions = fzf_get_positions(
+        "路径/组件-123", pattern, slab);
+    CHECK(first_positions != NULL);
+    fzf_free_positions(first_positions);
     size_t *scorer_retained = slab->UTF8.map.byte_to_char;
     size_t scorer_capacity = slab->UTF8.byte_slot_capacity;
     CHECK(scorer_retained != NULL);
     CHECK(scorer_capacity > 0);
-    CHECK(fzf_get_score("组件", pattern, slab) > 0);
+    fzf_position_t *second_positions = fzf_get_positions(
+        "组件", pattern, slab);
+    CHECK(second_positions != NULL);
+    fzf_free_positions(second_positions);
     CHECK(slab->UTF8.map.byte_to_char == scorer_retained);
     CHECK(slab->UTF8.byte_slot_capacity == scorer_capacity);
   }
@@ -1444,6 +1612,8 @@ int main(void) {
   RUN(test_fuzzy_pattern_longer_than_text);
   RUN(test_ascii_v2_single_byte_path);
   RUN(test_parsed_ascii_v2_short_paths_match_general);
+  RUN(test_unicode_other_letter_guard_is_sound);
+  RUN(test_parsed_unicode_v2_rune_rows_match_general);
   RUN(test_exact_match);
   RUN(test_exact_no_match);
   RUN(test_pinned_fzf_exact_boundary);

--- a/fzf-additions-test.c
+++ b/fzf-additions-test.c
@@ -790,6 +790,63 @@ static void test_bounded_entry_points_need_no_terminator(void) {
   free(text);
 }
 
+static bool scalar_is_ascii(const unsigned char *text, size_t length) {
+  for (size_t i = 0; i < length; i++)
+    if (text[i] & 0x80) return false;
+  return true;
+}
+
+static uint64_t classifier_test_random(uint64_t *state) {
+  uint64_t value = *state;
+  value ^= value << 13;
+  value ^= value >> 7;
+  value ^= value << 17;
+  return *state = value;
+}
+
+static void test_ascii_classifier_boundaries_and_differential(void) {
+  static const size_t lengths[] = {
+      0, 1, 7, 8, 9, 15, 16, 17, 31, 32, 33,
+      39, 40, 63, 64, 65, 95, 96, 97, 127, 128, 129,
+  };
+
+  /* Give the classifier exact-sized readable tails at every alignment.
+     Embedded NUL is ordinary bounded data and remains ASCII. */
+  for (size_t li = 0; li < sizeof lengths / sizeof lengths[0]; li++) {
+    size_t length = lengths[li];
+    for (size_t offset = 0; offset < 8; offset++) {
+      size_t allocation_size = offset + length;
+      unsigned char *allocation =
+          malloc(allocation_size ? allocation_size : 1);
+      CHECK(allocation != NULL);
+      if (!allocation) continue;
+      unsigned char *text = allocation + offset;
+      for (size_t i = 0; i < length; i++)
+        text[i] = i % 11 == 0 ? 0 : (unsigned char)(i & 0x7f);
+      CHECK(is_ascii_utf8proc((const char *)text, length));
+      for (size_t i = 0; i < length; i++) {
+        unsigned char saved = text[i];
+        text[i] = (unsigned char)(0x80 | (i & 0x7f));
+        CHECK(!is_ascii_utf8proc((const char *)text, length));
+        text[i] = saved;
+      }
+      free(allocation);
+    }
+  }
+
+  unsigned char storage[272];
+  uint64_t random = UINT64_C(0xd1b54a32d192ed03);
+  for (size_t iteration = 0; iteration < 4096; iteration++) {
+    size_t offset = (size_t)(classifier_test_random(&random) & 7);
+    size_t length = (size_t)(classifier_test_random(&random) % 257);
+    for (size_t i = 0; i < length; i++)
+      storage[offset + i] = (unsigned char)classifier_test_random(&random);
+    CHECK(is_ascii_utf8proc(
+              (const char *)storage + offset, length) ==
+          scalar_is_ascii(storage + offset, length));
+  }
+}
+
 static void test_invalid_utf8_exact_is_lossless(void) {
   /* Invalid bytes are individual lossy-decoder units.  An exact match must
      consume each unit; it must not declare success after only the valid
@@ -1418,6 +1475,7 @@ int main(void) {
   RUN(test_bounded_entry_points_derive_unicode_classification);
   RUN(test_bounded_entry_points_preserve_embedded_nul);
   RUN(test_bounded_entry_points_need_no_terminator);
+  RUN(test_ascii_classifier_boundaries_and_differential);
   RUN(test_invalid_utf8_exact_is_lossless);
   RUN(test_invalid_utf8_fuzzy_fallback_returns_positions);
   RUN(test_combined_score_positions_matches_legacy_calls);

--- a/fzf-additions.c
+++ b/fzf-additions.c
@@ -51,7 +51,7 @@ static bool fzf_addn_fuzzy(
   if (plan && plan->pattern_size == pn &&
       plan->case_sensitive == case_sensitive &&
       pn >= FZF_SIMD_FUZZY_MIN_PATTERN && tn >= FZF_SIMD_FUZZY_MIN_TEXT) {
-    const char *first = fzf_ascii_plan_find_byte(
+    const char *first = fzf_ascii_plan_find_initial_byte(
         text, tn, &plan->bytes[0], case_sensitive);
     return first && fzf_ascii_plan_ordered_after_first(
                         text, tn, plan, (size_t)(first - text));

--- a/fzf-native-ctest.c
+++ b/fzf-native-ctest.c
@@ -942,6 +942,39 @@ static void test_score_bounds_hide_partial_and_match(void) {
   fzf_free_pattern(pattern);
 }
 
+static void test_score_only_bounds_match_upstream_v2_start(void) {
+  struct {
+    char *query;
+    const char *candidate;
+    fzf_case_types case_mode;
+    int32_t expected_begin;
+  } cases[] = {
+    /* General ASCII matrix, specialized two-row scorer, general UTF-8
+       matrix, and the raw Other_Letter row scorer, respectively. */
+    {"abc", "zabc", CaseRespect, 1},
+    {"ab", "zza---b", CaseRespect, 2},
+    {"ång", "xång", CaseIgnore, 1},
+    {"中文", "前中-文", CaseIgnore, 1},
+  };
+
+  for (size_t i = 0; i < sizeof cases / sizeof cases[0]; i++) {
+    fzf_pattern_t *pattern = fzf_parse_pattern(
+        cases[i].case_mode, false, cases[i].query, true);
+    fzf_slab_t *slab = fzf_make_default_slab();
+    fzf_score_bounds_t bounds = {0};
+    CHECK(pattern != NULL && slab != NULL);
+    int score = fzf_get_score_with_bounds(
+        cases[i].candidate, pattern, slab, &bounds);
+    CHECK(score > 0);
+    CHECK(bounds.valid);
+    CHECK(bounds.raw_score == score);
+    CHECK(bounds.min_begin == cases[i].expected_begin);
+    CHECK(bounds.min_end > bounds.min_begin);
+    fzf_free_slab(slab);
+    fzf_free_pattern(pattern);
+  }
+}
+
 /* =====================================================================
  * counting_sort_scored (async-path twin of counting_sort_candidates)
  * ===================================================================== */
@@ -4374,6 +4407,7 @@ int main(void) {
   RUN(test_ranked_score_fast_path_preserves_raw_score);
   RUN(test_score_bounds_aggregate_positive_terms);
   RUN(test_score_bounds_hide_partial_and_match);
+  RUN(test_score_only_bounds_match_upstream_v2_start);
 
   printf("--- counting_sort_scored ---\n");
   RUN(test_scored_n_zero);

--- a/fzf-native-ctest.c
+++ b/fzf-native-ctest.c
@@ -1248,6 +1248,18 @@ static void test_async_reader_basic(void) {
   CHECK(strcmp(cands_at(s, 0), "alpha") == 0);
   CHECK(strcmp(cands_at(s, 1), "beta")  == 0);
   CHECK(strcmp(cands_at(s, 2), "gamma") == 0);
+  CHECK(async_candidate_length(cands_at(s, 0),
+            async_candidate_metadata(cands_at(s, 0))) == 5);
+  CHECK(async_candidate_length(cands_at(s, 1),
+            async_candidate_metadata(cands_at(s, 1))) == 4);
+  CHECK(async_candidate_length(cands_at(s, 2),
+            async_candidate_metadata(cands_at(s, 2))) == 5);
+  CHECK(async_candidate_ascii_from_metadata(
+            async_candidate_metadata(cands_at(s, 0))));
+  CHECK(async_candidate_ascii_from_metadata(
+            async_candidate_metadata(cands_at(s, 1))));
+  CHECK(async_candidate_ascii_from_metadata(
+            async_candidate_metadata(cands_at(s, 2))));
   CHECK(!atomic_load_explicit(&s->score_growth_pending,
                               memory_order_acquire));
   free_async_session(s);
@@ -1540,6 +1552,10 @@ static void test_async_line_decoder_matches_one_shot_reference(void) {
         if (actual) {
           CHECK(strlen(actual) == reference_len);
           CHECK(memcmp(actual, reference, reference_len) == 0);
+          uint32_t metadata = async_candidate_metadata(actual);
+          CHECK(async_candidate_length(actual, metadata) == reference_len);
+          CHECK(async_candidate_ascii_from_metadata(metadata) ==
+                is_ascii_utf8proc(reference, reference_len));
         }
         expected_count++;
       } else {
@@ -1578,6 +1594,9 @@ static void test_async_line_decoder_bounds_overlong_records(void) {
   CHECK(async_line_finish(s, &line));
   CHECK(s->count == 1);
   CHECK(strcmp(cands_at(s, 0), "\xe4\xbd\xa0\xe5\xa5\xbd") == 0);
+  uint32_t metadata = async_candidate_metadata(cands_at(s, 0));
+  CHECK(async_candidate_length(cands_at(s, 0), metadata) == 6);
+  CHECK(!async_candidate_ascii_from_metadata(metadata));
 
   /* An ordinary over-limit record is excluded without growing the retained
      buffer, including when its newline has not arrived yet. */
@@ -3128,8 +3147,19 @@ static void test_completed_batch_evidence_survives_request_cancellation(void) {
   batch->batch_id = 0;
   batch->cacheable = true;
   batch->len = BATCH_SIZE;
+  Arena arena = {0};
+  char *alpha = arena_strdup_candidate(&arena, "alpha", 5, true);
+  char *zzz = arena_strdup_candidate(&arena, "zzz", 3, true);
+  CHECK(alpha != NULL && zzz != NULL);
+  if (!alpha || !zzz) {
+    arena_free(&arena);
+    free(batch);
+    batch_cache_release_query(&cache, target);
+    batch_cache_free(&cache);
+    return;
+  }
   for (size_t i = 0; i < BATCH_SIZE; i++) {
-    batch->xs[i].str = i < 3 ? "alpha" : "zzz";
+    batch->xs[i].str = i < 3 ? alpha : zzz;
     batch->xs[i].idx = (uint32_t)i;
   }
   char pattern_text[] = "a";
@@ -3161,6 +3191,7 @@ static void test_completed_batch_evidence_survives_request_cancellation(void) {
 
   if (slab) fzf_free_slab(slab);
   if (pattern) fzf_free_pattern(pattern);
+  arena_free(&arena);
   free(batch);
   batch_cache_release_query(&cache, target);
   batch_cache_free(&cache);

--- a/fzf-native-ctest.c
+++ b/fzf-native-ctest.c
@@ -975,6 +975,86 @@ static void test_score_only_bounds_match_upstream_v2_start(void) {
   }
 }
 
+static void test_path_rank_backtracks_the_match_begin(void) {
+  char query[] = "alpha";
+  fzf_pattern_t *pattern = fzf_parse_pattern_with_direction(
+      CaseSmart, true, query, true, false);
+  fzf_slab_t *slab = fzf_make_default_slab();
+  fzf_score_bounds_t score_only = {0};
+  fzf_score_bounds_t ranked = {0};
+  FzfRankKeys beta_rank = {0};
+  FzfRankKeys foo_rank = {0};
+  const char *beta = "beta alpha";
+  const char *foo = "FOO alpha";
+  CHECK(pattern != NULL && slab != NULL);
+  CHECK(fzf_slab_set_score_scheme(slab, FZF_SCORE_SCHEME_PATH));
+
+  int score = fzf_get_score_with_bounds_bytes_preclassified(
+      beta, strlen(beta), true, pattern, slab, &score_only);
+  int ranked_score = fzf_get_score_with_rank_bounds_bytes_preclassified(
+      beta, strlen(beta), true, pattern, slab, &ranked);
+  CHECK(score > 0 && ranked_score == score);
+  CHECK(score_only.min_begin == 3);
+  CHECK(ranked.min_begin == 5);
+
+  int beta_score = fzf_score_and_rank(
+      beta, strlen(beta), true, pattern, slab, FZF_SCORE_SCHEME_PATH,
+      false, &beta_rank);
+  int foo_score = fzf_score_and_rank(
+      foo, strlen(foo), true, pattern, slab, FZF_SCORE_SCHEME_PATH,
+      false, &foo_rank);
+  CHECK(beta_score == foo_score);
+  CHECK(beta_rank.score == foo_rank.score);
+  CHECK(beta_rank.first == 6);
+  CHECK(foo_rank.first == 5);
+  CHECK(candidate_order(
+            &(struct Candidate){.rank = foo_rank, .idx = 1},
+            &(struct Candidate){.rank = beta_rank, .idx = 0}) < 0);
+  fzf_free_pattern(pattern);
+
+  char utf8_query[] = "alpha";
+  pattern = fzf_parse_pattern_with_direction(
+      CaseSmart, true, utf8_query, true, false);
+  const char *utf8_near = "目录/x alpha";
+  const char *utf8_far = "目录/yz alpha";
+  FzfRankKeys utf8_near_rank = {0};
+  FzfRankKeys utf8_far_rank = {0};
+  CHECK(pattern != NULL);
+  int utf8_near_score = fzf_score_and_rank(
+      utf8_near, strlen(utf8_near), false, pattern, slab,
+      FZF_SCORE_SCHEME_PATH, false, &utf8_near_rank);
+  int utf8_far_score = fzf_score_and_rank(
+      utf8_far, strlen(utf8_far), false, pattern, slab,
+      FZF_SCORE_SCHEME_PATH, false, &utf8_far_rank);
+  CHECK(utf8_near_score == utf8_far_score);
+  CHECK(utf8_near_rank.score == utf8_far_rank.score);
+  CHECK(utf8_near_rank.first == 3);
+  CHECK(utf8_far_rank.first == 4);
+  fzf_free_pattern(pattern);
+
+  char compound_query[] = "'alpha | 'omega 'beta";
+  pattern = fzf_parse_pattern_with_direction(
+      CaseSmart, true, compound_query, true, false);
+  const char *compound_near = "dir/x omega beta";
+  const char *compound_far = "dir/yz omega beta";
+  FzfRankKeys compound_near_rank = {0};
+  FzfRankKeys compound_far_rank = {0};
+  CHECK(pattern != NULL);
+  int compound_near_score = fzf_score_and_rank(
+      compound_near, strlen(compound_near), true, pattern, slab,
+      FZF_SCORE_SCHEME_PATH, false, &compound_near_rank);
+  int compound_far_score = fzf_score_and_rank(
+      compound_far, strlen(compound_far), true, pattern, slab,
+      FZF_SCORE_SCHEME_PATH, false, &compound_far_rank);
+  CHECK(compound_near_score == compound_far_score);
+  CHECK(compound_near_rank.score == compound_far_rank.score);
+  CHECK(compound_near_rank.first == 3);
+  CHECK(compound_far_rank.first == 4);
+
+  fzf_free_slab(slab);
+  fzf_free_pattern(pattern);
+}
+
 /* =====================================================================
  * counting_sort_scored (async-path twin of counting_sort_candidates)
  * ===================================================================== */
@@ -4408,6 +4488,7 @@ int main(void) {
   RUN(test_score_bounds_aggregate_positive_terms);
   RUN(test_score_bounds_hide_partial_and_match);
   RUN(test_score_only_bounds_match_upstream_v2_start);
+  RUN(test_path_rank_backtracks_the_match_begin);
 
   printf("--- counting_sort_scored ---\n");
   RUN(test_scored_n_zero);

--- a/fzf-native-module.c
+++ b/fzf-native-module.c
@@ -2003,15 +2003,68 @@ emacs_value fzf_native_make_slab(emacs_env *env,
 typedef struct ArenaChunk { struct ArenaChunk *next; size_t used; char data[]; } ArenaChunk;
 typedef struct { ArenaChunk *head; } Arena;
 
-static char *arena_strdup(Arena *a, const char *s, size_t len) {
-  size_t need = len + 1;
-  if (!a->head || a->head->used + need > ARENA_CHUNK_SIZE) {
-    size_t chunk_sz = sizeof(ArenaChunk) + (need > ARENA_CHUNK_SIZE ? need : ARENA_CHUNK_SIZE);
+/* Candidate bytes are immutable after publication.  Store the byte length and
+   ASCII classification immediately before each arena string so every query
+   can reuse them.  A four-byte common header minimizes cache and arena cost;
+   exceptionally long candidates keep their full length in an extra field. */
+#define ASYNC_CANDIDATE_ASCII_BIT UINT32_C(0x80000000)
+#define ASYNC_CANDIDATE_LENGTH_MASK UINT32_C(0x7fffffff)
+
+typedef struct {
+  uint32_t metadata;
+} AsyncCandidateHeader;
+
+static uint32_t async_candidate_metadata(const char *candidate) {
+  uint32_t metadata;
+  memcpy(&metadata, candidate - sizeof(AsyncCandidateHeader),
+         sizeof metadata);
+  return metadata;
+}
+
+static size_t async_candidate_length(const char *candidate,
+                                     uint32_t metadata) {
+  uint32_t encoded = metadata & ASYNC_CANDIDATE_LENGTH_MASK;
+  if (encoded != ASYNC_CANDIDATE_LENGTH_MASK) return encoded;
+  size_t length;
+  memcpy(&length, candidate - sizeof(AsyncCandidateHeader) - sizeof length,
+         sizeof length);
+  return length;
+}
+
+static bool async_candidate_ascii_from_metadata(uint32_t metadata) {
+  return (metadata & ASYNC_CANDIDATE_ASCII_BIT) != 0;
+}
+
+static char *arena_strdup_candidate(Arena *a, const char *s, size_t len,
+                                    bool input_is_ascii) {
+  bool extended_length = len >= ASYNC_CANDIDATE_LENGTH_MASK;
+  if (len > SIZE_MAX - sizeof(AsyncCandidateHeader) - 1)
+    return NULL;
+  size_t need = sizeof(AsyncCandidateHeader) + len + 1;
+  if (extended_length) {
+    if (need > SIZE_MAX - sizeof len) return NULL;
+    need += sizeof len;
+  }
+  if (!a->head || a->head->used > ARENA_CHUNK_SIZE ||
+      need > ARENA_CHUNK_SIZE - a->head->used) {
+    if (need > SIZE_MAX - sizeof(ArenaChunk)) return NULL;
+    size_t chunk_sz = sizeof(ArenaChunk) +
+        (need > ARENA_CHUNK_SIZE ? need : ARENA_CHUNK_SIZE);
     ArenaChunk *c = malloc(chunk_sz);
     if (!c) return NULL;
     c->used = 0; c->next = a->head; a->head = c;
   }
-  char *p = a->head->data + a->head->used;
+  char *header = a->head->data + a->head->used;
+  if (extended_length) {
+    memcpy(header, &len, sizeof len);
+    header += sizeof len;
+  }
+  uint32_t metadata = (extended_length
+                           ? ASYNC_CANDIDATE_LENGTH_MASK
+                           : (uint32_t)len) |
+      (input_is_ascii ? ASYNC_CANDIDATE_ASCII_BIT : 0);
+  memcpy(header, &metadata, sizeof metadata);
+  char *p = header + sizeof(AsyncCandidateHeader);
   memcpy(p, s, len + 1);
   a->head->used += need;
   return p;
@@ -4144,8 +4197,9 @@ static void async_publish_stop(AsyncSession *s) {
    top-level block pointer before taking MU is safe.  Keeping this operation
    separate from getline lets the native interactive fuzzer drive the real
    growth path without an Emacs process or a shell child. */
-static bool async_append_candidate(AsyncSession *s, const char *line,
-                                   size_t len) {
+static bool async_append_candidate_classified(AsyncSession *s,
+                                              const char *line, size_t len,
+                                              bool input_is_ascii) {
   if (atomic_load_explicit(&s->stop, memory_order_acquire)) return false;
   size_t i  = s->count;
   size_t hi = i >> CANDS_BLOCK_SHIFT;
@@ -4160,7 +4214,8 @@ static bool async_append_candidate(AsyncSession *s, const char *line,
     return false;
   }
 
-  char *dup = arena_strdup(&s->arena, line, len);
+  char *dup = arena_strdup_candidate(
+      &s->arena, line, len, input_is_ascii);
   if (!dup) {
     async_record_producer_failure(
         s, AsyncProducerErrorAllocation, ENOMEM);
@@ -4196,6 +4251,12 @@ static bool async_append_candidate(AsyncSession *s, const char *line,
   atomic_fetch_add_explicit(&s->gen, 1, memory_order_relaxed);
   async_notify_candidate_growth(s);
   return true;
+}
+
+static bool UNUSED(async_append_candidate)(AsyncSession *s, const char *line,
+                                           size_t len) {
+  return async_append_candidate_classified(
+      s, line, len, is_ascii_utf8proc(line, len));
 }
 
 enum AsyncAnsiState {
@@ -4234,6 +4295,7 @@ typedef struct {
   enum AsyncAnsiState ansi_state;
   bool                over_limit;
   bool                saw_bytes;
+  bool                output_has_non_ascii;
 } AsyncLineDecoder;
 
 static size_t async_line_limit(ptrdiff_t configured) {
@@ -4307,6 +4369,7 @@ static bool async_line_commit_character(AsyncSession *s,
     }
     line->char_count++;
   }
+  if (width && (bytes[0] & 0x80)) line->output_has_non_ascii = true;
   return async_line_append_output(s, line, bytes, width);
 }
 
@@ -4320,8 +4383,10 @@ static unsigned async_utf8_expected_width(unsigned char byte) {
 static bool async_line_emit_visible_byte(AsyncSession *s,
                                          AsyncLineDecoder *line,
                                          unsigned char byte) {
-  if (s->max_line_length == 0)
+  if (s->max_line_length == 0) {
+    if (byte & 0x80) line->output_has_non_ascii = true;
     return async_line_append_output(s, line, &byte, 1);
+  }
 
   size_t cap = async_line_limit(s->max_line_length);
   if ((s->max_line_length > 0 && line->over_limit) ||
@@ -4427,11 +4492,13 @@ static bool async_line_feed_byte(AsyncSession *s, AsyncLineDecoder *line,
 static bool async_line_emit_visible_run(AsyncSession *s,
                                         AsyncLineDecoder *line,
                                         const unsigned char *bytes,
-                                        size_t amount) {
+                                        size_t amount, bool run_is_ascii) {
   if (amount == 0) return true;
   line->saw_bytes = true;
-  if (s->max_line_length == 0)
+  if (s->max_line_length == 0) {
+    if (!run_is_ascii) line->output_has_non_ascii = true;
     return async_line_append_output(s, line, bytes, amount);
+  }
 
   size_t cap = async_line_limit(s->max_line_length);
   size_t offset = 0;
@@ -4461,6 +4528,7 @@ static bool async_line_emit_visible_run(AsyncSession *s,
     }
 
     unsigned expected = async_utf8_expected_width(bytes[offset]);
+    line->output_has_non_ascii = true;
     if (expected > amount - offset) {
       line->utf8_used = amount - offset;
       line->utf8_expected = expected;
@@ -4508,16 +4576,18 @@ static bool async_line_feed_bytes(AsyncSession *s, AsyncLineDecoder *line,
 
     if (line->ansi_state == AsyncAnsiNormal && line->pending_crs == 0) {
       size_t start = offset;
+      unsigned char run_bytes = 0;
       while (offset < amount) {
         unsigned char byte = (unsigned char)bytes[offset];
         if (byte == '\0' || byte == '\r' || byte == 0x1b)
           break;
+        run_bytes |= byte;
         offset++;
       }
       if (offset > start &&
           !async_line_emit_visible_run(
               s, line, (const unsigned char *)bytes + start,
-              offset - start))
+              offset - start, (run_bytes & 0x80) == 0))
         return false;
       if (offset == amount) return true;
     }
@@ -4555,6 +4625,7 @@ static void async_line_reset(AsyncLineDecoder *line) {
   line->ansi_state = AsyncAnsiNormal;
   line->over_limit = false;
   line->saw_bytes = false;
+  line->output_has_non_ascii = false;
   if (line->output) line->output[0] = '\0';
 }
 
@@ -4574,7 +4645,8 @@ static bool async_line_finish(AsyncSession *s, AsyncLineDecoder *line) {
   if (publish) {
     if (!async_line_reserve(s, line, 0)) return false;
     line->output[line->output_len] = '\0';
-    ok = async_append_candidate(s, line->output, line->output_len);
+    ok = async_append_candidate_classified(
+        s, line->output, line->output_len, !line->output_has_non_ascii);
   }
   async_line_reset(line);
   return ok;
@@ -6024,11 +6096,16 @@ static void async_score_batches(struct AsyncScoringShared *shared,
       if (!pattern) {
         sc = 1;                  /* empty filter: keep everything */
       } else if (filter_only) {
-        sc = fzf_has_match(batch->xs[i].str, pattern, slab) ? 1 : 0;
+        uint32_t metadata = async_candidate_metadata(batch->xs[i].str);
+        text_len = async_candidate_length(batch->xs[i].str, metadata);
+        input_is_ascii = async_candidate_ascii_from_metadata(metadata);
+        sc = fzf_has_match_bytes_preclassified(
+                 batch->xs[i].str, text_len, input_is_ascii, pattern, slab)
+                 ? 1 : 0;
       } else {
-        text_len = strlen(batch->xs[i].str);
-        input_is_ascii = is_ascii_utf8proc(
-            batch->xs[i].str, text_len);
+        uint32_t metadata = async_candidate_metadata(batch->xs[i].str);
+        text_len = async_candidate_length(batch->xs[i].str, metadata);
+        input_is_ascii = async_candidate_ascii_from_metadata(metadata);
         sc = fzf_score_and_rank(
             batch->xs[i].str, text_len, input_is_ascii,
             pattern, slab, shared->score_scheme,
@@ -7023,8 +7100,9 @@ static void *scoring_thread_fn(void *arg) {
           rank_aborted = true;
           break;
         }
-        size_t text_len = strlen(flat[i].str);
-        bool input_is_ascii = is_ascii_utf8proc(flat[i].str, text_len);
+        uint32_t metadata = async_candidate_metadata(flat[i].str);
+        size_t text_len = async_candidate_length(flat[i].str, metadata);
+        bool input_is_ascii = async_candidate_ascii_from_metadata(metadata);
         flat[i].score = fzf_score_and_rank(
             flat[i].str, text_len, input_is_ascii, pattern, rank_slab,
             score_scheme, can_reuse_public_score, &flat[i].rank);

--- a/fzf-native-module.c
+++ b/fzf-native-module.c
@@ -625,8 +625,11 @@ static int fzf_score_and_rank(
       bounds.raw_score = score;
     }
   } else {
-    score = fzf_get_score_with_bounds_bytes_preclassified(
-        text, text_len, input_is_ascii, pattern, slab, &bounds);
+    score = scheme == FZF_SCORE_SCHEME_PATH
+                ? fzf_get_score_with_rank_bounds_bytes_preclassified(
+                      text, text_len, input_is_ascii, pattern, slab, &bounds)
+                : fzf_get_score_with_bounds_bytes_preclassified(
+                      text, text_len, input_is_ascii, pattern, slab, &bounds);
   }
   if (score > 0 && rank)
     *rank = fzf_rank_keys_preclassified(

--- a/fzf-score-input.inc
+++ b/fzf-score-input.inc
@@ -13,6 +13,14 @@
 #define FZF_SCORE_COMMIT_BOUNDS() ((void)0)
 #define FZF_SCORE_COMMIT_BOUNDS_WAS_DEFAULTED 1
 #endif
+#ifndef FZF_SCORE_POSITIONS
+#define FZF_SCORE_POSITIONS NULL
+#define FZF_SCORE_POSITIONS_WAS_DEFAULTED 1
+#endif
+#ifndef FZF_SCORE_RETURN
+#define FZF_SCORE_RETURN(value) return (value)
+#define FZF_SCORE_RETURN_WAS_DEFAULTED 1
+#endif
 
 if (pattern->only_inv) {
   for (size_t i = 0; i < pattern->size; i++) {
@@ -24,10 +32,10 @@ if (pattern->only_inv) {
        small slab accept candidates that the default slab rejected. */
     fzf_result_t res = CALL_ALG(
         term, false, input, input_is_ascii, pattern->forward, NULL, slab);
-    if (fzf_allocation_failed()) return 0;
-    if (res.start >= 0) return 0;
+    if (fzf_allocation_failed()) FZF_SCORE_RETURN(0);
+    if (res.start >= 0) FZF_SCORE_RETURN(0);
   }
-  return 1;
+  FZF_SCORE_RETURN(1);
 }
 
 int32_t total_score = 0;
@@ -38,8 +46,9 @@ for (size_t i = 0; i < pattern->size; i++) {
   for (size_t j = 0; j < term_set->size; j++) {
     fzf_term_t *term = &term_set->ptr[j];
     fzf_result_t res = CALL_ALG(
-        term, false, input, input_is_ascii, pattern->forward, NULL, slab);
-    if (fzf_allocation_failed()) return 0;
+        term, false, input, input_is_ascii, pattern->forward,
+        term->inv ? NULL : FZF_SCORE_POSITIONS, slab);
+    if (fzf_allocation_failed()) FZF_SCORE_RETURN(0);
     if (res.start >= 0) {
       if (term->inv) continue;
       FZF_SCORE_RECORD_BOUNDS(res);
@@ -60,7 +69,7 @@ for (size_t i = 0; i < pattern->size; i++) {
       matched = true;
     }
   }
-  if (!matched) return 0;
+  if (!matched) FZF_SCORE_RETURN(0);
   total_score += current_score;
 }
 
@@ -78,4 +87,13 @@ FZF_SCORE_COMMIT_BOUNDS();
 #undef FZF_SCORE_COMMIT_BOUNDS
 #endif
 
-return total_score > 0 ? total_score : 1;
+FZF_SCORE_RETURN(total_score > 0 ? total_score : 1);
+
+#ifdef FZF_SCORE_POSITIONS_WAS_DEFAULTED
+#undef FZF_SCORE_POSITIONS_WAS_DEFAULTED
+#undef FZF_SCORE_POSITIONS
+#endif
+#ifdef FZF_SCORE_RETURN_WAS_DEFAULTED
+#undef FZF_SCORE_RETURN_WAS_DEFAULTED
+#undef FZF_SCORE_RETURN
+#endif

--- a/fzf-scorer-oom-ctest.c
+++ b/fzf-scorer-oom-ctest.c
@@ -59,6 +59,14 @@ static fzf_pattern_t *make_pattern(char *query) {
   return fzf_parse_pattern(CaseRespect, false, query, true);
 }
 
+static fzf_pattern_t *make_path_pattern(char *query) {
+  fail_at = SIZE_MAX;
+  allocation_number = 0;
+  failure_injected = false;
+  return fzf_parse_pattern_with_direction(
+      CaseRespect, false, query, true, false);
+}
+
 static int exercise_score(const char *label, const char *candidate,
                           fzf_pattern_t *pattern, size_t *tested) {
   for (fail_at = 0;; fail_at++) {
@@ -138,21 +146,76 @@ static int exercise_score_positions(const char *label, const char *candidate,
   }
 }
 
+static int exercise_rank_bounds(const char *label, const char *candidate,
+                                fzf_pattern_t *pattern, size_t *tested) {
+  size_t length = strlen(candidate);
+  bool input_is_ascii = is_ascii_utf8proc(candidate, length);
+  for (size_t index = 0;; index++) {
+    fail_at = SIZE_MAX;
+    allocation_number = 0;
+    failure_injected = false;
+    fzf_slab_t *slab = fzf_make_default_slab();
+    if (!slab || !fzf_slab_set_score_scheme(
+                     slab, FZF_SCORE_SCHEME_PATH)) {
+      fzf_free_slab(slab);
+      return fail(label, index, "could not create the path slab");
+    }
+
+    allocation_number = 0;
+    fail_at = index;
+    failure_injected = false;
+    fzf_score_bounds_t bounds = {
+      .min_begin = -99, .min_end = -99, .max_end = -99,
+      .raw_score = -99, .valid = true,
+    };
+    int32_t score = fzf_get_score_with_rank_bounds_bytes_preclassified(
+        candidate, length, input_is_ascii, pattern, slab, &bounds);
+    fail_at = SIZE_MAX;
+    fzf_free_slab(slab);
+
+    if (!failure_injected) {
+      if (score <= 0 || !bounds.valid || bounds.min_begin < 0)
+        return fail(label, index, "successful run lost score or rank bounds");
+      if (fzf_allocation_failed())
+        return fail(label, index, "successful run retained OOM flag");
+      return 0;
+    }
+    if (score != 0)
+      return fail(label, index, "injected OOM returned a match score");
+    if (!fzf_allocation_failed())
+      return fail(label, index, "injected OOM was reported as no-match");
+    if (bounds.valid || bounds.min_begin != 0 || bounds.min_end != 0 ||
+        bounds.max_end != 0 || bounds.raw_score != 0)
+      return fail(label, index, "injected OOM published partial bounds");
+    (*tested)++;
+  }
+}
+
 int main(void) {
   size_t tested = 0;
   char one_query[] = "a";
   char two_query[] = "ab";
   char ascii_query[] = "abc";
   char utf8_query[] = "你界";
+  char utf8_path_query[] = "你界";
+  char path_query[] = "alpha";
+  char compound_query[] = "'alpha | 'omega 'beta";
   fzf_pattern_t *one_pattern = make_pattern(one_query);
   fzf_pattern_t *two_pattern = make_pattern(two_query);
   fzf_pattern_t *ascii_pattern = make_pattern(ascii_query);
   fzf_pattern_t *utf8_pattern = make_pattern(utf8_query);
-  if (!one_pattern || !two_pattern || !ascii_pattern || !utf8_pattern) {
+  fzf_pattern_t *utf8_path_pattern = make_path_pattern(utf8_path_query);
+  fzf_pattern_t *path_pattern = make_path_pattern(path_query);
+  fzf_pattern_t *compound_pattern = make_path_pattern(compound_query);
+  if (!one_pattern || !two_pattern || !ascii_pattern || !utf8_pattern ||
+      !utf8_path_pattern || !path_pattern || !compound_pattern) {
     fzf_free_pattern(one_pattern);
     fzf_free_pattern(two_pattern);
     fzf_free_pattern(ascii_pattern);
     fzf_free_pattern(utf8_pattern);
+    fzf_free_pattern(utf8_path_pattern);
+    fzf_free_pattern(path_pattern);
+    fzf_free_pattern(compound_pattern);
     return fail("setup", 0, "could not create patterns");
   }
 
@@ -177,13 +240,22 @@ int main(void) {
       exercise_positions("UTF-8 positions", "a你---界z", utf8_pattern,
                          &tested) ||
       exercise_score_positions("UTF-8 combined", "a你---界z", utf8_pattern,
-                               &tested);
+                               &tested) ||
+      exercise_rank_bounds("ASCII path rank bounds", "beta alpha",
+                           path_pattern, &tested) ||
+      exercise_rank_bounds("UTF-8 path rank bounds", "目录/x 你界",
+                           utf8_path_pattern, &tested) ||
+      exercise_rank_bounds("compound path rank bounds",
+                           "dir/x omega beta", compound_pattern, &tested);
 
   fail_at = SIZE_MAX;
   fzf_free_pattern(one_pattern);
   fzf_free_pattern(two_pattern);
   fzf_free_pattern(ascii_pattern);
   fzf_free_pattern(utf8_pattern);
+  fzf_free_pattern(utf8_path_pattern);
+  fzf_free_pattern(path_pattern);
+  fzf_free_pattern(compound_pattern);
   if (result) return result;
   printf("scorer OOM test passed (%zu allocation failures)\n", tested);
   return 0;

--- a/fzf-scorer-oom-ctest.c
+++ b/fzf-scorer-oom-ctest.c
@@ -140,17 +140,33 @@ static int exercise_score_positions(const char *label, const char *candidate,
 
 int main(void) {
   size_t tested = 0;
+  char one_query[] = "a";
+  char two_query[] = "ab";
   char ascii_query[] = "abc";
   char utf8_query[] = "你界";
+  fzf_pattern_t *one_pattern = make_pattern(one_query);
+  fzf_pattern_t *two_pattern = make_pattern(two_query);
   fzf_pattern_t *ascii_pattern = make_pattern(ascii_query);
   fzf_pattern_t *utf8_pattern = make_pattern(utf8_query);
-  if (!ascii_pattern || !utf8_pattern) {
+  if (!one_pattern || !two_pattern || !ascii_pattern || !utf8_pattern) {
+    fzf_free_pattern(one_pattern);
+    fzf_free_pattern(two_pattern);
     fzf_free_pattern(ascii_pattern);
     fzf_free_pattern(utf8_pattern);
     return fail("setup", 0, "could not create patterns");
   }
 
   int result =
+      exercise_score("one-byte score", "beta", one_pattern, &tested) ||
+      exercise_positions("one-byte positions", "beta", one_pattern,
+                         &tested) ||
+      exercise_score_positions("one-byte combined", "beta", one_pattern,
+                               &tested) ||
+      exercise_score("two-byte score", "alphabet", two_pattern, &tested) ||
+      exercise_positions("two-byte positions", "alphabet", two_pattern,
+                         &tested) ||
+      exercise_score_positions("two-byte combined", "alphabet", two_pattern,
+                               &tested) ||
       exercise_score("ASCII score", "alphabet-bravo-charlie", ascii_pattern,
                      &tested) ||
       exercise_positions("ASCII positions", "alphabet-bravo-charlie",
@@ -164,6 +180,8 @@ int main(void) {
                                &tested);
 
   fail_at = SIZE_MAX;
+  fzf_free_pattern(one_pattern);
+  fzf_free_pattern(two_pattern);
   fzf_free_pattern(ascii_pattern);
   fzf_free_pattern(utf8_pattern);
   if (result) return result;

--- a/fzf-simd-prefilter-test.c
+++ b/fzf-simd-prefilter-test.c
@@ -72,6 +72,59 @@ static ptrdiff_t planned_fuzzy_index(const uint8_t *text, size_t text_size,
   return first_index == 0 ? 0 : (ptrdiff_t)(first_index - 1);
 }
 
+static const char *scalar_find_byte_two(const char *text, size_t text_size,
+                                        uint8_t exact_byte,
+                                        uint8_t alternate_byte) {
+  for (size_t i = 0; i < text_size; i++) {
+    uint8_t byte = (uint8_t)text[i];
+    if (byte == exact_byte || byte == alternate_byte) return text + i;
+  }
+  return NULL;
+}
+
+static void check_byte_two(const char *text, size_t text_size,
+                           uint8_t exact_byte, uint8_t alternate_byte) {
+  const char *scalar = scalar_find_byte_two(
+      text, text_size, exact_byte, alternate_byte);
+  const char *simd = fzf_simd_find_byte_two(
+      text, text_size, exact_byte, alternate_byte);
+  if (scalar != simd) {
+    fprintf(stderr,
+            "FAIL paired byte search: size=%zu exact=%u alternate=%u "
+            "scalar=%td simd=%td\n",
+            text_size, (unsigned int)exact_byte, (unsigned int)alternate_byte,
+            scalar ? scalar - text : -1, simd ? simd - text : -1);
+    failures++;
+  }
+}
+
+static void test_paired_byte_search(void) {
+  for (size_t text_size = 0; text_size <= 256; text_size++) {
+    char *text = malloc(text_size == 0 ? 1 : text_size);
+    CHECK(text != NULL, "paired byte search allocation failed");
+    if (!text) return;
+    memset(text, 'x', text_size);
+    check_byte_two(text, text_size, 'q', 'Q');
+    check_byte_two(text, text_size, 'q', 'q');
+    for (size_t position = 0; position < text_size; position++) {
+      text[position] = 'q';
+      check_byte_two(text, text_size, 'q', 'Q');
+      text[position] = 'Q';
+      check_byte_two(text, text_size, 'q', 'Q');
+      text[position] = 'x';
+    }
+    if (text_size > 1) {
+      text[text_size - 1] = 'q';
+      for (size_t position = 0; position + 1 < text_size; position++) {
+        text[position] = 'Q';
+        check_byte_two(text, text_size, 'q', 'Q');
+        text[position] = 'x';
+      }
+    }
+    free(text);
+  }
+}
+
 static bool scalar_matches_at(const uint8_t *text, const uint8_t *pattern,
                               size_t pattern_size, bool case_sensitive) {
   for (size_t i = 0; i < pattern_size; i++)
@@ -373,6 +426,7 @@ static void test_long_query_scalar_fallback(void) {
 
 int main(void) {
 #if FZF_HAVE_SIMD_PREFILTER
+  test_paired_byte_search();
   test_seed_selection();
   test_complete_occurrence_sets();
   test_first_index_semantics();

--- a/fzf-simd-prefilter-test.c
+++ b/fzf-simd-prefilter-test.c
@@ -62,7 +62,7 @@ static ptrdiff_t scalar_fuzzy_index(const uint8_t *text, size_t text_size,
 static ptrdiff_t planned_fuzzy_index(const uint8_t *text, size_t text_size,
                                      const fzf_ascii_query_plan_t *plan) {
   if (plan->pattern_size == 0) return 0;
-  const char *first = fzf_ascii_plan_find_byte(
+  const char *first = fzf_ascii_plan_find_initial_byte(
       (const char *)text, text_size, &plan->bytes[0], plan->case_sensitive);
   if (!first) return -1;
   size_t first_index = (size_t)(first - (const char *)text);
@@ -95,6 +95,21 @@ static void check_byte_two(const char *text, size_t text_size,
             text_size, (unsigned int)exact_byte, (unsigned int)alternate_byte,
             scalar ? scalar - text : -1, simd ? simd - text : -1);
     failures++;
+  }
+  if (text_size > FZF_SIMD_LANES &&
+      text_size < 2 * FZF_SIMD_LANES) {
+    const char *short_simd = fzf_simd_find_byte_two_short(
+        text, text_size, exact_byte, alternate_byte);
+    if (scalar != short_simd) {
+      fprintf(stderr,
+              "FAIL short paired byte search: size=%zu exact=%u alternate=%u "
+              "scalar=%td simd=%td\n",
+              text_size, (unsigned int)exact_byte,
+              (unsigned int)alternate_byte,
+              scalar ? scalar - text : -1,
+              short_simd ? short_simd - text : -1);
+      failures++;
+    }
   }
 }
 

--- a/fzf-simd-prefilter.h
+++ b/fzf-simd-prefilter.h
@@ -230,6 +230,87 @@ static inline unsigned int fzf_simd_first_lane(uint16_t mask) {
 #endif
 }
 
+#if defined(_MSC_VER)
+#define FZF_SIMD_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__) || defined(__clang__)
+#define FZF_SIMD_NOINLINE __attribute__((noinline))
+#else
+#define FZF_SIMD_NOINLINE
+#endif
+
+/* Case-insensitive planned matching needs the first occurrence of either
+   ASCII case variant. Keep the two-byte scan out of line so its vector setup
+   does not enlarge the surrounding scorer or perturb unrelated hot paths. */
+static FZF_SIMD_NOINLINE const char *fzf_simd_find_byte_two(
+    const char *text, size_t text_size,
+    uint8_t exact_byte, uint8_t alternate_byte) {
+#if defined(FZF_SIMD_NEON)
+  fzf_simd_chunk_t exact = vdupq_n_u8(exact_byte);
+  fzf_simd_chunk_t alternate = vdupq_n_u8(alternate_byte);
+#elif defined(FZF_SIMD_SSE2)
+  fzf_simd_chunk_t exact = _mm_set1_epi8((char)exact_byte);
+  fzf_simd_chunk_t alternate = _mm_set1_epi8((char)alternate_byte);
+#endif
+  size_t offset = 0;
+
+  while (text_size - offset >= 2 * FZF_SIMD_LANES) {
+    fzf_simd_chunk_t first = fzf_simd_load(text + offset);
+    fzf_simd_chunk_t second =
+        fzf_simd_load(text + offset + FZF_SIMD_LANES);
+#if defined(FZF_SIMD_NEON)
+    uint8x16_t first_matches = vorrq_u8(
+        vceqq_u8(first, exact), vceqq_u8(first, alternate));
+    uint8x16_t second_matches = vorrq_u8(
+        vceqq_u8(second, exact), vceqq_u8(second, alternate));
+    if (vmaxvq_u8(vorrq_u8(first_matches, second_matches)) != 0) {
+      uint16_t mask = fzf_simd_movemask(first_matches);
+      if (mask != 0) return text + offset + fzf_simd_first_lane(mask);
+      mask = fzf_simd_movemask(second_matches);
+      return text + offset + FZF_SIMD_LANES +
+             fzf_simd_first_lane(mask);
+    }
+#elif defined(FZF_SIMD_SSE2)
+    __m128i first_matches = _mm_or_si128(
+        _mm_cmpeq_epi8(first, exact), _mm_cmpeq_epi8(first, alternate));
+    __m128i second_matches = _mm_or_si128(
+        _mm_cmpeq_epi8(second, exact), _mm_cmpeq_epi8(second, alternate));
+    uint16_t mask = (uint16_t)_mm_movemask_epi8(first_matches);
+    if (mask != 0) return text + offset + fzf_simd_first_lane(mask);
+    mask = (uint16_t)_mm_movemask_epi8(second_matches);
+    if (mask != 0)
+      return text + offset + FZF_SIMD_LANES + fzf_simd_first_lane(mask);
+#endif
+    offset += 2 * FZF_SIMD_LANES;
+  }
+
+  if (text_size - offset >= FZF_SIMD_LANES) {
+    fzf_simd_chunk_t chunk = fzf_simd_load(text + offset);
+#if defined(FZF_SIMD_NEON)
+    uint8x16_t matches = vorrq_u8(
+        vceqq_u8(chunk, exact), vceqq_u8(chunk, alternate));
+    if (vmaxvq_u8(matches) != 0) {
+      uint16_t mask = fzf_simd_movemask(matches);
+      return text + offset + fzf_simd_first_lane(mask);
+    }
+#elif defined(FZF_SIMD_SSE2)
+    __m128i matches = _mm_or_si128(
+        _mm_cmpeq_epi8(chunk, exact), _mm_cmpeq_epi8(chunk, alternate));
+    uint16_t mask = (uint16_t)_mm_movemask_epi8(matches);
+    if (mask != 0) return text + offset + fzf_simd_first_lane(mask);
+#endif
+    offset += FZF_SIMD_LANES;
+  }
+
+  while (offset < text_size) {
+    uint8_t byte = (uint8_t)text[offset];
+    if (byte == exact_byte || byte == alternate_byte) return text + offset;
+    offset++;
+  }
+  return NULL;
+}
+
+#undef FZF_SIMD_NOINLINE
+
 static inline bool fzf_ascii_plan_byte_matches(
     uint8_t candidate, const fzf_simd_query_byte_t *query,
     bool case_sensitive) {
@@ -240,12 +321,18 @@ static inline bool fzf_ascii_plan_byte_matches(
 static inline const char *fzf_ascii_plan_find_byte(
     const char *text, size_t text_size,
     const fzf_simd_query_byte_t *query, bool case_sensitive) {
-  const char *exact = memchr(text, query->exact[0], text_size);
-  if (case_sensitive || query->alternate[0] == query->exact[0]) return exact;
-  size_t alternate_size = exact ? (size_t)(exact - text) : text_size;
-  const char *alternate =
-      memchr(text, query->alternate[0], alternate_size);
-  return alternate ? alternate : exact;
+  if (case_sensitive || query->alternate[0] == query->exact[0])
+    return memchr(text, query->exact[0], text_size);
+  /* libc's two short memchr calls beat an out-of-line vector setup on tails. */
+  if (text_size < FZF_SIMD_LANES) {
+    const char *exact = memchr(text, query->exact[0], text_size);
+    size_t alternate_size = exact ? (size_t)(exact - text) : text_size;
+    const char *alternate =
+        memchr(text, query->alternate[0], alternate_size);
+    return alternate ? alternate : exact;
+  }
+  return fzf_simd_find_byte_two(
+      text, text_size, query->exact[0], query->alternate[0]);
 }
 
 /* FIRST_INDEX is a verified match for query byte zero. */

--- a/fzf-simd-prefilter.h
+++ b/fzf-simd-prefilter.h
@@ -309,6 +309,44 @@ static FZF_SIMD_NOINLINE const char *fzf_simd_find_byte_two(
   return NULL;
 }
 
+/* Specialized partial two-vector span for the initial mandatory byte.  The
+   second load ends exactly at TEXT_SIZE and overlaps the first; lanes already
+   covered by the first load are masked out. */
+static FZF_SIMD_NOINLINE const char *fzf_simd_find_byte_two_short(
+    const char *text, size_t text_size,
+    uint8_t exact_byte, uint8_t alternate_byte) {
+#if defined(FZF_SIMD_NEON)
+  uint8x16_t exact = vdupq_n_u8(exact_byte);
+  uint8x16_t alternate = vdupq_n_u8(alternate_byte);
+  uint8x16_t first = fzf_simd_load(text);
+  uint16_t mask = fzf_simd_movemask(vorrq_u8(
+      vceqq_u8(first, exact), vceqq_u8(first, alternate)));
+#elif defined(FZF_SIMD_SSE2)
+  __m128i exact = _mm_set1_epi8((char)exact_byte);
+  __m128i alternate = _mm_set1_epi8((char)alternate_byte);
+  __m128i first = fzf_simd_load(text);
+  uint16_t mask = (uint16_t)_mm_movemask_epi8(_mm_or_si128(
+      _mm_cmpeq_epi8(first, exact), _mm_cmpeq_epi8(first, alternate)));
+#endif
+  if (mask != 0) return text + fzf_simd_first_lane(mask);
+
+  size_t tail_offset = text_size - FZF_SIMD_LANES;
+#if defined(FZF_SIMD_NEON)
+  uint8x16_t last = fzf_simd_load(text + tail_offset);
+  mask = fzf_simd_movemask(vorrq_u8(
+      vceqq_u8(last, exact), vceqq_u8(last, alternate)));
+#elif defined(FZF_SIMD_SSE2)
+  __m128i last = fzf_simd_load(text + tail_offset);
+  mask = (uint16_t)_mm_movemask_epi8(_mm_or_si128(
+      _mm_cmpeq_epi8(last, exact), _mm_cmpeq_epi8(last, alternate)));
+#endif
+  unsigned int overlap = (unsigned int)(2 * FZF_SIMD_LANES - text_size);
+  mask = (uint16_t)(mask & (uint16_t)(UINT32_C(0xffff) << overlap));
+  if (mask != 0)
+    return text + tail_offset + fzf_simd_first_lane(mask);
+  return NULL;
+}
+
 #undef FZF_SIMD_NOINLINE
 
 static inline bool fzf_ascii_plan_byte_matches(
@@ -333,6 +371,21 @@ static inline const char *fzf_ascii_plan_find_byte(
   }
   return fzf_simd_find_byte_two(
       text, text_size, query->exact[0], query->alternate[0]);
+}
+
+/* The initial mandatory byte is often absent, so its scan dominates rejected
+   candidates.  Use the overlapping-tail specialization for a partial second
+   vector; later query bytes keep the smaller general helper because they
+   start deeper in the text and more often find a match. */
+static inline const char *fzf_ascii_plan_find_initial_byte(
+    const char *text, size_t text_size,
+    const fzf_simd_query_byte_t *query, bool case_sensitive) {
+  if (!case_sensitive && query->alternate[0] != query->exact[0] &&
+      text_size > FZF_SIMD_LANES &&
+      text_size < 2 * FZF_SIMD_LANES)
+    return fzf_simd_find_byte_two_short(
+        text, text_size, query->exact[0], query->alternate[0]);
+  return fzf_ascii_plan_find_byte(text, text_size, query, case_sensitive);
 }
 
 /* FIRST_INDEX is a verified match for query byte zero. */

--- a/fzf-simd-prefilter.h
+++ b/fzf-simd-prefilter.h
@@ -18,15 +18,16 @@
 #include <stdint.h>
 #include <string.h>
 
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
 #if defined(__aarch64__) || defined(_M_ARM64)
 #include <arm_neon.h>
 #define FZF_HAVE_SIMD_PREFILTER 1
 #define FZF_SIMD_NEON 1
 #elif defined(__x86_64__) || defined(_M_X64)
 #include <emmintrin.h>
-#if defined(_MSC_VER)
-#include <intrin.h>
-#endif
 #define FZF_HAVE_SIMD_PREFILTER 1
 #define FZF_SIMD_SSE2 1
 #else

--- a/fzf-simd-prefilter.h
+++ b/fzf-simd-prefilter.h
@@ -42,6 +42,8 @@
 /* The plan's strictest member is size_t.  Spell the alignment this way
    instead of using C11 _Alignof so the header also builds as MSVC C. */
 #define FZF_SIMD_PLAN_ALIGNMENT sizeof(size_t)
+#define FZF_PARSED_PATTERN_FLAGS_SIZE 1u
+#define FZF_PARSED_PATTERN_RAW_OTHER_LETTER UINT8_C(1)
 
 typedef struct {
   uint8_t exact[FZF_SIMD_LANES];
@@ -79,7 +81,8 @@ static inline const fzf_ascii_query_plan_t *
 fzf_ascii_query_plan_from_parsed(const fzf_string_t *pattern) {
 #if FZF_HAVE_SIMD_PREFILTER
   uintptr_t after_codepoints =
-      (uintptr_t)(pattern->codepoints + pattern->codepoint_count);
+      (uintptr_t)(pattern->codepoints + pattern->codepoint_count) +
+      FZF_PARSED_PATTERN_FLAGS_SIZE;
   size_t alignment = FZF_SIMD_PLAN_ALIGNMENT;
   uintptr_t aligned =
       (after_codepoints + alignment - 1) & ~(uintptr_t)(alignment - 1);
@@ -92,18 +95,28 @@ fzf_ascii_query_plan_from_parsed(const fzf_string_t *pattern) {
 
 static inline size_t fzf_ascii_query_plan_private_size(
     const fzf_string_t *pattern) {
-#if FZF_HAVE_SIMD_PREFILTER
   const unsigned char *after_codepoints =
       (const unsigned char *)(pattern->codepoints +
                               pattern->codepoint_count);
+#if FZF_HAVE_SIMD_PREFILTER
   const fzf_ascii_query_plan_t *plan =
       fzf_ascii_query_plan_from_parsed(pattern);
   return (size_t)((const unsigned char *)plan - after_codepoints) +
          fzf_ascii_query_plan_size(plan->pattern_size);
 #else
   (void)pattern;
-  return 0;
+  (void)after_codepoints;
+  return FZF_PARSED_PATTERN_FLAGS_SIZE;
 #endif
+}
+
+/* Parsed terms append one byte of scorer metadata before the optional,
+   aligned SIMD plan.  Keeping it out of fzf_string_t preserves the public
+   structure ABI. */
+static inline const uint8_t *fzf_parsed_pattern_flags(
+    const fzf_string_t *pattern) {
+  return (const uint8_t *)(pattern->codepoints +
+                           pattern->codepoint_count);
 }
 
 #if FZF_HAVE_SIMD_PREFILTER

--- a/fzf.c
+++ b/fzf.c
@@ -1478,8 +1478,11 @@ static fzf_result_t fzf_fuzzy_match_v2_impl(
   }
 
   resize_pos(pos, M, M);
-  size_t j = max_score_pos;
+  /* Match upstream's score-only boundary: without a backtrace, fzf reports
+     the first Phase-2 match (F[0]), not the best final-row position. */
+  size_t j = f0;
   if (pos) {
+    j = max_score_pos;
     size_t i = M - 1;
     bool prefer_match = true;
     for (;;) {
@@ -2798,8 +2801,11 @@ static fzf_result_t fzf_fuzzy_match_v2_utf8_impl(
 
   // Phase 4: Backtrace
   resize_pos(pos, Mc, Mc);
-  size_t j = max_score_pos;
+  /* Match upstream's score-only boundary: without a backtrace, fzf reports
+     the first Phase-2 match (F[0]), not the best final-row position. */
+  size_t j = f0;
   if (pos) {
+    j = max_score_pos;
     size_t i = Mc - 1;
     bool prefer_match = true;
     for (;;) {
@@ -3638,6 +3644,7 @@ static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_two_score(
   bool in_gap1 = false;
   bool found0 = false;
   bool found1 = false;
+  size_t first_match_pos = SIZE_MAX;
 
   for (size_t col = (size_t)first; col < scan_end; col++) {
     char c = text->data[col];
@@ -3649,7 +3656,10 @@ static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_two_score(
 
     bool row1_was_active = found1;
     if (!found0) {
-      if (c == pchar0) found0 = true;
+      if (c == pchar0) {
+        found0 = true;
+        first_match_pos = col;
+      }
     } else if (!found1 && c == pchar1) {
       found1 = true;
     }
@@ -3698,7 +3708,9 @@ static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_two_score(
     bonus_prev = bonus;
   }
 
-  return (fzf_result_t){(int32_t)max_score_pos,
+  if (first_match_pos == SIZE_MAX)
+    return (fzf_result_t){-1, -1, 0};
+  return (fzf_result_t){(int32_t)first_match_pos,
                         (int32_t)max_score_pos + 1, max_score};
 }
 
@@ -3773,6 +3785,7 @@ static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_score_rune_rows(
   size_t active = 0;
   int16_t max_score = 0;
   size_t max_score_pos = 0;
+  size_t first_match_pos = SIZE_MAX;
   size_t char_pos = scope.start_char;
   char_class prev_class = config->initial_class;
 
@@ -3787,7 +3800,10 @@ static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_score_rune_rows(
     int16_t bonus = bonus_for(config, prev_class, class);
     prev_class = class;
 
-    if (active < row_count && codepoint == query[active]) active++;
+    if (active < row_count && codepoint == query[active]) {
+      if (active == 0) first_match_pos = char_pos;
+      active++;
+    }
     for (size_t row_plus_one = active; row_plus_one > 0; row_plus_one--) {
       size_t row = row_plus_one - 1;
       if (row == 0) {
@@ -3858,7 +3874,8 @@ static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_score_rune_rows(
   }
 
   if (active != row_count) return (fzf_result_t){-1, -1, 0};
-  return (fzf_result_t){(int32_t)max_score_pos,
+  size_t start_pos = row_count == 1 ? max_score_pos : first_match_pos;
+  return (fzf_result_t){(int32_t)start_pos,
                         (int32_t)max_score_pos + 1, max_score};
 }
 

--- a/fzf.c
+++ b/fzf.c
@@ -709,15 +709,24 @@ static int32_t ascii_fuzzy_index(
 
 bool is_ascii_utf8proc(const char *text, size_t len) {
   const unsigned char *ptr = (const unsigned char *)text;
+  const uint64_t high_bits = UINT64_C(0x8080808080808080);
 
-  /* fzf_has_match uses this check for every filter-only candidate.  Inspect
-     eight bytes at a time so Unicode correctness does not add a byte-at-a-time
-     pre-pass to the overwhelmingly ASCII completion corpus.  memcpy keeps the
-     load valid for unaligned strings. */
+  /* fzf_has_match uses this check for every filter-only candidate.  Fold four
+     words before testing their high bits so the overwhelmingly ASCII corpus
+     takes one branch per 32 bytes, then use single words for the bounded tail.
+     memcpy keeps every load valid for unaligned, exact-sized ranges. */
+  while (len >= 4 * sizeof(uint64_t)) {
+    uint64_t words[4];
+    memcpy(words, ptr, sizeof words);
+    if ((words[0] | words[1] | words[2] | words[3]) & high_bits)
+      return false;
+    ptr += sizeof words;
+    len -= sizeof words;
+  }
   while (len >= sizeof(uint64_t)) {
     uint64_t word;
     memcpy(&word, ptr, sizeof(word));
-    if (word & UINT64_C(0x8080808080808080)) return false;
+    if (word & high_bits) return false;
     ptr += sizeof(word);
     len -= sizeof(word);
   }

--- a/fzf.c
+++ b/fzf.c
@@ -3384,6 +3384,34 @@ int32_t fzf_get_score_with_bounds_bytes_preclassified(
 #undef FZF_SCORE_RECORD_BOUNDS
 }
 
+int32_t fzf_get_score_with_rank_bounds_bytes_preclassified(
+    const char *text, size_t text_len, bool input_is_ascii,
+    fzf_pattern_t *pattern, fzf_slab_t *slab,
+    fzf_score_bounds_t *bounds) {
+  fzf_clear_allocation_failure();
+  if (bounds) *bounds = (fzf_score_bounds_t){0};
+  if (pattern->ptr == NULL) return 1;
+
+  fzf_string_t input = {.data = text, .size = text_len};
+  fzf_score_bounds_t staged_bounds = {0};
+  fzf_position_t positions = {0};
+#define FZF_SCORE_RECORD_BOUNDS(result) \
+  fzf_score_bounds_add(&staged_bounds, (result))
+#define FZF_SCORE_COMMIT_BOUNDS() do { \
+  if (bounds) *bounds = staged_bounds; \
+} while (0)
+#define FZF_SCORE_POSITIONS (&positions)
+#define FZF_SCORE_RETURN(value) do { \
+  free(positions.data); \
+  return (value); \
+} while (0)
+#include "fzf-score-input.inc"
+#undef FZF_SCORE_RETURN
+#undef FZF_SCORE_POSITIONS
+#undef FZF_SCORE_COMMIT_BOUNDS
+#undef FZF_SCORE_RECORD_BOUNDS
+}
+
 static int32_t score_positions_for_input(const char *text,
                                          fzf_pattern_t *pattern,
                                          fzf_slab_t *slab,

--- a/fzf.c
+++ b/fzf.c
@@ -1184,6 +1184,21 @@ fzf_result_t fzf_fuzzy_match_v1(bool case_sensitive, bool normalize,
                                  pattern, pos, slab, NULL);
 }
 
+#if defined(_MSC_VER)
+#define FZF_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__) || defined(__clang__)
+#define FZF_NOINLINE __attribute__((noinline))
+#else
+#define FZF_NOINLINE
+#endif
+
+static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_single(
+    bool case_sensitive, bool forward, fzf_string_t *text, char pchar,
+    fzf_position_t *pos, fzf_slab_t *slab);
+static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_two_score(
+    bool case_sensitive, bool forward, fzf_string_t *text,
+    fzf_string_t *pattern, fzf_slab_t *slab);
+
 static fzf_result_t fzf_fuzzy_match_v2_impl(
     bool case_sensitive, bool normalize, bool forward, fzf_string_t *text,
     fzf_string_t *pattern, fzf_position_t *pos, fzf_slab_t *slab,
@@ -2984,6 +2999,21 @@ static inline fzf_result_t call_alg_for_input(
         slab, plan);
   }
   if (algo == fzf_fuzzy_match_v2) {
+    /* With one ASCII pattern byte, each occurrence has an independent score:
+       ScoreMatch plus the local boundary bonus.  The DP scratch arrays cannot
+       affect the winner.  Two bytes need only two scalar running rows when
+       positions are not requested.  Keep the general v1 fallback for slabs
+       too small for the candidate. */
+    if (pattern->size <= 2 && input_is_ascii) {
+      if (pattern->size == 1 &&
+          (slab == NULL || input->size <= slab->I16.cap))
+        return fzf_fuzzy_match_v2_single(
+            term->case_sensitive, forward, input, pattern->data[0], pos, slab);
+      if (pattern->size == 2 && pos == NULL &&
+          (slab == NULL || input->size <= slab->I16.cap / 2))
+        return fzf_fuzzy_match_v2_two_score(
+            term->case_sensitive, forward, input, pattern, slab);
+    }
     const fzf_ascii_query_plan_t *plan =
         fzf_fuzzy_query_plan(input, pattern);
     return fzf_fuzzy_match_v2_impl(
@@ -3491,3 +3521,153 @@ void fzf_free_slab(fzf_slab_t *slab) {
     free(slab);
   }
 }
+
+static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_single(
+    bool case_sensitive, bool forward, fzf_string_t *text, char pchar,
+    fzf_position_t *pos, fzf_slab_t *slab) {
+  int16_t max_score = 0;
+  size_t max_score_pos = SIZE_MAX;
+  const score_scheme_config_t *config = score_scheme_config(slab);
+
+  /* Keep the common one-byte candidate off the libc search path. */
+  if (text->size == 1) {
+    char text_byte = text->data[0];
+    bool exact = text_byte == pchar;
+    bool folded = !case_sensitive && pchar >= 'a' && pchar <= 'z' &&
+                  text_byte == pchar - (char)32;
+    if (!exact && !folded) return (fzf_result_t){-1, -1, 0};
+    char_class class = char_class_of_ascii(text_byte, config);
+    int16_t score = ScoreMatch +
+                    bonus_for(config, config->initial_class, class) *
+                        BonusFirstCharMultiplier;
+    append_pos(pos, 0);
+    return (fzf_result_t){0, 1, score};
+  }
+
+  /* Parsed scoring has already classified the candidate as ASCII.  Jump
+     directly between occurrences because a one-byte score depends only on
+     that byte and its immediate predecessor. */
+  size_t from = 0;
+  for (;;) {
+    int32_t found = try_skip(text, case_sensitive, pchar, (int32_t)from);
+    if (found < 0) break;
+    size_t off = (size_t)found;
+    char_class class = char_class_of_ascii(text->data[off], config);
+    char_class prev_class = off == 0
+                                ? config->initial_class
+                                : char_class_of_ascii(text->data[off - 1],
+                                                      config);
+    int16_t bonus = bonus_for(config, prev_class, class);
+    int16_t score = ScoreMatch + bonus * BonusFirstCharMultiplier;
+    if (forward ? score > max_score : score >= max_score) {
+      max_score = score;
+      max_score_pos = off;
+      if (forward && bonus >= BonusBoundary) break;
+    }
+    if (off == text->size - 1) break;
+    from = off + 1;
+  }
+
+  if (max_score_pos == SIZE_MAX) return (fzf_result_t){-1, -1, 0};
+  append_pos(pos, max_score_pos);
+  return (fzf_result_t){(int32_t)max_score_pos,
+                        (int32_t)max_score_pos + 1, max_score};
+}
+
+static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_two_score(
+    bool case_sensitive, bool forward, fzf_string_t *text,
+    fzf_string_t *pattern, fzf_slab_t *slab) {
+  int32_t first = ascii_fuzzy_index(text, pattern, NULL, case_sensitive);
+  if (first < 0) return (fzf_result_t){-1, -1, 0};
+
+  const score_scheme_config_t *config = score_scheme_config(slab);
+  char pchar0 = pattern->data[0];
+  char pchar1 = pattern->data[1];
+
+  /* No final-row score at a gap after the last pchar1 can improve: each such
+     cell only applies a negative gap penalty.  A cheap reverse byte scan
+     avoids carrying either row through an irrelevant candidate suffix. */
+  size_t scan_end = text->size;
+  while (scan_end > (size_t)first) {
+    char c = text->data[scan_end - 1];
+    if (!case_sensitive && c >= 'A' && c <= 'Z') c += 'a' - 'A';
+    if (c == pchar1) break;
+    scan_end--;
+  }
+
+  int32_t prev_class = config->initial_class;
+  int16_t h0_prev = 0;
+  int16_t c0_prev = 0;
+  int16_t bonus_prev = 0;
+  int16_t h1_prev = 0;
+  int16_t max_score = 0;
+  size_t max_score_pos = 0;
+  bool in_gap0 = false;
+  bool in_gap1 = false;
+  bool found0 = false;
+  bool found1 = false;
+
+  for (size_t col = (size_t)first; col < scan_end; col++) {
+    char c = text->data[col];
+    char_class class = char_class_of_ascii(c, config);
+    if (!case_sensitive && class == CharUpper)
+      c = (char)tolower((uint8_t)c);
+    int16_t bonus = bonus_for(config, prev_class, class);
+    prev_class = class;
+
+    bool row1_was_active = found1;
+    if (!found0) {
+      if (c == pchar0) found0 = true;
+    } else if (!found1 && c == pchar1) {
+      found1 = true;
+    }
+
+    int16_t h0;
+    int16_t c0;
+    if (c == pchar0) {
+      h0 = ScoreMatch + bonus * BonusFirstCharMultiplier;
+      c0 = 1;
+      in_gap0 = false;
+    } else {
+      h0 = max16(h0_prev +
+                     (in_gap0 ? ScoreGapExtention : ScoreGapStart),
+                 0);
+      c0 = 0;
+      in_gap0 = true;
+    }
+
+    if (found1) {
+      int16_t h_left = row1_was_active ? h1_prev : 0;
+      int16_t s1 = 0;
+      int16_t s2 = h_left +
+                   (in_gap1 ? ScoreGapExtention : ScoreGapStart);
+      if (c == pchar1) {
+        int16_t match_bonus = bonus;
+        if (c0_prev > 0 &&
+            !(match_bonus >= BonusBoundary && match_bonus > bonus_prev))
+          match_bonus = max16(
+              match_bonus, max16(BonusConsecutive, bonus_prev));
+        s1 = h0_prev + ScoreMatch;
+        if (s1 + match_bonus < s2)
+          s1 += bonus;
+        else
+          s1 += match_bonus;
+      }
+      in_gap1 = s1 < s2;
+      h1_prev = max16(max16(s1, s2), 0);
+      if (forward ? h1_prev > max_score : h1_prev >= max_score) {
+        max_score = h1_prev;
+        max_score_pos = col;
+      }
+    }
+
+    h0_prev = h0;
+    c0_prev = c0;
+    bonus_prev = bonus;
+  }
+
+  return (fzf_result_t){(int32_t)max_score_pos,
+                        (int32_t)max_score_pos + 1, max_score};
+}
+
+#undef FZF_NOINLINE

--- a/fzf.c
+++ b/fzf.c
@@ -676,7 +676,7 @@ static int32_t ascii_fuzzy_index(
       plan->case_sensitive == case_sensitive &&
       pattern->size >= FZF_SIMD_FUZZY_MIN_PATTERN &&
       input->size >= FZF_SIMD_FUZZY_MIN_TEXT) {
-    const char *first = fzf_ascii_plan_find_byte(
+    const char *first = fzf_ascii_plan_find_initial_byte(
         input->data, input->size, &plan->bytes[0], case_sensitive);
     if (!first) return -1;
     size_t first_index = (size_t)(first - input->data);

--- a/fzf.c
+++ b/fzf.c
@@ -1207,6 +1207,12 @@ static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_single(
 static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_two_score(
     bool case_sensitive, bool forward, fzf_string_t *text,
     fzf_string_t *pattern, fzf_slab_t *slab);
+#define FZF_FUZZY_RUNE_SCORE_ROWS_MAX 16u
+static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_score_rune_rows(
+    bool forward, fzf_string_t *text, fzf_string_t *pattern,
+    fzf_slab_t *slab);
+static inline bool fzf_raw_unicode_query_prefilterable(
+    const fzf_string_t *pattern);
 
 static fzf_result_t fzf_fuzzy_match_v2_impl(
     bool case_sensitive, bool normalize, bool forward, fzf_string_t *text,
@@ -2920,6 +2926,9 @@ static fzf_string_t *make_pattern_text(const char *data, size_t size,
     return NULL;
   size_t codepoint_bytes = count * sizeof(utf8proc_int32_t);
   size_t plan_offset = sizeof(fzf_string_t) + codepoint_bytes;
+  if (FZF_PARSED_PATTERN_FLAGS_SIZE > SIZE_MAX - plan_offset) return NULL;
+  size_t flags_offset = plan_offset;
+  plan_offset += FZF_PARSED_PATTERN_FLAGS_SIZE;
 #if FZF_HAVE_SIMD_PREFILTER
   size_t alignment = FZF_SIMD_PLAN_ALIGNMENT;
   size_t remainder = plan_offset % alignment;
@@ -2933,6 +2942,7 @@ static fzf_string_t *make_pattern_text(const char *data, size_t size,
   fzf_string_t *text = malloc(plan_offset + plan_size);
   if (!text) return NULL;
   utf8proc_int32_t *codepoints = (utf8proc_int32_t *)(text + 1);
+  uint8_t *pattern_flags = (uint8_t *)text + flags_offset;
 #if FZF_HAVE_SIMD_PREFILTER
   fzf_ascii_query_plan_t *plan =
       (fzf_ascii_query_plan_t *)((unsigned char *)text + plan_offset);
@@ -2946,13 +2956,18 @@ static fzf_string_t *make_pattern_text(const char *data, size_t size,
       .codepoints_case_folded = !case_sensitive,
   };
   size_t byte_pos = 0;
+  bool raw_other_letter = count > 0;
   for (size_t i = 0; i < count; i++) {
     utf8proc_ssize_t width = utf8_iterate_lossy(
         (const utf8proc_uint8_t *)data + byte_pos,
         (utf8proc_ssize_t)(size - byte_pos), &codepoints[i]);
     if (!case_sensitive) codepoints[i] = utf8proc_case_fold(codepoints[i]);
+    if (utf8proc_category(codepoints[i]) != UTF8PROC_CATEGORY_LO)
+      raw_other_letter = false;
     byte_pos += (size_t)width;
   }
+  *pattern_flags =
+      raw_other_letter ? FZF_PARSED_PATTERN_RAW_OTHER_LETTER : 0;
   return text;
 }
 
@@ -3043,10 +3058,18 @@ static inline fzf_result_t call_alg_for_input(
     return fzf_fuzzy_match_v1_utf8_with_direction(
         term->case_sensitive, term->normalize, forward, input, pattern, pos,
         slab);
-  if (algo == fzf_fuzzy_match_v2_utf8)
+  if (algo == fzf_fuzzy_match_v2_utf8) {
+    size_t rune_count = pattern->codepoint_count;
+    if (fzf_raw_unicode_query_prefilterable(pattern) && pos == NULL &&
+        rune_count > 0 &&
+        rune_count <= FZF_FUZZY_RUNE_SCORE_ROWS_MAX &&
+        (slab == NULL || input->size <= slab->I16.cap / rune_count))
+      return fzf_fuzzy_match_v2_score_rune_rows(
+          forward, input, pattern, slab);
     return fzf_fuzzy_match_v2_utf8_with_direction(
         term->case_sensitive, term->normalize, forward, input, pattern, pos,
         slab);
+  }
   if (algo == fzf_exact_match_utf8)
     return fzf_exact_match_utf8_with_direction(
         term->case_sensitive, term->normalize, forward, input, pattern, pos,
@@ -3675,6 +3698,166 @@ static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_two_score(
     bonus_prev = bonus;
   }
 
+  return (fzf_result_t){(int32_t)max_score_pos,
+                        (int32_t)max_score_pos + 1, max_score};
+}
+
+typedef struct {
+  size_t start_byte;
+  size_t end_byte;
+  size_t start_char;
+} fzf_raw_rune_scope_t;
+
+/* Unicode Other_Letter runes are uncased.  fzf's normalization table only
+   produces ASCII, so neither lowercase nor normalization can make a distinct
+   candidate rune reach an Lo query rune.  The exhaustive scorer test audits
+   the lowercase mappings of uppercase runes in the vendored utf8proc table. */
+static inline bool fzf_raw_unicode_query_prefilterable(
+    const fzf_string_t *pattern) {
+  const uint8_t *flags = fzf_parsed_pattern_flags(pattern);
+  return (*flags & FZF_PARSED_PATTERN_RAW_OTHER_LETTER) != 0;
+}
+
+/* Find the same first/last useful columns as v2's first two phases.  The
+   parser admits this scan only for Other_Letter queries, whose runes cannot
+   be produced by v2's uppercase-to-lowercase transform. */
+static bool fzf_raw_rune_scope(
+    fzf_string_t *text, const utf8proc_int32_t *pattern, size_t pattern_size,
+    fzf_raw_rune_scope_t *scope) {
+  size_t byte_pos = 0;
+  size_t previous_byte = 0;
+  size_t char_pos = 0;
+  size_t pattern_pos = 0;
+  utf8proc_int32_t last = pattern[pattern_size - 1];
+  *scope = (fzf_raw_rune_scope_t){0};
+
+  while (byte_pos < text->size) {
+    utf8proc_int32_t codepoint;
+    utf8proc_ssize_t width = utf8_iterate_lossy(
+        (const utf8proc_uint8_t *)text->data + byte_pos,
+        (utf8proc_ssize_t)(text->size - byte_pos), &codepoint);
+    if (pattern_pos < pattern_size && codepoint == pattern[pattern_pos]) {
+      if (pattern_pos == 0) {
+        scope->start_byte = char_pos == 0 ? byte_pos : previous_byte;
+        scope->start_char = char_pos == 0 ? 0 : char_pos - 1;
+      }
+      pattern_pos++;
+    }
+    if (pattern_pos == pattern_size && codepoint == last)
+      scope->end_byte = byte_pos + (size_t)width;
+    previous_byte = byte_pos;
+    byte_pos += (size_t)width;
+    char_pos++;
+  }
+  return pattern_pos == pattern_size;
+}
+
+/* UTF-8 counterpart of the compact ASCII row scorer.  A cheap exact-rune
+   scope pass rejects uncased-script misses without Unicode property lookups;
+   matching candidates then need only this narrowed scoring pass, not a
+   byte-to-character map, decoded text array, or backtrace matrix. */
+static FZF_NOINLINE fzf_result_t fzf_fuzzy_match_v2_score_rune_rows(
+    bool forward, fzf_string_t *text, fzf_string_t *pattern,
+    fzf_slab_t *slab) {
+  const size_t row_count = pattern->codepoint_count;
+  const utf8proc_int32_t *query = pattern->codepoints;
+  fzf_raw_rune_scope_t scope;
+  if (!fzf_raw_rune_scope(text, query, row_count, &scope))
+    return (fzf_result_t){-1, -1, 0};
+
+  const score_scheme_config_t *config = score_scheme_config(slab);
+  int16_t h[FZF_FUZZY_RUNE_SCORE_ROWS_MAX] = {0};
+  int16_t consecutive[FZF_FUZZY_RUNE_SCORE_ROWS_MAX] = {0};
+  int16_t first_bonus[FZF_FUZZY_RUNE_SCORE_ROWS_MAX] = {0};
+  bool in_gap[FZF_FUZZY_RUNE_SCORE_ROWS_MAX] = {false};
+  size_t active = 0;
+  int16_t max_score = 0;
+  size_t max_score_pos = 0;
+  size_t char_pos = scope.start_char;
+  char_class prev_class = config->initial_class;
+
+  for (size_t byte_pos = scope.start_byte; byte_pos < scope.end_byte;
+       char_pos++) {
+    utf8proc_int32_t codepoint;
+    utf8proc_ssize_t width = utf8_iterate_lossy(
+        (const utf8proc_uint8_t *)text->data + byte_pos,
+        (utf8proc_ssize_t)(scope.end_byte - byte_pos), &codepoint);
+    byte_pos += (size_t)width;
+    char_class class = char_class_of_codepoint(codepoint, config);
+    int16_t bonus = bonus_for(config, prev_class, class);
+    prev_class = class;
+
+    if (active < row_count && codepoint == query[active]) active++;
+    for (size_t row_plus_one = active; row_plus_one > 0; row_plus_one--) {
+      size_t row = row_plus_one - 1;
+      if (row == 0) {
+        if (codepoint == query[0]) {
+          h[0] = ScoreMatch + bonus * BonusFirstCharMultiplier;
+          consecutive[0] = 1;
+          first_bonus[0] = bonus;
+          in_gap[0] = false;
+        } else {
+          h[0] = max16(h[0] +
+                           (in_gap[0] ? ScoreGapExtention : ScoreGapStart),
+                       0);
+          consecutive[0] = 0;
+          first_bonus[0] = 0;
+          in_gap[0] = true;
+        }
+        if (row_count == 1 &&
+            (forward ? h[0] > max_score : h[0] >= max_score)) {
+          max_score = h[0];
+          max_score_pos = char_pos;
+        }
+        if (row_count == 1 && forward && codepoint == query[0] &&
+            bonus >= BonusBoundary)
+          return (fzf_result_t){(int32_t)max_score_pos,
+                                (int32_t)max_score_pos + 1, max_score};
+        continue;
+      }
+
+      int16_t s1 = 0;
+      int16_t s2 = h[row] +
+                   (in_gap[row] ? ScoreGapExtention : ScoreGapStart);
+      int16_t next_consecutive = 0;
+      int16_t next_first_bonus = 0;
+      if (codepoint == query[row]) {
+        int16_t match_bonus = bonus;
+        next_consecutive = consecutive[row - 1] + 1;
+        next_first_bonus = bonus;
+        if (next_consecutive > 1) {
+          next_first_bonus = first_bonus[row - 1];
+          if (match_bonus >= BonusBoundary &&
+              match_bonus > next_first_bonus) {
+            next_consecutive = 1;
+            next_first_bonus = bonus;
+          } else {
+            match_bonus = max16(
+                match_bonus, max16(BonusConsecutive, next_first_bonus));
+          }
+        }
+        s1 = h[row - 1] + ScoreMatch;
+        if (s1 + match_bonus < s2) {
+          s1 += bonus;
+          next_consecutive = 0;
+          next_first_bonus = 0;
+        } else {
+          s1 += match_bonus;
+        }
+      }
+      consecutive[row] = next_consecutive;
+      first_bonus[row] = next_first_bonus;
+      in_gap[row] = s1 < s2;
+      h[row] = max16(max16(s1, s2), 0);
+      if (row + 1 == row_count &&
+          (forward ? h[row] > max_score : h[row] >= max_score)) {
+        max_score = h[row];
+        max_score_pos = char_pos;
+      }
+    }
+  }
+
+  if (active != row_count) return (fzf_result_t){-1, -1, 0};
   return (fzf_result_t){(int32_t)max_score_pos,
                         (int32_t)max_score_pos + 1, max_score};
 }

--- a/fzf.h
+++ b/fzf.h
@@ -191,6 +191,13 @@ int32_t fzf_get_score_with_bounds_bytes_preclassified(
     const char *text, size_t text_len, bool input_is_ascii,
     fzf_pattern_t *pattern, fzf_slab_t *slab,
     fzf_score_bounds_t *bounds);
+/* Score one byte string and backtrack positive matches before retaining their
+   bounds.  This matches fzf's begin-dependent ranking modes, which request
+   positions from the matcher even when the positions are not displayed. */
+int32_t fzf_get_score_with_rank_bounds_bytes_preclassified(
+    const char *text, size_t text_len, bool input_is_ascii,
+    fzf_pattern_t *pattern, fzf_slab_t *slab,
+    fzf_score_bounds_t *bounds);
 int32_t fzf_get_score_with_bounds(const char *text,
                                   fzf_pattern_t *pattern,
                                   fzf_slab_t *slab,


### PR DESCRIPTION
Summary
Speed up ASCII, Unicode, and persistent-session matching paths. 
Add a native C driver that mirrors the timed scan boundary of fzf --bench. 
Publish a 19-cell matched-envelope comparison and correct the earlier cross-harness fzf ratios. 
Matched-envelope result
With one worker, the candidate is 1.041x faster than pinned fzf across 19 equally weighted cells (95% bootstrap interval: 1.011x to 1.054x). It wins 11 of 19 cells and is 1.219x faster on the three real corpora.
The result is not uniform. fzf remains 1.119x faster on partial-miss cells and 1.276x faster on no-match cells. With eight workers, fzf is 1.333x faster in the equal-cell aggregate.
The candidate/base one-worker aggregate is 1.011x (interval: 0.997x to 1.018x), so the overall candidate gain is not statistically clear. The base is itself 1.037x faster than fzf in this envelope.
See benchmarks/2026-09-09T18:56:18Z.md. The correction at the top of benchmarks/2026-09-09T12:22:04Z.md marks the old cross-harness ratios as non-comparable.
Validation
760 timed fresh processes across five shuffled rounds; no outlier removal. 
Candidate, base, and pinned fzf produce identical ordered output for all 19 corpora (646,229 matched lines per subject). 
Full native C suite passes. 
Driver passes 9,097 ASan/UBSan iterations and 9,378 TSan iterations. 
Independent rebuilds match the measured binaries after removal of only the Mach-O UUID and signature regions. 
Scope
This is a matched scan-boundary comparison, not identical internal work. It excludes input ingestion, query parsing, the Emacs boundary, and interactive sessions. The report documents runtime, storage, orchestration, and garbage-collection differences that can affect the result.
